### PR TITLE
Agent lane: embedded terminal + coding agent + per-worktree context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@tauri-apps/plugin-dialog": "^2.7.2",
         "@tauri-apps/plugin-opener": "^2",
         "@xterm/addon-fit": "^0.10.0",
+        "@xterm/addon-webgl": "^0.18.0",
         "@xterm/xterm": "^5.5.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -997,6 +998,15 @@
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.10.0.tgz",
       "integrity": "sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
+      }
+    },
+    "node_modules/@xterm/addon-webgl": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-webgl/-/addon-webgl-0.18.0.tgz",
+      "integrity": "sha512-xCnfMBTI+/HKPdRnSOHaJDRqEpq2Ugy8LEj9GiY4J3zJObo3joylIFaMvzBwbYRg8zLtkO0KQaStCeSfoaI2/w==",
       "license": "MIT",
       "peerDependencies": {
         "@xterm/xterm": "^5.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@tauri-apps/api": "^2.11.1",
         "@tauri-apps/plugin-dialog": "^2.7.2",
         "@tauri-apps/plugin-opener": "^2",
+        "@xterm/addon-fit": "^0.10.0",
+        "@xterm/xterm": "^5.5.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "zustand": "^5.0.14"
@@ -181,9 +183,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -201,9 +200,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -221,9 +217,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -241,9 +234,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -261,9 +251,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -281,9 +268,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -469,9 +453,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -489,9 +470,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -509,9 +487,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -529,9 +504,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -549,9 +521,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1024,6 +993,21 @@
         }
       }
     },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.10.0.tgz",
+      "integrity": "sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
+      }
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
+      "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -1215,9 +1199,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1239,9 +1220,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1263,9 +1241,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1287,9 +1262,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@tauri-apps/plugin-dialog": "^2.7.2",
     "@tauri-apps/plugin-opener": "^2",
     "@xterm/addon-fit": "^0.10.0",
+    "@xterm/addon-webgl": "^0.18.0",
     "@xterm/xterm": "^5.5.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "@tauri-apps/api": "^2.11.1",
     "@tauri-apps/plugin-dialog": "^2.7.2",
     "@tauri-apps/plugin-opener": "^2",
+    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/xterm": "^5.5.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "zustand": "^5.0.14"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -387,8 +387,10 @@ dependencies = [
 name = "canopy"
 version = "0.4.0"
 dependencies = [
+ "base64 0.22.1",
  "fix-path-env",
  "libc",
+ "portable-pty",
  "serde",
  "serde_json",
  "sysinfo",
@@ -809,6 +811,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,7 +878,7 @@ dependencies = [
  "rustc_version",
  "toml 1.1.2+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -975,8 +983,19 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
- "memoffset",
+ "memoffset 0.9.1",
  "rustc_version",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
 ]
 
 [[package]]
@@ -1777,6 +1796,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ioctl-rs"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7970510895cee30b3e9128319f2cefd4bde883a39f38baa279567ba3a7eb97d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1919,6 +1947,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2028,6 +2062,15 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
@@ -2122,6 +2165,20 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.6.5",
+ "pin-utils",
+]
 
 [[package]]
 name = "ntapi"
@@ -2574,6 +2631,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "piper"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2641,6 +2704,27 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "portable-pty"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806ee80c2a03dbe1a9fb9534f8d19e4c0546b790cde8fd1fea9d6390644cb0be"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix",
+ "serial",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg 0.10.1",
 ]
 
 [[package]]
@@ -3163,6 +3247,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1237a96570fc377c13baa1b88c7589ab66edced652e43ffb17088f003db3e86"
+dependencies = [
+ "serial-core",
+ "serial-unix",
+ "serial-windows",
+]
+
+[[package]]
+name = "serial-core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f46209b345401737ae2125fe5b19a77acce90cd53e1658cda928e4fe9a64581"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "serial-unix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03fbca4c9d866e24a459cbca71283f545a37f8e3e002ad8c70593871453cab7"
+dependencies = [
+ "ioctl-rs",
+ "libc",
+ "serial-core",
+ "termios",
+]
+
+[[package]]
+name = "serial-windows"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c6d3b776267a75d31bbdfd5d36c0ca051251caafc285827052bc53bcdc8162"
+dependencies = [
+ "libc",
+ "serial-core",
+]
+
+[[package]]
 name = "serialize-to-javascript"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3203,6 +3329,22 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -3840,6 +3982,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termios"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4217,7 +4368,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
- "memoffset",
+ "memoffset 0.9.1",
  "tempfile",
  "windows-sys 0.61.2",
 ]
@@ -5116,6 +5267,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,6 +26,10 @@ tokio = { version = "1", features = ["process", "io-util", "sync", "time", "macr
 libc = "0.2"
 fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs" }
 sysinfo = "0.39.3"
+# embedded per-worktree terminals: a real PTY per session (the agent lane runs
+# the coding-agent CLI inside one). portable-pty is cross-platform (helps Linux).
+portable-pty = "0.8"
+base64 = "0.22"
 
 # macOS-only: the tray popover is a non-activating NSPanel. Other platforms fall
 # back to a plain borderless window (see src/tray.rs).

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -14,6 +14,7 @@
     "core:window:allow-close",
     "core:webview:allow-create-webview-window",
     "opener:default",
+    "opener:allow-open-url",
     "dialog:default"
   ]
 }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,8 +1,8 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Capability for both app windows",
-  "windows": ["main", "popover"],
+  "description": "Capability for the app windows and detached terminals",
+  "windows": ["main", "popover", "term-*"],
   "permissions": [
     "core:default",
     "core:window:allow-set-size",
@@ -11,6 +11,8 @@
     "core:window:allow-hide",
     "core:window:allow-set-focus",
     "core:window:allow-start-dragging",
+    "core:window:allow-close",
+    "core:webview:allow-create-webview-window",
     "opener:default",
     "dialog:default"
   ]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2,6 +2,7 @@ use crate::git;
 use crate::services::{self, LogLine, ProcTable};
 use crate::settings::{self, RepoCfg, Settings};
 use crate::state::{refresh_all_git_meta, refresh_git_meta, refresh_tree, AppState, RepoNode};
+use crate::terminal::{self, TermTable};
 use tauri::{AppHandle, Manager, State};
 
 #[tauri::command]
@@ -240,6 +241,40 @@ pub fn get_logs(table: State<'_, ProcTable>, svc_key: String) -> Vec<LogLine> {
         .get(&svc_key)
         .map(|b| b.iter().cloned().collect())
         .unwrap_or_default()
+}
+
+// ── embedded terminals (agent lane) ──
+
+#[tauri::command]
+pub fn terminal_open(
+    app: AppHandle,
+    table: State<'_, TermTable>,
+    id: String,
+    cwd: String,
+    cols: u16,
+    rows: u16,
+) -> Result<(), String> {
+    terminal::open(&app, &table, &id, &cwd, cols, rows)
+}
+
+#[tauri::command]
+pub fn terminal_write(table: State<'_, TermTable>, id: String, data: String) -> Result<(), String> {
+    terminal::write(&table, &id, &data)
+}
+
+#[tauri::command]
+pub fn terminal_resize(table: State<'_, TermTable>, id: String, cols: u16, rows: u16) -> Result<(), String> {
+    terminal::resize(&table, &id, cols, rows)
+}
+
+#[tauri::command]
+pub fn terminal_get_buffer(table: State<'_, TermTable>, id: String) -> Option<String> {
+    terminal::get_buffer(&table, &id)
+}
+
+#[tauri::command]
+pub fn terminal_close(table: State<'_, TermTable>, id: String) {
+    terminal::close(&table, &id);
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -254,8 +254,9 @@ pub fn terminal_open(
     cwd: String,
     cols: u16,
     rows: u16,
+    command: Option<String>,
 ) -> Result<(), String> {
-    terminal::open(&app, &table, &id, &cwd, cols, rows)
+    terminal::open(&app, &table, &id, &cwd, cols, rows, command)
 }
 
 #[tauri::command]
@@ -269,7 +270,7 @@ pub fn terminal_resize(table: State<'_, TermTable>, id: String, cols: u16, rows:
 }
 
 #[tauri::command]
-pub fn terminal_get_buffer(table: State<'_, TermTable>, id: String) -> Option<String> {
+pub fn terminal_get_buffer(table: State<'_, TermTable>, id: String) -> Option<terminal::BufferSnapshot> {
     terminal::get_buffer(&table, &id)
 }
 
@@ -936,10 +937,14 @@ pub fn get_repo_config(app: AppHandle, repo_id: String) -> Result<RepoConfig, St
     })
 }
 
-/// Write text to a user-chosen path (from a native save dialog). Used by the
-/// Settings config Export — anchor downloads don't work in the webview.
+/// Write text to a path, creating parent directories as needed. Used by the
+/// Settings config Export and by the agent lane (writing `.canopy/context.md`,
+/// whose parent dir may not exist yet).
 #[tauri::command]
 pub fn save_text_file(path: String, contents: String) -> Result<(), String> {
+    if let Some(dir) = std::path::Path::new(&path).parent() {
+        std::fs::create_dir_all(dir).map_err(|e| format!("mkdir {}: {e}", dir.display()))?;
+    }
     std::fs::write(&path, contents).map_err(|e| format!("write {path}: {e}"))
 }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -275,8 +275,22 @@ pub fn terminal_get_buffer(table: State<'_, TermTable>, id: String) -> Option<te
 }
 
 #[tauri::command]
-pub fn terminal_close(table: State<'_, TermTable>, id: String) {
-    terminal::close(&table, &id);
+pub fn terminal_close(app: AppHandle, table: State<'_, TermTable>, id: String) {
+    terminal::close_and_persist(&app, &table, &id);
+}
+
+/// Ensure a worktree's `.canopy/` exists with a self-ignoring `.gitignore`, then
+/// write `context.md`. Never truncates an existing `.gitignore`.
+#[tauri::command]
+pub fn write_worktree_context(wt_path: String, contents: String) -> Result<(), String> {
+    let dir = std::path::Path::new(&wt_path).join(".canopy");
+    std::fs::create_dir_all(&dir).map_err(|e| format!("mkdir {}: {e}", dir.display()))?;
+    let ignore = dir.join(".gitignore");
+    if !ignore.exists() {
+        std::fs::write(&ignore, "*\n").map_err(|e| format!("write {}: {e}", ignore.display()))?;
+    }
+    let file = dir.join("context.md");
+    std::fs::write(&file, contents).map_err(|e| format!("write {}: {e}", file.display()))
 }
 
 /// The agent CLI to run for a worktree: the repo's configured `agentCommand`,
@@ -701,6 +715,8 @@ pub async fn remove_worktree(app: AppHandle, wt_key: String, delete_branch: bool
     for key in services::worktree_svc_keys(&app, &wt_key) {
         let _ = services::stop_service(&app, &key).await;
     }
+    // and close its embedded terminals, so no shell/agent lingers with no UI
+    terminal::close_worktree(&app, &app.state::<TermTable>(), &wt_key);
 
     // run teardown (e.g. drop the worktree's database) while the worktree still
     // exists. Best-effort: a teardown failure shouldn't block removal.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -66,6 +66,7 @@ pub async fn add_repo(app: AppHandle, path: String) -> Result<RepoCfg, String> {
         migrate_db: String::new(),
         services: Vec::new(),
         custom_commands: Vec::new(),
+        agent_command: String::new(),
     };
 
     let updated = {
@@ -275,6 +276,31 @@ pub fn terminal_get_buffer(table: State<'_, TermTable>, id: String) -> Option<St
 #[tauri::command]
 pub fn terminal_close(table: State<'_, TermTable>, id: String) {
     terminal::close(&table, &id);
+}
+
+/// The agent CLI to run for a worktree: the repo's configured `agentCommand`,
+/// or the built-in default when unset.
+#[tauri::command]
+pub fn resolve_agent_command(state: State<'_, AppState>, wt_key: String) -> String {
+    const DEFAULT_AGENT: &str = "claude";
+    let repo_id = {
+        let tree = state.tree.read().unwrap();
+        tree.iter()
+            .find(|r| r.worktrees.iter().any(|w| w.wt_key == wt_key))
+            .map(|r| r.repo_id.clone())
+    };
+    let cmd = repo_id.and_then(|id| {
+        let settings = state.settings.read().unwrap();
+        settings
+            .repos
+            .iter()
+            .find(|r| r.id == id)
+            .map(|r| r.agent_command.trim().to_string())
+    });
+    match cmd {
+        Some(c) if !c.is_empty() => c,
+        _ => DEFAULT_AGENT.to_string(),
+    }
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -44,6 +44,19 @@ pub fn run() {
 
             stats::spawn_stats_task(handle.clone());
 
+            // periodically sweep idle shell terminals (bounds long-run memory)
+            {
+                let handle = handle.clone();
+                tauri::async_runtime::spawn(async move {
+                    loop {
+                        tokio::time::sleep(std::time::Duration::from_secs(5 * 60)).await;
+                        if let Some(table) = handle.try_state::<TermTable>() {
+                            terminal::sweep_idle(&table);
+                        }
+                    }
+                });
+            }
+
             // initial scan + 60s background git refresh
             tauri::async_runtime::spawn(async move {
                 let _ = state::refresh_tree(&handle).await;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -181,6 +181,7 @@ pub fn run() {
             commands::terminal_resize,
             commands::terminal_get_buffer,
             commands::terminal_close,
+            commands::resolve_agent_command,
             commands::service_start,
             commands::service_stop,
             commands::service_restart,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -41,6 +41,7 @@ pub fn run() {
 
             // kill process groups left over from a crashed previous run
             services::sweep_orphans(&handle);
+            terminal::sweep_orphans(&handle);
 
             stats::spawn_stats_task(handle.clone());
 
@@ -194,6 +195,7 @@ pub fn run() {
             commands::terminal_resize,
             commands::terminal_get_buffer,
             commands::terminal_close,
+            commands::write_worktree_context,
             commands::resolve_agent_command,
             commands::service_start,
             commands::service_stop,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,12 +7,14 @@ mod setup;
 mod state;
 mod stats;
 mod suite;
+mod terminal;
 mod toolchain;
 mod tray;
 
 use services::ProcTable;
 use state::AppState;
 use tauri::Manager;
+use terminal::TermTable;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -35,6 +37,7 @@ pub fn run() {
                 settings::load_runtime(&handle),
             ));
             app.manage(ProcTable::default());
+            app.manage(TermTable::default());
 
             // kill process groups left over from a crashed previous run
             services::sweep_orphans(&handle);
@@ -173,6 +176,11 @@ pub fn run() {
             commands::save_repo_config,
             commands::save_text_file,
             commands::get_logs,
+            commands::terminal_open,
+            commands::terminal_write,
+            commands::terminal_resize,
+            commands::terminal_get_buffer,
+            commands::terminal_close,
             commands::service_start,
             commands::service_stop,
             commands::service_restart,
@@ -204,6 +212,10 @@ pub fn run() {
         .run(|app, event| {
             // Cmd-Q / app exit: kill every spawned process group before dying
             if let tauri::RunEvent::ExitRequested { .. } = event {
+                // kill embedded terminal shells before their host process dies
+                if let Some(table) = app.try_state::<TermTable>() {
+                    terminal::close_all(&table);
+                }
                 let handle = app.clone();
                 tauri::async_runtime::block_on(async move {
                     services::stop_all(&handle).await;

--- a/src-tauri/src/services.rs
+++ b/src-tauri/src/services.rs
@@ -572,7 +572,7 @@ pub fn sweep_orphans(app: &AppHandle) {
 }
 
 /// Compare recorded spawn time against the process's actual start time (±5s).
-fn proc_start_time_matches(pid: u32, recorded_secs: u64) -> bool {
+pub(crate) fn proc_start_time_matches(pid: u32, recorded_secs: u64) -> bool {
     let out = std::process::Command::new("ps")
         .args(["-o", "lstart=", "-p", &pid.to_string()])
         .output();

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -99,12 +99,23 @@ pub struct RuntimeState {
     pub port_overrides: HashMap<String, u32>,
     /// pgids of spawned services, swept on startup after a crash
     pub orphans: Vec<OrphanProc>,
+    /// pgids of embedded terminal sessions, swept on startup after a crash
+    #[serde(default)]
+    pub terminal_orphans: Vec<TermOrphan>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase", default)]
 pub struct OrphanProc {
     pub svc_key: String,
+    pub pgid: i32,
+    pub spawn_time_secs: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase", default)]
+pub struct TermOrphan {
+    pub id: String,
     pub pgid: i32,
     pub spawn_time_secs: u64,
 }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -58,6 +58,10 @@ pub struct RepoCfg {
     /// the worktree root on the pinned Node.
     #[serde(default)]
     pub custom_commands: Vec<CustomCmd>,
+    /// CLI the agent lane's "Start agent" runs in a worktree terminal (e.g.
+    /// `claude`, `aider`, `codex`). Empty = fall back to the built-in default.
+    #[serde(default)]
+    pub agent_command: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -101,6 +101,13 @@ pub fn open(
         cmd.arg("-l");
     }
     if let Some(c) = command.as_deref().filter(|c| !c.trim().is_empty()) {
+        // A bare login shell on a PTY is interactive (so it sources .zshrc /
+        // .bashrc), but `-c` is NOT — user aliases/functions and rc-only PATH
+        // wouldn't resolve (e.g. an agent aliased in .zshrc). Force interactive
+        // for bash/zsh so the agent command runs like it would when typed.
+        if matches!(name, "zsh" | "bash") {
+            cmd.arg("-i");
+        }
         cmd.arg("-c");
         cmd.arg(c);
     }

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -12,10 +12,13 @@
 use base64::Engine;
 use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize};
 use serde::Serialize;
+use crate::settings::TermOrphan;
+use crate::state::AppState;
 use std::collections::{HashMap, VecDeque};
 use std::io::{Read, Write};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tauri::{AppHandle, Emitter, Manager};
 
 /// Per-session scrollback cap (bytes). Big enough for a screenful of history on
@@ -41,11 +44,18 @@ pub struct PtySession {
     seq: u64,
     /// last output or input time, for idle sweeping
     last_activity: Instant,
+    /// generation guard: a fast reopen under the same id bumps this so a stale
+    /// reader thread doesn't remove/exit the replacement session.
+    generation: u64,
+    /// child pgid (session leader) + spawn time, persisted for crash-orphan sweep
+    pgid: i32,
+    started_unix: u64,
 }
 
 #[derive(Default)]
 pub struct TermTable {
     pub sessions: Mutex<HashMap<String, PtySession>>,
+    next_gen: AtomicU64,
 }
 
 #[derive(Serialize, Clone)]
@@ -135,6 +145,11 @@ pub fn open(
     let mut reader = pair.master.try_clone_reader().map_err(|e| format!("reader clone failed: {e}"))?;
     let writer = pair.master.take_writer().map_err(|e| format!("writer failed: {e}"))?;
 
+    // the child is its own session leader (the pty setsid's it), so pid == pgid
+    let pgid = child.process_id().unwrap_or(0) as i32;
+    let started_unix = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+    let generation = table.next_gen.fetch_add(1, Ordering::Relaxed) + 1;
+
     sessions.insert(
         id.to_string(),
         PtySession {
@@ -144,9 +159,13 @@ pub fn open(
             scrollback: VecDeque::new(),
             seq: 0,
             last_activity: Instant::now(),
+            generation,
+            pgid,
+            started_unix,
         },
     );
     drop(sessions); // release before spawning the reader thread
+    persist_orphans(app); // record for the crash-orphan sweep
 
     // reader loop on a dedicated thread: PTY reads are blocking byte I/O.
     let app = app.clone();
@@ -178,11 +197,25 @@ pub fn open(
                 Err(_) => break,
             }
         }
-        // session ended: drop it and tell the UI
-        if let Some(table) = app.try_state::<TermTable>() {
-            table.sessions.lock().unwrap().remove(&id);
+        // session ended: drop it and tell the UI — but only if a newer session
+        // hasn't already replaced this id (fast reopen), else we'd delete the
+        // replacement and emit a false exit.
+        let removed = if let Some(table) = app.try_state::<TermTable>() {
+            let mut sessions = table.sessions.lock().unwrap();
+            match sessions.get(&id) {
+                Some(s) if s.generation == generation => {
+                    sessions.remove(&id);
+                    true
+                }
+                _ => false,
+            }
+        } else {
+            false
+        };
+        if removed {
+            persist_orphans(&app);
+            let _ = app.emit("terminal:exit", &ExitEvent { id: &id });
         }
-        let _ = app.emit("terminal:exit", &ExitEvent { id: &id });
     });
 
     Ok(())
@@ -224,12 +257,80 @@ pub fn close(table: &TermTable, id: &str) {
     }
 }
 
+/// Close a session and refresh the persisted orphan list (command path).
+pub fn close_and_persist(app: &AppHandle, table: &TermTable, id: &str) {
+    close(table, id);
+    persist_orphans(app);
+}
+
+/// Close every terminal belonging to a worktree (called before it's removed, so
+/// no shell/agent lingers with no UI to stop it).
+pub fn close_worktree(app: &AppHandle, table: &TermTable, wt_key: &str) {
+    let prefix = format!("{wt_key}::");
+    let ids: Vec<String> = table.sessions.lock().unwrap().keys().filter(|k| k.starts_with(&prefix)).cloned().collect();
+    for id in &ids {
+        close(table, id);
+    }
+    if !ids.is_empty() {
+        persist_orphans(app);
+    }
+}
+
 /// Kill every session (app quit).
 pub fn close_all(table: &TermTable) {
     let mut sessions = table.sessions.lock().unwrap();
     for (_, mut sess) in sessions.drain() {
         let _ = sess.child.kill();
     }
+}
+
+/// Snapshot live sessions' pgids into persisted runtime state, so a crash can be
+/// cleaned up on next launch (mirrors the service orphan sweep).
+fn persist_orphans(app: &AppHandle) {
+    let table = app.state::<TermTable>();
+    let orphans: Vec<TermOrphan> = table
+        .sessions
+        .lock()
+        .unwrap()
+        .iter()
+        .map(|(id, s)| TermOrphan { id: id.clone(), pgid: s.pgid, spawn_time_secs: s.started_unix })
+        .collect();
+    let state = app.state::<AppState>();
+    let runtime = {
+        let mut rt = state.runtime.write().unwrap();
+        rt.terminal_orphans = orphans;
+        rt.clone()
+    };
+    let _ = crate::settings::save_runtime(app, &runtime);
+}
+
+/// Startup: kill terminal process groups left over from a crashed previous run
+/// (only when the group leader still exists and its start time matches).
+pub fn sweep_orphans(app: &AppHandle) {
+    let orphans = {
+        let state = app.state::<AppState>();
+        let rt = state.runtime.read().unwrap();
+        rt.terminal_orphans.clone()
+    };
+    for o in &orphans {
+        if o.pgid <= 1 {
+            continue;
+        }
+        let alive = unsafe { libc::killpg(o.pgid, 0) == 0 };
+        if alive && crate::services::proc_start_time_matches(o.pgid as u32, o.spawn_time_secs) {
+            eprintln!("[wtm] sweeping terminal orphan pgid {} ({})", o.pgid, o.id);
+            unsafe {
+                libc::killpg(o.pgid, libc::SIGTERM);
+            }
+        }
+    }
+    let state = app.state::<AppState>();
+    let runtime = {
+        let mut rt = state.runtime.write().unwrap();
+        rt.terminal_orphans.clear();
+        rt.clone()
+    };
+    let _ = crate::settings::save_runtime(app, &runtime);
 }
 
 /// Sweep idle SHELL sessions (bounds long-run resource growth). Killing the

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -28,6 +28,10 @@ pub struct PtySession {
     child: Box<dyn Child + Send + Sync>,
     /// raw byte scrollback, capped at SCROLLBACK_CAP
     scrollback: VecDeque<u8>,
+    /// total bytes ever emitted for this session (monotonic). Lets a re-mounting
+    /// window rehydrate without double-rendering: it replays the snapshot up to
+    /// this cursor and applies only later `terminal:data` events.
+    seq: u64,
 }
 
 #[derive(Default)]
@@ -41,6 +45,8 @@ struct DataEvent<'a> {
     id: &'a str,
     /// base64 of the raw PTY bytes (raw bytes aren't guaranteed valid UTF-8)
     data: String,
+    /// cumulative byte cursor *after* this chunk
+    seq: u64,
 }
 
 #[derive(Serialize, Clone)]
@@ -49,31 +55,54 @@ struct ExitEvent<'a> {
     id: &'a str,
 }
 
+/// Scrollback snapshot + the byte cursor it ends at (for race-free rehydrate).
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct BufferSnapshot {
+    pub buffer: String,
+    pub seq: u64,
+}
+
 fn b64(bytes: &[u8]) -> String {
     base64::engine::general_purpose::STANDARD.encode(bytes)
 }
 
-/// Open (or no-op if already open) a terminal session `id` running an interactive
-/// login shell in `cwd`. `cols`/`rows` size the initial PTY.
-pub fn open(app: &AppHandle, table: &TermTable, id: &str, cwd: &str, cols: u16, rows: u16) -> Result<(), String> {
-    {
-        let sessions = table.sessions.lock().unwrap();
-        if sessions.contains_key(id) {
-            return Ok(()); // already running
-        }
+/// Open (or no-op if already open) a terminal session `id` in `cwd`. With no
+/// `command` it runs an interactive login shell; with one it runs that command
+/// under a login shell (so the session ends — firing `terminal:exit` — when the
+/// command exits, which is how the agent lane tracks agent lifecycle).
+///
+/// The whole check→spawn→insert runs under the sessions lock so two concurrent
+/// attaches for one id (StrictMode remount, pop-out) can't both spawn.
+pub fn open(
+    app: &AppHandle,
+    table: &TermTable,
+    id: &str,
+    cwd: &str,
+    cols: u16,
+    rows: u16,
+    command: Option<String>,
+) -> Result<(), String> {
+    let mut sessions = table.sessions.lock().unwrap();
+    if sessions.contains_key(id) {
+        return Ok(()); // already running — idempotent attach
     }
 
     let pair = native_pty_system()
         .openpty(PtySize { rows, cols, pixel_width: 0, pixel_height: 0 })
         .map_err(|e| format!("openpty failed: {e}"))?;
 
-    // interactive login shell (nvm/asdf/volta + user PATH initialize); honor a
-    // worktree's pinned Node the same way spawned services do.
+    // login shell (nvm/asdf/volta + user PATH initialize); honor a worktree's
+    // pinned Node the same way spawned services do.
     let shell = crate::toolchain::user_shell();
     let mut cmd = CommandBuilder::new(&shell);
     let name = std::path::Path::new(&shell).file_name().and_then(|s| s.to_str()).unwrap_or("");
     if !matches!(name, "sh" | "dash") {
         cmd.arg("-l");
+    }
+    if let Some(c) = command.as_deref().filter(|c| !c.trim().is_empty()) {
+        cmd.arg("-c");
+        cmd.arg(c);
     }
     cmd.cwd(cwd);
     cmd.env("TERM", "xterm-256color");
@@ -84,19 +113,17 @@ pub fn open(app: &AppHandle, table: &TermTable, id: &str, cwd: &str, cols: u16, 
 
     let child = pair.slave.spawn_command(cmd).map_err(|e| format!("spawn failed: {e}"))?;
     // the parent doesn't need the slave handle; dropping it lets EOF propagate
-    // when the shell exits.
+    // when the shell/command exits.
     drop(pair.slave);
 
     let mut reader = pair.master.try_clone_reader().map_err(|e| format!("reader clone failed: {e}"))?;
     let writer = pair.master.take_writer().map_err(|e| format!("writer failed: {e}"))?;
 
-    {
-        let mut sessions = table.sessions.lock().unwrap();
-        sessions.insert(
-            id.to_string(),
-            PtySession { master: pair.master, writer, child, scrollback: VecDeque::new() },
-        );
-    }
+    sessions.insert(
+        id.to_string(),
+        PtySession { master: pair.master, writer, child, scrollback: VecDeque::new(), seq: 0 },
+    );
+    drop(sessions); // release before spawning the reader thread
 
     // reader loop on a dedicated thread: PTY reads are blocking byte I/O.
     let app = app.clone();
@@ -105,10 +132,12 @@ pub fn open(app: &AppHandle, table: &TermTable, id: &str, cwd: &str, cols: u16, 
         let mut buf = [0u8; READ_CHUNK];
         loop {
             match reader.read(&mut buf) {
-                Ok(0) => break, // EOF — shell exited / pty closed
+                Ok(0) => break, // EOF — shell/command exited / pty closed
                 Ok(n) => {
                     let chunk = &buf[..n];
-                    // append to the session's scrollback (capped)
+                    // append to scrollback and advance the cursor atomically, so
+                    // the emitted seq always matches a chunk boundary.
+                    let mut seq = 0;
                     if let Some(table) = app.try_state::<TermTable>() {
                         if let Some(sess) = table.sessions.lock().unwrap().get_mut(&id) {
                             sess.scrollback.extend(chunk.iter().copied());
@@ -116,9 +145,11 @@ pub fn open(app: &AppHandle, table: &TermTable, id: &str, cwd: &str, cols: u16, 
                             if overflow > 0 {
                                 sess.scrollback.drain(0..overflow);
                             }
+                            sess.seq += n as u64;
+                            seq = sess.seq;
                         }
                     }
-                    let _ = app.emit("terminal:data", &DataEvent { id: &id, data: b64(chunk) });
+                    let _ = app.emit("terminal:data", &DataEvent { id: &id, data: b64(chunk), seq });
                 }
                 Err(_) => break,
             }
@@ -151,13 +182,13 @@ pub fn resize(table: &TermTable, id: &str, cols: u16, rows: u16) -> Result<(), S
         .map_err(|e| e.to_string())
 }
 
-/// Base64 of a session's whole scrollback, for a re-mounting window to rehydrate.
+/// Scrollback snapshot + its end cursor, for a re-mounting window to rehydrate.
 /// `None` when the session doesn't exist (never opened, or exited).
-pub fn get_buffer(table: &TermTable, id: &str) -> Option<String> {
+pub fn get_buffer(table: &TermTable, id: &str) -> Option<BufferSnapshot> {
     let sessions = table.sessions.lock().unwrap();
     sessions.get(id).map(|s| {
         let bytes: Vec<u8> = s.scrollback.iter().copied().collect();
-        b64(&bytes)
+        BufferSnapshot { buffer: b64(&bytes), seq: s.seq }
     })
 }
 

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -15,12 +15,19 @@ use serde::Serialize;
 use std::collections::{HashMap, VecDeque};
 use std::io::{Read, Write};
 use std::sync::Mutex;
+use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter, Manager};
 
 /// Per-session scrollback cap (bytes). Big enough for a screenful of history on
 /// rehydrate, small enough to stay cheap across many idle worktrees.
 const SCROLLBACK_CAP: usize = 256 * 1024;
-const READ_CHUNK: usize = 8 * 1024;
+/// Idle shell sessions past this are swept (bounds long-run memory/threads over,
+/// e.g., an overnight run of visiting many worktrees). Agents are exempt.
+const IDLE_LIMIT: Duration = Duration::from_secs(60 * 60);
+// a read() returns whatever bytes are already available (up to this size), so a
+// larger buffer coalesces bursts into fewer events — fewer base64/JSON emits
+// under heavy output, with no added latency for small writes.
+const READ_CHUNK: usize = 32 * 1024;
 
 pub struct PtySession {
     master: Box<dyn MasterPty + Send>,
@@ -32,6 +39,8 @@ pub struct PtySession {
     /// window rehydrate without double-rendering: it replays the snapshot up to
     /// this cursor and applies only later `terminal:data` events.
     seq: u64,
+    /// last output or input time, for idle sweeping
+    last_activity: Instant,
 }
 
 #[derive(Default)]
@@ -128,7 +137,14 @@ pub fn open(
 
     sessions.insert(
         id.to_string(),
-        PtySession { master: pair.master, writer, child, scrollback: VecDeque::new(), seq: 0 },
+        PtySession {
+            master: pair.master,
+            writer,
+            child,
+            scrollback: VecDeque::new(),
+            seq: 0,
+            last_activity: Instant::now(),
+        },
     );
     drop(sessions); // release before spawning the reader thread
 
@@ -153,6 +169,7 @@ pub fn open(
                                 sess.scrollback.drain(0..overflow);
                             }
                             sess.seq += n as u64;
+                            sess.last_activity = Instant::now();
                             seq = sess.seq;
                         }
                     }
@@ -177,6 +194,7 @@ pub fn write(table: &TermTable, id: &str, data: &str) -> Result<(), String> {
     let mut sessions = table.sessions.lock().unwrap();
     let sess = sessions.get_mut(id).ok_or("no such terminal")?;
     sess.writer.write_all(data.as_bytes()).map_err(|e| e.to_string())?;
+    sess.last_activity = Instant::now();
     sess.writer.flush().map_err(|e| e.to_string())
 }
 
@@ -211,5 +229,18 @@ pub fn close_all(table: &TermTable) {
     let mut sessions = table.sessions.lock().unwrap();
     for (_, mut sess) in sessions.drain() {
         let _ = sess.child.kill();
+    }
+}
+
+/// Sweep idle SHELL sessions (bounds long-run resource growth). Killing the
+/// child makes its reader hit EOF, which removes the session and emits
+/// `terminal:exit`. Agent sessions are exempt — a quiet agent may just be
+/// waiting for the user, and killing it would lose work.
+pub fn sweep_idle(table: &TermTable) {
+    let mut sessions = table.sessions.lock().unwrap();
+    for (id, sess) in sessions.iter_mut() {
+        if id.ends_with("::shell") && sess.last_activity.elapsed() > IDLE_LIMIT {
+            let _ = sess.child.kill();
+        }
     }
 }

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -1,0 +1,177 @@
+// Embedded per-worktree terminals.
+//
+// Each session is a real PTY running the user's login shell in a worktree's
+// directory — the foundation for the agent lane, where the configured coding
+// agent CLI runs inside a shell just like anything else the user types.
+//
+// Model mirrors `services.rs`: a table of sessions keyed by an opaque id, with a
+// capped scrollback ring buffer per session so a late-joining or re-mounting
+// window can rehydrate. Where a service is spawned over pipes and read *by line*
+// on the async runtime, a PTY is raw, bidirectional, byte-oriented I/O — so the
+// read loop lives on a dedicated std thread and streams `terminal:data` events.
+use base64::Engine;
+use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize};
+use serde::Serialize;
+use std::collections::{HashMap, VecDeque};
+use std::io::{Read, Write};
+use std::sync::Mutex;
+use tauri::{AppHandle, Emitter, Manager};
+
+/// Per-session scrollback cap (bytes). Big enough for a screenful of history on
+/// rehydrate, small enough to stay cheap across many idle worktrees.
+const SCROLLBACK_CAP: usize = 256 * 1024;
+const READ_CHUNK: usize = 8 * 1024;
+
+pub struct PtySession {
+    master: Box<dyn MasterPty + Send>,
+    writer: Box<dyn Write + Send>,
+    child: Box<dyn Child + Send + Sync>,
+    /// raw byte scrollback, capped at SCROLLBACK_CAP
+    scrollback: VecDeque<u8>,
+}
+
+#[derive(Default)]
+pub struct TermTable {
+    pub sessions: Mutex<HashMap<String, PtySession>>,
+}
+
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct DataEvent<'a> {
+    id: &'a str,
+    /// base64 of the raw PTY bytes (raw bytes aren't guaranteed valid UTF-8)
+    data: String,
+}
+
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct ExitEvent<'a> {
+    id: &'a str,
+}
+
+fn b64(bytes: &[u8]) -> String {
+    base64::engine::general_purpose::STANDARD.encode(bytes)
+}
+
+/// Open (or no-op if already open) a terminal session `id` running an interactive
+/// login shell in `cwd`. `cols`/`rows` size the initial PTY.
+pub fn open(app: &AppHandle, table: &TermTable, id: &str, cwd: &str, cols: u16, rows: u16) -> Result<(), String> {
+    {
+        let sessions = table.sessions.lock().unwrap();
+        if sessions.contains_key(id) {
+            return Ok(()); // already running
+        }
+    }
+
+    let pair = native_pty_system()
+        .openpty(PtySize { rows, cols, pixel_width: 0, pixel_height: 0 })
+        .map_err(|e| format!("openpty failed: {e}"))?;
+
+    // interactive login shell (nvm/asdf/volta + user PATH initialize); honor a
+    // worktree's pinned Node the same way spawned services do.
+    let shell = crate::toolchain::user_shell();
+    let mut cmd = CommandBuilder::new(&shell);
+    let name = std::path::Path::new(&shell).file_name().and_then(|s| s.to_str()).unwrap_or("");
+    if !matches!(name, "sh" | "dash") {
+        cmd.arg("-l");
+    }
+    cmd.cwd(cwd);
+    cmd.env("TERM", "xterm-256color");
+    if let Some(bin) = crate::toolchain::pinned_node_bin(cwd) {
+        let path = std::env::var("PATH").unwrap_or_default();
+        cmd.env("PATH", format!("{bin}:{path}"));
+    }
+
+    let child = pair.slave.spawn_command(cmd).map_err(|e| format!("spawn failed: {e}"))?;
+    // the parent doesn't need the slave handle; dropping it lets EOF propagate
+    // when the shell exits.
+    drop(pair.slave);
+
+    let mut reader = pair.master.try_clone_reader().map_err(|e| format!("reader clone failed: {e}"))?;
+    let writer = pair.master.take_writer().map_err(|e| format!("writer failed: {e}"))?;
+
+    {
+        let mut sessions = table.sessions.lock().unwrap();
+        sessions.insert(
+            id.to_string(),
+            PtySession { master: pair.master, writer, child, scrollback: VecDeque::new() },
+        );
+    }
+
+    // reader loop on a dedicated thread: PTY reads are blocking byte I/O.
+    let app = app.clone();
+    let id = id.to_string();
+    std::thread::spawn(move || {
+        let mut buf = [0u8; READ_CHUNK];
+        loop {
+            match reader.read(&mut buf) {
+                Ok(0) => break, // EOF — shell exited / pty closed
+                Ok(n) => {
+                    let chunk = &buf[..n];
+                    // append to the session's scrollback (capped)
+                    if let Some(table) = app.try_state::<TermTable>() {
+                        if let Some(sess) = table.sessions.lock().unwrap().get_mut(&id) {
+                            sess.scrollback.extend(chunk.iter().copied());
+                            let overflow = sess.scrollback.len().saturating_sub(SCROLLBACK_CAP);
+                            if overflow > 0 {
+                                sess.scrollback.drain(0..overflow);
+                            }
+                        }
+                    }
+                    let _ = app.emit("terminal:data", &DataEvent { id: &id, data: b64(chunk) });
+                }
+                Err(_) => break,
+            }
+        }
+        // session ended: drop it and tell the UI
+        if let Some(table) = app.try_state::<TermTable>() {
+            table.sessions.lock().unwrap().remove(&id);
+        }
+        let _ = app.emit("terminal:exit", &ExitEvent { id: &id });
+    });
+
+    Ok(())
+}
+
+/// Write user input (keystrokes, or a command the UI injects such as the agent
+/// CLI) to a session.
+pub fn write(table: &TermTable, id: &str, data: &str) -> Result<(), String> {
+    let mut sessions = table.sessions.lock().unwrap();
+    let sess = sessions.get_mut(id).ok_or("no such terminal")?;
+    sess.writer.write_all(data.as_bytes()).map_err(|e| e.to_string())?;
+    sess.writer.flush().map_err(|e| e.to_string())
+}
+
+/// Resize a session's PTY (xterm's fit addon drives this).
+pub fn resize(table: &TermTable, id: &str, cols: u16, rows: u16) -> Result<(), String> {
+    let sessions = table.sessions.lock().unwrap();
+    let sess = sessions.get(id).ok_or("no such terminal")?;
+    sess.master
+        .resize(PtySize { rows, cols, pixel_width: 0, pixel_height: 0 })
+        .map_err(|e| e.to_string())
+}
+
+/// Base64 of a session's whole scrollback, for a re-mounting window to rehydrate.
+/// `None` when the session doesn't exist (never opened, or exited).
+pub fn get_buffer(table: &TermTable, id: &str) -> Option<String> {
+    let sessions = table.sessions.lock().unwrap();
+    sessions.get(id).map(|s| {
+        let bytes: Vec<u8> = s.scrollback.iter().copied().collect();
+        b64(&bytes)
+    })
+}
+
+/// Kill and drop a session.
+pub fn close(table: &TermTable, id: &str) {
+    if let Some(mut sess) = table.sessions.lock().unwrap().remove(id) {
+        let _ = sess.child.kill();
+    }
+}
+
+/// Kill every session (app quit).
+pub fn close_all(table: &TermTable) {
+    let mut sessions = table.sessions.lock().unwrap();
+    for (_, mut sess) in sessions.drain() {
+        let _ = sess.child.kill();
+    }
+}

--- a/src/app/AgentLane.tsx
+++ b/src/app/AgentLane.tsx
@@ -5,16 +5,31 @@
 import { useEffect, useRef, useState } from "react";
 import type { RepoNode, WorktreeNode } from "../types";
 import { useStore } from "../store";
-import { ChevLeft, ChevRight, Doc, Sparkle, Terminal as TerminalIcon } from "../icons";
+import { hasBackend, ipc } from "../ipc";
+import { ChevLeft, ChevRight, Doc, Spinner, Sparkle, Terminal as TerminalIcon, X } from "../icons";
 import TerminalPane from "./TerminalPane";
-import { ContextEditor, bodyPreview, isBlank, useWtContext } from "./WorktreeContext";
+import { ContextEditor, bodyPreview, composeContextMd, isBlank, useWtContext } from "./WorktreeContext";
 
 const COLLAPSE_KEY = "canopy.lane.collapsed";
 
 type Tab = "agent" | "shell";
 
+/** Write to a PTY that may have only just been opened (retry briefly). */
+async function writeWhenReady(id: string, data: string, tries = 6) {
+  for (let i = 0; i < tries; i++) {
+    try {
+      await ipc.terminalWrite(id, data);
+      return;
+    } catch {
+      await new Promise((r) => setTimeout(r, 250));
+    }
+  }
+}
+
 export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNode }) {
   const showToast = useStore((s) => s.showToast);
+  const agentState = useStore((s) => s.agents[wt.wtKey] ?? "off");
+  const setAgent = useStore((s) => s.setAgent);
   const [collapsed, setCollapsed] = useState(() => localStorage.getItem(COLLAPSE_KEY) === "1");
   const [tab, setTab] = useState<Tab>("agent");
   const [ctxOpen, setCtxOpen] = useState(false);
@@ -76,16 +91,43 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
     );
   }
 
-  const seedAgent = () => {
+  // Start the configured agent CLI inside the agent PTY (the terminal *is* the
+  // chat). The context, if any, is written to .canopy/context.md so the agent
+  // can read it, and we show a banner noting the seed.
+  const startAgent = async () => {
     setCtxOpen(false);
     setTab("agent");
-    showToast(`Agent — ${repo.name} · ${wt.branch}`);
+    if (!hasBackend()) {
+      setAgent(wt.wtKey, "running");
+      showToast(`Agent — ${repo.name} · ${wt.branch}`);
+      return;
+    }
+    try {
+      if (!isBlank(ctx)) {
+        await ipc.saveTextFile(`${wt.path}/.canopy/context.md`, composeContextMd(ctx)).catch(() => {});
+      }
+      const cmd = (await ipc.resolveAgentCommand(wt.wtKey)) || "claude";
+      await writeWhenReady(`${wt.wtKey}::agent`, `${cmd}\n`);
+      setAgent(wt.wtKey, "running");
+      showToast(`Agent started — ${repo.name} · ${wt.branch}`);
+    } catch (e) {
+      showToast(String(e));
+    }
+  };
+
+  const stopAgent = () => {
+    if (hasBackend()) ipc.terminalWrite(`${wt.wtKey}::agent`, "\x03").catch(() => {}); // Ctrl-C
+    setAgent(wt.wtKey, "off");
+    showToast("Agent stopped");
   };
 
   return (
     <aside className="lane">
       <div className="lane-head">
-        <span className="ag-pip busy" style={{ width: 26, height: 26, borderRadius: 8, background: "var(--accent-dim)" }}>
+        <span
+          className={"ag-pip" + (agentState === "running" ? " busy" : "")}
+          style={{ width: 26, height: 26, borderRadius: 8, background: "var(--accent-dim)", color: "var(--accent)" }}
+        >
           <Sparkle size={14} />
         </span>
         <div className="lh-t">
@@ -133,6 +175,17 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
         </button>
       </div>
 
+      {tab === "agent" && agentState === "running" && (
+        <div className="ag-banner">
+          <Sparkle size={13} />
+          <span className="nm">agent</span>
+          <span className="sep">·</span>
+          <span className="ctxref">
+            {isBlank(ctx) ? "running in this worktree" : `seeded with “${ctx.title || "context"}”`}
+          </span>
+        </div>
+      )}
+
       <div className="lane-body">
         <div className="term">
           {activated.current.has("agent") && (
@@ -149,11 +202,22 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
       </div>
 
       <div className="lane-foot">
-        <button className="startagent" style={{ flex: 1, justifyContent: "center", height: 30 }} onClick={seedAgent}>
-          <Sparkle size={13} />
-          Start agent
-          <span className="ar">▸</span>
-        </button>
+        {agentState === "running" ? (
+          <span className="agent-live" style={{ flex: 1 }}>
+            <Spinner size={12} />
+            Agent working
+            <span className="grow" />
+            <button className="stopx" title="Stop agent" onClick={stopAgent}>
+              <X size={12} />
+            </button>
+          </span>
+        ) : (
+          <button className="startagent" style={{ flex: 1, justifyContent: "center", height: 30 }} onClick={startAgent}>
+            <Sparkle size={13} />
+            Start agent
+            <span className="ar">▸</span>
+          </button>
+        )}
       </div>
 
       {ctxOpen && (
@@ -161,7 +225,7 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
           ctx={ctx}
           setCtx={setCtx}
           onClose={() => setCtxOpen(false)}
-          onSeed={seedAgent}
+          onSeed={startAgent}
           onToast={showToast}
         />
       )}

--- a/src/app/AgentLane.tsx
+++ b/src/app/AgentLane.tsx
@@ -10,8 +10,13 @@ import { ChevLeft, ChevRight, Doc, ExpandH, PopIn, PopOut, Spinner, Sparkle, Ter
 import TerminalPane from "./TerminalPane";
 import { ContextEditor, bodyPreview, composeContextMd, isBlank, useWtContext } from "./WorktreeContext";
 
-/** Deterministic window label for a detached terminal (matches the term-* capability). */
-const laneLabel = (id: string) => "term-" + id.replace(/[^a-zA-Z0-9_-]/g, "_");
+/** Deterministic, injective window label for a detached terminal (hex of the id's
+    UTF-8 bytes) — a lossy replace could collide two worktrees onto one window. */
+const laneLabel = (id: string) =>
+  "term-" +
+  Array.from(new TextEncoder().encode(id))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
 
 function DetachedPlaceholder({ onBack }: { onBack: () => void }) {
   return (
@@ -239,10 +244,9 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
     }
     try {
       if (!isBlank(ctx)) {
-        // keep Canopy's dir out of the user's git status, then write context
-        // (propagate failure — don't claim "seeded" if the write failed)
-        await ipc.saveTextFile(`${wt.path}/.canopy/.gitignore`, "*\n").catch(() => {});
-        await ipc.saveTextFile(`${wt.path}/.canopy/context.md`, composeContextMd(ctx));
+        // writes .canopy/context.md (+ a self-ignoring .gitignore it won't
+        // clobber); propagate failure — don't claim "seeded" if it failed
+        await ipc.writeWorktreeContext(wt.path, composeContextMd(ctx));
       }
       const cmd = (await ipc.resolveAgentCommand(wt.wtKey)) || "claude";
       setAgentCmd(cmd);
@@ -327,13 +331,18 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
           <span>{wt.branch}</span>
         </div>
         <span className="grow" />
-        <button
-          className="ib"
-          title="Open in a separate window"
-          onClick={() => popOut(tab === "agent" ? agentId : shellId)}
-        >
-          <PopOut size={14} />
-        </button>
+        {/* only pop out a tab that actually has a session — popping the agent
+            tab while idle would open a plain shell under the ::agent id and a
+            later Start would falsely see the agent as already running. */}
+        {(tab === "shell" || agentState === "running") && (
+          <button
+            className="ib"
+            title="Open in a separate window"
+            onClick={() => popOut(tab === "agent" ? agentId : shellId)}
+          >
+            <PopOut size={14} />
+          </button>
+        )}
         {!tight && (
           <button className="ib" title={mainRailed ? "Show worktree details" : "Focus the terminal"} onClick={toggleFocus}>
             <ExpandH size={15} />

--- a/src/app/AgentLane.tsx
+++ b/src/app/AgentLane.tsx
@@ -6,11 +6,22 @@ import { useEffect, useRef, useState } from "react";
 import type { RepoNode, WorktreeNode } from "../types";
 import { useStore } from "../store";
 import { hasBackend, ipc } from "../ipc";
-import { ChevLeft, ChevRight, Doc, Spinner, Sparkle, Terminal as TerminalIcon, X } from "../icons";
+import { ChevLeft, ChevRight, Doc, ExpandH, Spinner, Sparkle, Terminal as TerminalIcon, X } from "../icons";
 import TerminalPane from "./TerminalPane";
 import { ContextEditor, bodyPreview, composeContextMd, isBlank, useWtContext } from "./WorktreeContext";
 
 const COLLAPSE_KEY = "canopy.lane.collapsed";
+const WIDTH_KEY = "canopy.lane.width";
+
+// layout constants (match terminal.css): sidebar, main-pane floor, focus rail.
+const SIDE = 264;
+const MIN_MAIN = 460;
+const RAIL = 52;
+const MIN_LANE = 300;
+const DEFAULT_LANE = 372;
+// below this the lane can't be a flex sibling without squeezing the main pane
+// past its floor — it becomes an overlay drawer instead (see the handoff).
+const TIGHT = 1180;
 
 type Tab = "agent" | "shell";
 
@@ -30,10 +41,16 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
   const showToast = useStore((s) => s.showToast);
   const agentState = useStore((s) => s.agents[wt.wtKey] ?? "off");
   const setAgent = useStore((s) => s.setAgent);
+  const mainRailed = useStore((s) => s.mainRailed);
+  const setMainRailed = useStore((s) => s.setMainRailed);
   const [collapsed, setCollapsed] = useState(() => localStorage.getItem(COLLAPSE_KEY) === "1");
   const [tab, setTab] = useState<Tab>("agent");
   const [ctxOpen, setCtxOpen] = useState(false);
   const [ctx, setCtx] = useWtContext(wt.wtKey);
+  const [laneW, setLaneW] = useState(() => Number(localStorage.getItem(WIDTH_KEY)) || DEFAULT_LANE);
+  const [resizing, setResizing] = useState(false);
+  const [tight, setTight] = useState(() => window.innerWidth < TIGHT);
+  const asideRef = useRef<HTMLElement>(null);
   // lazily mount a tab's terminal the first time it's shown, then keep it
   // mounted (hidden) so its PTY keeps running in the background.
   const activated = useRef<Set<Tab>>(new Set(["agent"]));
@@ -42,6 +59,85 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
   useEffect(() => {
     localStorage.setItem(COLLAPSE_KEY, collapsed ? "1" : "0");
   }, [collapsed]);
+  useEffect(() => {
+    localStorage.setItem(WIDTH_KEY, String(laneW));
+  }, [laneW]);
+
+  // room available for the lane at a given main-pane floor
+  const availFor = (railed: boolean) => {
+    const body = asideRef.current?.parentElement;
+    if (!body) return null;
+    return body.clientWidth - SIDE - (railed ? RAIL : MIN_MAIN);
+  };
+
+  // narrow-window fallback: overlay drawer + auto-collapse on first crossing
+  useEffect(() => {
+    if (window.innerWidth < TIGHT) setCollapsed(true); // start collapsed when tight
+    const onResize = () => {
+      const t = window.innerWidth < TIGHT;
+      setTight((was) => {
+        if (t && !was) {
+          setCollapsed(true);
+          setMainRailed(false);
+        }
+        return t;
+      });
+    };
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, [setMainRailed]);
+
+  // single source of truth for lane-width validity: clamp on mount, on window
+  // resize, and whenever focus mode changes the main pane's floor.
+  useEffect(() => {
+    if (tight) return;
+    const clamp = () => {
+      const avail = availFor(mainRailed);
+      if (avail == null || avail < MIN_LANE) return;
+      setLaneW((w) => Math.min(w, avail));
+    };
+    clamp();
+    window.addEventListener("resize", clamp);
+    return () => window.removeEventListener("resize", clamp);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mainRailed, tight]);
+
+  // drag the lane's left edge to resize
+  useEffect(() => {
+    if (!resizing) return;
+    const move = (e: MouseEvent) => {
+      const body = asideRef.current?.parentElement;
+      if (!body) return;
+      const avail = availFor(mainRailed);
+      if (avail == null || avail < MIN_LANE) return; // no room to resize here
+      const right = body.getBoundingClientRect().right;
+      setLaneW(Math.round(Math.min(avail, Math.max(MIN_LANE, right - e.clientX))));
+    };
+    const up = () => setResizing(false);
+    window.addEventListener("mousemove", move);
+    window.addEventListener("mouseup", up);
+    document.body.style.cursor = "col-resize";
+    return () => {
+      window.removeEventListener("mousemove", move);
+      window.removeEventListener("mouseup", up);
+      document.body.style.cursor = "";
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [resizing, mainRailed]);
+
+  // focus mode: collapse the middle pane to a rail, give the lane the rest
+  const toggleFocus = () => {
+    if (!mainRailed) {
+      setMainRailed(true);
+      const avail = availFor(true);
+      if (avail != null) setLaneW(Math.max(MIN_LANE, avail));
+      showToast("Terminal focus — worktree details collapsed");
+    } else {
+      setMainRailed(false);
+      const avail = availFor(false);
+      setLaneW(avail == null ? DEFAULT_LANE : Math.min(DEFAULT_LANE, Math.max(MIN_LANE, avail)));
+    }
+  };
 
   const shellId = `${wt.wtKey}::shell`;
   const agentId = `${wt.wtKey}::agent`;
@@ -122,7 +218,20 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
   };
 
   return (
-    <aside className="lane">
+    <aside
+      ref={asideRef}
+      className={"lane" + (tight ? " overlay" : "") + (resizing ? " resizing" : "")}
+      style={tight ? undefined : { width: laneW }}
+    >
+      {!tight && (
+        <span
+          className={"lane-grip" + (resizing ? " on" : "")}
+          onMouseDown={(e) => {
+            e.preventDefault();
+            setResizing(true);
+          }}
+        />
+      )}
       <div className="lane-head">
         <span
           className={"ag-pip" + (agentState === "running" ? " busy" : "")}
@@ -135,7 +244,19 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
           <span>{wt.branch}</span>
         </div>
         <span className="grow" />
-        <button className="ib" title="Collapse lane" onClick={() => setCollapsed(true)}>
+        {!tight && (
+          <button className="ib" title={mainRailed ? "Show worktree details" : "Focus the terminal"} onClick={toggleFocus}>
+            <ExpandH size={15} />
+          </button>
+        )}
+        <button
+          className="ib"
+          title="Collapse lane"
+          onClick={() => {
+            setCollapsed(true);
+            setMainRailed(false);
+          }}
+        >
           <ChevRight size={16} />
         </button>
       </div>

--- a/src/app/AgentLane.tsx
+++ b/src/app/AgentLane.tsx
@@ -6,9 +6,32 @@ import { useEffect, useRef, useState } from "react";
 import type { RepoNode, WorktreeNode } from "../types";
 import { useStore } from "../store";
 import { hasBackend, ipc } from "../ipc";
-import { ChevLeft, ChevRight, Doc, ExpandH, Spinner, Sparkle, Terminal as TerminalIcon, X } from "../icons";
+import { ChevLeft, ChevRight, Doc, ExpandH, PopIn, PopOut, Spinner, Sparkle, Terminal as TerminalIcon, X } from "../icons";
 import TerminalPane from "./TerminalPane";
 import { ContextEditor, bodyPreview, composeContextMd, isBlank, useWtContext } from "./WorktreeContext";
+
+/** Deterministic window label for a detached terminal (matches the term-* capability). */
+const laneLabel = (id: string) => "term-" + id.replace(/[^a-zA-Z0-9_-]/g, "_");
+
+function DetachedPlaceholder({ onBack }: { onBack: () => void }) {
+  return (
+    <div className="term-ph">
+      <span className="ph-ic">
+        <PopOut size={19} />
+      </span>
+      <span className="ph-t">
+        Running in a detached window <PopOut size={12} />
+      </span>
+      <span className="ph-s">
+        The shell keeps running — output goes to the floating window. Close it or bring it back here any time.
+      </span>
+      <button className="btn-sm" onClick={onBack}>
+        <PopIn size={13} />
+        Bring back
+      </button>
+    </div>
+  );
+}
 
 const COLLAPSE_KEY = "canopy.lane.collapsed";
 const WIDTH_KEY = "canopy.lane.width";
@@ -50,6 +73,7 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
   const [laneW, setLaneW] = useState(() => Number(localStorage.getItem(WIDTH_KEY)) || DEFAULT_LANE);
   const [resizing, setResizing] = useState(false);
   const [tight, setTight] = useState(() => window.innerWidth < TIGHT);
+  const [detached, setDetached] = useState<Set<string>>(new Set());
   const asideRef = useRef<HTMLElement>(null);
   // lazily mount a tab's terminal the first time it's shown, then keep it
   // mounted (hidden) so its PTY keeps running in the background.
@@ -217,6 +241,56 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
     showToast("Agent stopped");
   };
 
+  // Pop a terminal into its own OS window that attaches to the SAME PTY. The
+  // lane shows a placeholder while detached; closing the window (or "Bring
+  // back") re-docks it — the shell never stops.
+  const popOut = async (id: string) => {
+    if (!hasBackend()) {
+      showToast("Pop-out is available in the desktop app");
+      return;
+    }
+    const { WebviewWindow } = await import("@tauri-apps/api/webviewWindow");
+    const label = laneLabel(id);
+    const existing = await WebviewWindow.getByLabel(label);
+    if (existing) {
+      existing.setFocus();
+      return;
+    }
+    const url = `terminal.html?id=${encodeURIComponent(id)}&cwd=${encodeURIComponent(wt.path)}&branch=${encodeURIComponent(wt.branch)}`;
+    const win = new WebviewWindow(label, {
+      url,
+      width: 560,
+      height: 360,
+      minWidth: 360,
+      minHeight: 220,
+      title: `Terminal — ${wt.branch}`,
+      decorations: false,
+      resizable: true,
+    });
+    win.once("tauri://created", () => setDetached((s) => new Set(s).add(id)));
+    win.once("tauri://error", () => showToast("Could not open terminal window"));
+    win.once("tauri://destroyed", () =>
+      setDetached((s) => {
+        const n = new Set(s);
+        n.delete(id);
+        return n;
+      }),
+    );
+  };
+
+  const bringBack = async (id: string) => {
+    if (hasBackend()) {
+      const { WebviewWindow } = await import("@tauri-apps/api/webviewWindow");
+      const w = await WebviewWindow.getByLabel(laneLabel(id));
+      await w?.close();
+    }
+    setDetached((s) => {
+      const n = new Set(s);
+      n.delete(id);
+      return n;
+    });
+  };
+
   return (
     <aside
       ref={asideRef}
@@ -244,6 +318,13 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
           <span>{wt.branch}</span>
         </div>
         <span className="grow" />
+        <button
+          className="ib"
+          title="Open in a separate window"
+          onClick={() => popOut(tab === "agent" ? agentId : shellId)}
+        >
+          <PopOut size={14} />
+        </button>
         {!tight && (
           <button className="ib" title={mainRailed ? "Show worktree details" : "Focus the terminal"} onClick={toggleFocus}>
             <ExpandH size={15} />
@@ -311,12 +392,20 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
         <div className="term">
           {activated.current.has("agent") && (
             <div className={"term-body" + (tab === "agent" ? "" : " hidden")}>
-              <TerminalPane termId={agentId} cwd={wt.path} hidden={tab !== "agent"} />
+              {detached.has(agentId) ? (
+                <DetachedPlaceholder onBack={() => bringBack(agentId)} />
+              ) : (
+                <TerminalPane termId={agentId} cwd={wt.path} hidden={tab !== "agent"} />
+              )}
             </div>
           )}
           {activated.current.has("shell") && (
             <div className={"term-body" + (tab === "shell" ? "" : " hidden")}>
-              <TerminalPane termId={shellId} cwd={wt.path} hidden={tab !== "shell"} />
+              {detached.has(shellId) ? (
+                <DetachedPlaceholder onBack={() => bringBack(shellId)} />
+              ) : (
+                <TerminalPane termId={shellId} cwd={wt.path} hidden={tab !== "shell"} />
+              )}
             </div>
           )}
         </div>

--- a/src/app/AgentLane.tsx
+++ b/src/app/AgentLane.tsx
@@ -1,0 +1,146 @@
+// The agent lane (VariantC) — a first-class right-hand column holding the
+// per-worktree context, the coding agent, and a shell. Both the Agent and Shell
+// tabs are backed by their own live PTY (see TerminalPane); toggling between
+// them keeps both sessions alive.
+import { useEffect, useRef, useState } from "react";
+import type { RepoNode, WorktreeNode } from "../types";
+import { useStore } from "../store";
+import { ChevLeft, ChevRight, Doc, Sparkle, Terminal as TerminalIcon } from "../icons";
+import TerminalPane from "./TerminalPane";
+
+const COLLAPSE_KEY = "canopy.lane.collapsed";
+
+type Tab = "agent" | "shell";
+
+export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNode }) {
+  const showToast = useStore((s) => s.showToast);
+  const [collapsed, setCollapsed] = useState(() => localStorage.getItem(COLLAPSE_KEY) === "1");
+  const [tab, setTab] = useState<Tab>("agent");
+  // lazily mount a tab's terminal the first time it's shown, then keep it
+  // mounted (hidden) so its PTY keeps running in the background.
+  const activated = useRef<Set<Tab>>(new Set(["agent"]));
+  activated.current.add(tab);
+
+  useEffect(() => {
+    localStorage.setItem(COLLAPSE_KEY, collapsed ? "1" : "0");
+  }, [collapsed]);
+
+  const shellId = `${wt.wtKey}::shell`;
+  const agentId = `${wt.wtKey}::agent`;
+
+  if (collapsed) {
+    return (
+      <aside className="lane collapsed">
+        <div className="lane-head" style={{ padding: 0, justifyContent: "center" }}>
+          <button className="ib" title="Open agent lane" onClick={() => setCollapsed(false)}>
+            <ChevLeft size={16} />
+          </button>
+        </div>
+        <div className="lane-rail">
+          <button
+            className="ib"
+            title="Agent"
+            onClick={() => {
+              setCollapsed(false);
+              setTab("agent");
+            }}
+          >
+            <Sparkle size={15} />
+          </button>
+          <button
+            className="ib"
+            title="Shell"
+            onClick={() => {
+              setCollapsed(false);
+              setTab("shell");
+            }}
+          >
+            <TerminalIcon size={15} />
+          </button>
+          <button className="ib" title="Context" onClick={() => setCollapsed(false)}>
+            <Doc size={15} />
+          </button>
+          <span className="vtxt">Agent</span>
+        </div>
+      </aside>
+    );
+  }
+
+  return (
+    <aside className="lane">
+      <div className="lane-head">
+        <span className="ag-pip busy" style={{ width: 26, height: 26, borderRadius: 8, background: "var(--accent-dim)" }}>
+          <Sparkle size={14} />
+        </span>
+        <div className="lh-t">
+          <b>Agent</b>
+          <span>{wt.branch}</span>
+        </div>
+        <span className="grow" />
+        <button className="ib" title="Collapse lane" onClick={() => setCollapsed(true)}>
+          <ChevRight size={16} />
+        </button>
+      </div>
+
+      <div className="lane-ctx">
+        <div className="lc-lbl">
+          <Doc size={11} />
+          Context
+          <span className="grow" />
+          <button
+            className="ib"
+            style={{ height: 22, fontSize: 11, padding: "0 7px" }}
+            onClick={() => showToast("Context editor — coming next")}
+          >
+            Edit
+          </button>
+        </div>
+        <div className="lc-title" style={{ color: "var(--faint)" }}>
+          What is this worktree for?
+        </div>
+        <div className="lc-body">Set a task or PR description to seed the agent and pre-fill the PR body.</div>
+      </div>
+
+      <div className="lane-seg">
+        <button className={tab === "agent" ? "on" : ""} onClick={() => setTab("agent")}>
+          <Sparkle size={12} />
+          Agent
+        </button>
+        <button className={tab === "shell" ? "on" : ""} onClick={() => setTab("shell")}>
+          <TerminalIcon size={12} />
+          Shell
+        </button>
+      </div>
+
+      <div className="lane-body">
+        <div className="term">
+          {activated.current.has("agent") && (
+            <div className={"term-body" + (tab === "agent" ? "" : " hidden")}>
+              <TerminalPane termId={agentId} cwd={wt.path} hidden={tab !== "agent"} />
+            </div>
+          )}
+          {activated.current.has("shell") && (
+            <div className={"term-body" + (tab === "shell" ? "" : " hidden")}>
+              <TerminalPane termId={shellId} cwd={wt.path} hidden={tab !== "shell"} />
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="lane-foot">
+        <button
+          className="startagent"
+          style={{ flex: 1, justifyContent: "center", height: 30 }}
+          onClick={() => {
+            setTab("agent");
+            showToast(`Agent — ${repo.name} · ${wt.branch}`);
+          }}
+        >
+          <Sparkle size={13} />
+          Start agent
+          <span className="ar">▸</span>
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/src/app/AgentLane.tsx
+++ b/src/app/AgentLane.tsx
@@ -33,6 +33,25 @@ function DetachedPlaceholder({ onBack }: { onBack: () => void }) {
   );
 }
 
+function AgentIdle({ onStart }: { onStart: () => void }) {
+  return (
+    <div className="term-ph">
+      <span className="ph-ic">
+        <Sparkle size={19} />
+      </span>
+      <span className="ph-t">No agent running</span>
+      <span className="ph-s">
+        Start the coding agent in this worktree. It runs in a real terminal, seeded with the context above.
+      </span>
+      <button className="startagent" onClick={onStart}>
+        <Sparkle size={13} />
+        Start agent
+        <span className="ar">▸</span>
+      </button>
+    </div>
+  );
+}
+
 const COLLAPSE_KEY = "canopy.lane.collapsed";
 const WIDTH_KEY = "canopy.lane.width";
 
@@ -48,18 +67,6 @@ const TIGHT = 1180;
 
 type Tab = "agent" | "shell";
 
-/** Write to a PTY that may have only just been opened (retry briefly). */
-async function writeWhenReady(id: string, data: string, tries = 6) {
-  for (let i = 0; i < tries; i++) {
-    try {
-      await ipc.terminalWrite(id, data);
-      return;
-    } catch {
-      await new Promise((r) => setTimeout(r, 250));
-    }
-  }
-}
-
 export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNode }) {
   const showToast = useStore((s) => s.showToast);
   const agentState = useStore((s) => s.agents[wt.wtKey] ?? "off");
@@ -74,11 +81,14 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
   const [resizing, setResizing] = useState(false);
   const [tight, setTight] = useState(() => window.innerWidth < TIGHT);
   const [detached, setDetached] = useState<Set<string>>(new Set());
+  // resolved agent CLI, set on the first Start; only needed to *create* the
+  // agent PTY — remounts while it's already running attach without it.
+  const [agentCmd, setAgentCmd] = useState<string | null>(null);
   const asideRef = useRef<HTMLElement>(null);
-  // lazily mount a tab's terminal the first time it's shown, then keep it
-  // mounted (hidden) so its PTY keeps running in the background.
-  const activated = useRef<Set<Tab>>(new Set(["agent"]));
-  activated.current.add(tab);
+  // the shell terminal is lazily mounted the first time its tab is shown, then
+  // kept mounted (hidden) so its PTY keeps running in the background.
+  const shellActivated = useRef(false);
+  if (tab === "shell") shellActivated.current = true;
 
   useEffect(() => {
     localStorage.setItem(COLLAPSE_KEY, collapsed ? "1" : "0");
@@ -211,33 +221,37 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
     );
   }
 
-  // Start the configured agent CLI inside the agent PTY (the terminal *is* the
-  // chat). The context, if any, is written to .canopy/context.md so the agent
-  // can read it, and we show a banner noting the seed.
+  // Start the coding agent as its OWN PTY session (the terminal *is* the chat).
+  // Running it as the session's command means the session ends — and the run
+  // state clears via terminal:exit — exactly when the agent exits. The context,
+  // if any, is written to .canopy/context.md first so the agent can read it.
   const startAgent = async () => {
     setCtxOpen(false);
     setTab("agent");
     if (!hasBackend()) {
+      setAgentCmd("agent");
       setAgent(wt.wtKey, "running");
       showToast(`Agent — ${repo.name} · ${wt.branch}`);
       return;
     }
     try {
       if (!isBlank(ctx)) {
-        await ipc.saveTextFile(`${wt.path}/.canopy/context.md`, composeContextMd(ctx)).catch(() => {});
+        // propagate failure — don't claim "seeded" if the write failed
+        await ipc.saveTextFile(`${wt.path}/.canopy/context.md`, composeContextMd(ctx));
       }
       const cmd = (await ipc.resolveAgentCommand(wt.wtKey)) || "claude";
-      await writeWhenReady(`${wt.wtKey}::agent`, `${cmd}\n`);
-      setAgent(wt.wtKey, "running");
+      setAgentCmd(cmd);
+      setAgent(wt.wtKey, "running"); // TerminalPane mounts and creates the PTY with `cmd`
       showToast(`Agent started — ${repo.name} · ${wt.branch}`);
     } catch (e) {
-      showToast(String(e));
+      showToast(`Agent start failed — ${String(e)}`);
     }
   };
 
+  // Kill the agent PTY; terminal:exit then clears run state (see the store).
   const stopAgent = () => {
-    if (hasBackend()) ipc.terminalWrite(`${wt.wtKey}::agent`, "\x03").catch(() => {}); // Ctrl-C
     setAgent(wt.wtKey, "off");
+    if (hasBackend()) ipc.terminalClose(agentId).catch(() => {});
     showToast("Agent stopped");
   };
 
@@ -390,16 +404,16 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
 
       <div className="lane-body">
         <div className="term">
-          {activated.current.has("agent") && (
-            <div className={"term-body" + (tab === "agent" ? "" : " hidden")}>
-              {detached.has(agentId) ? (
-                <DetachedPlaceholder onBack={() => bringBack(agentId)} />
-              ) : (
-                <TerminalPane termId={agentId} cwd={wt.path} hidden={tab !== "agent"} />
-              )}
-            </div>
-          )}
-          {activated.current.has("shell") && (
+          <div className={"term-body" + (tab === "agent" ? "" : " hidden")}>
+            {detached.has(agentId) ? (
+              <DetachedPlaceholder onBack={() => bringBack(agentId)} />
+            ) : agentState === "running" ? (
+              <TerminalPane termId={agentId} cwd={wt.path} hidden={tab !== "agent"} command={agentCmd ?? undefined} />
+            ) : (
+              <AgentIdle onStart={startAgent} />
+            )}
+          </div>
+          {shellActivated.current && (
             <div className={"term-body" + (tab === "shell" ? "" : " hidden")}>
               {detached.has(shellId) ? (
                 <DetachedPlaceholder onBack={() => bringBack(shellId)} />

--- a/src/app/AgentLane.tsx
+++ b/src/app/AgentLane.tsx
@@ -7,6 +7,7 @@ import type { RepoNode, WorktreeNode } from "../types";
 import { useStore } from "../store";
 import { ChevLeft, ChevRight, Doc, Sparkle, Terminal as TerminalIcon } from "../icons";
 import TerminalPane from "./TerminalPane";
+import { ContextEditor, bodyPreview, isBlank, useWtContext } from "./WorktreeContext";
 
 const COLLAPSE_KEY = "canopy.lane.collapsed";
 
@@ -16,6 +17,8 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
   const showToast = useStore((s) => s.showToast);
   const [collapsed, setCollapsed] = useState(() => localStorage.getItem(COLLAPSE_KEY) === "1");
   const [tab, setTab] = useState<Tab>("agent");
+  const [ctxOpen, setCtxOpen] = useState(false);
+  const [ctx, setCtx] = useWtContext(wt.wtKey);
   // lazily mount a tab's terminal the first time it's shown, then keep it
   // mounted (hidden) so its PTY keeps running in the background.
   const activated = useRef<Set<Tab>>(new Set(["agent"]));
@@ -57,7 +60,14 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
           >
             <TerminalIcon size={15} />
           </button>
-          <button className="ib" title="Context" onClick={() => setCollapsed(false)}>
+          <button
+            className="ib"
+            title="Context"
+            onClick={() => {
+              setCollapsed(false);
+              setCtxOpen(true);
+            }}
+          >
             <Doc size={15} />
           </button>
           <span className="vtxt">Agent</span>
@@ -65,6 +75,12 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
       </aside>
     );
   }
+
+  const seedAgent = () => {
+    setCtxOpen(false);
+    setTab("agent");
+    showToast(`Agent — ${repo.name} · ${wt.branch}`);
+  };
 
   return (
     <aside className="lane">
@@ -87,18 +103,23 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
           <Doc size={11} />
           Context
           <span className="grow" />
-          <button
-            className="ib"
-            style={{ height: 22, fontSize: 11, padding: "0 7px" }}
-            onClick={() => showToast("Context editor — coming next")}
-          >
+          <button className="ib" style={{ height: 22, fontSize: 11, padding: "0 7px" }} onClick={() => setCtxOpen(true)}>
             Edit
           </button>
         </div>
-        <div className="lc-title" style={{ color: "var(--faint)" }}>
-          What is this worktree for?
-        </div>
-        <div className="lc-body">Set a task or PR description to seed the agent and pre-fill the PR body.</div>
+        {isBlank(ctx) ? (
+          <>
+            <div className="lc-title" style={{ color: "var(--faint)" }}>
+              What is this worktree for?
+            </div>
+            <div className="lc-body">Set a task or PR description to seed the agent and pre-fill the PR body.</div>
+          </>
+        ) : (
+          <>
+            <div className="lc-title">{ctx.title || "Untitled"}</div>
+            <div className="lc-body">{bodyPreview(ctx.body) || `${ctx.links.length} link(s)`}</div>
+          </>
+        )}
       </div>
 
       <div className="lane-seg">
@@ -128,19 +149,22 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
       </div>
 
       <div className="lane-foot">
-        <button
-          className="startagent"
-          style={{ flex: 1, justifyContent: "center", height: 30 }}
-          onClick={() => {
-            setTab("agent");
-            showToast(`Agent — ${repo.name} · ${wt.branch}`);
-          }}
-        >
+        <button className="startagent" style={{ flex: 1, justifyContent: "center", height: 30 }} onClick={seedAgent}>
           <Sparkle size={13} />
           Start agent
           <span className="ar">▸</span>
         </button>
       </div>
+
+      {ctxOpen && (
+        <ContextEditor
+          ctx={ctx}
+          setCtx={setCtx}
+          onClose={() => setCtxOpen(false)}
+          onSeed={seedAgent}
+          onToast={showToast}
+        />
+      )}
     </aside>
   );
 }

--- a/src/app/AgentLane.tsx
+++ b/src/app/AgentLane.tsx
@@ -73,6 +73,10 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
   const setAgent = useStore((s) => s.setAgent);
   const mainRailed = useStore((s) => s.mainRailed);
   const setMainRailed = useStore((s) => s.setMainRailed);
+  // detached tracking lives in the store so it survives this lane remounting on
+  // worktree switch (the window stays open; the placeholder must persist).
+  const detached = useStore((s) => s.detachedTerms);
+  const setTermDetached = useStore((s) => s.setTermDetached);
   const [collapsed, setCollapsed] = useState(() => localStorage.getItem(COLLAPSE_KEY) === "1");
   const [tab, setTab] = useState<Tab>("agent");
   const [ctxOpen, setCtxOpen] = useState(false);
@@ -80,7 +84,6 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
   const [laneW, setLaneW] = useState(() => Number(localStorage.getItem(WIDTH_KEY)) || DEFAULT_LANE);
   const [resizing, setResizing] = useState(false);
   const [tight, setTight] = useState(() => window.innerWidth < TIGHT);
-  const [detached, setDetached] = useState<Set<string>>(new Set());
   // resolved agent CLI, set on the first Start; only needed to *create* the
   // agent PTY — remounts while it's already running attach without it.
   const [agentCmd, setAgentCmd] = useState<string | null>(null);
@@ -236,7 +239,9 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
     }
     try {
       if (!isBlank(ctx)) {
-        // propagate failure — don't claim "seeded" if the write failed
+        // keep Canopy's dir out of the user's git status, then write context
+        // (propagate failure — don't claim "seeded" if the write failed)
+        await ipc.saveTextFile(`${wt.path}/.canopy/.gitignore`, "*\n").catch(() => {});
         await ipc.saveTextFile(`${wt.path}/.canopy/context.md`, composeContextMd(ctx));
       }
       const cmd = (await ipc.resolveAgentCommand(wt.wtKey)) || "claude";
@@ -281,15 +286,9 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
       decorations: false,
       resizable: true,
     });
-    win.once("tauri://created", () => setDetached((s) => new Set(s).add(id)));
+    win.once("tauri://created", () => setTermDetached(id, true));
     win.once("tauri://error", () => showToast("Could not open terminal window"));
-    win.once("tauri://destroyed", () =>
-      setDetached((s) => {
-        const n = new Set(s);
-        n.delete(id);
-        return n;
-      }),
-    );
+    win.once("tauri://destroyed", () => setTermDetached(id, false));
   };
 
   const bringBack = async (id: string) => {
@@ -298,11 +297,7 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
       const w = await WebviewWindow.getByLabel(laneLabel(id));
       await w?.close();
     }
-    setDetached((s) => {
-      const n = new Set(s);
-      n.delete(id);
-      return n;
-    });
+    setTermDetached(id, false);
   };
 
   return (

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -131,7 +131,7 @@ export default function App() {
           </section>
         )}
 
-        {!showSettings && sel?.wt && <AgentLane repo={sel.repo} wt={sel.wt} />}
+        {!showSettings && sel?.wt && <AgentLane key={sel.wt.wtKey} repo={sel.repo} wt={sel.wt} />}
       </div>
 
       {showNewWt && <NewWorktreeModal repoId={sel?.repo.repoId ?? ""} onClose={() => setShowNewWt(false)} />}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -7,6 +7,7 @@ import WorktreeHeader from "./WorktreeHeader";
 import ServiceCard from "./ServiceCard";
 import DatabaseControl from "./DatabaseControl";
 import Console from "./Console";
+import AgentLane from "./AgentLane";
 import SettingsView from "./SettingsView";
 import NewWorktreeModal from "./NewWorktreeModal";
 import RemoveWorktreeModal from "./RemoveWorktreeModal";
@@ -69,7 +70,7 @@ export default function App() {
         </button>
       </div>
 
-      <div className="app">
+      <div className={"app" + (!showSettings && sel?.wt ? " with-lane" : "")}>
         <Sidebar onAdd={() => setShowNewWt(true)} />
 
         {showSettings ? (
@@ -107,6 +108,8 @@ export default function App() {
             <Console wt={sel.wt} />
           </section>
         )}
+
+        {!showSettings && sel?.wt && <AgentLane repo={sel.repo} wt={sel.wt} />}
       </div>
 
       {showNewWt && <NewWorktreeModal repoId={sel?.repo.repoId ?? ""} onClose={() => setShowNewWt(false)} />}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { initSync, useStore } from "../store";
 import { isLive } from "../types";
-import { Fork, Plus, Refresh, Settings } from "../icons";
+import { ChevRight, Fork, Logs, Plus, Refresh, Settings } from "../icons";
 import Sidebar from "./Sidebar";
 import WorktreeHeader from "./WorktreeHeader";
 import ServiceCard from "./ServiceCard";
@@ -18,6 +18,8 @@ export default function App() {
   const selKey = useStore((s) => s.selKey);
   const toast = useStore((s) => s.toast);
   const showToast = useStore((s) => s.showToast);
+  const mainRailed = useStore((s) => s.mainRailed);
+  const setMainRailed = useStore((s) => s.setMainRailed);
   const [, setTick] = useState(0);
   const [showSettings, setShowSettings] = useState(false);
   const [showNewWt, setShowNewWt] = useState(false);
@@ -81,6 +83,26 @@ export default function App() {
               <Plus size={13} />
               Add your first repository
             </button>
+          </div>
+        ) : mainRailed ? (
+          <div className="main railed">
+            <div className="main-rail">
+              <button className="ib" title="Show worktree details" onClick={() => setMainRailed(false)}>
+                <ChevRight size={16} />
+              </button>
+              <span className="rdiv" />
+              {sel.wt.services
+                .filter((s) => isLive(s.status))
+                .map((s) => (
+                  <span className="rdot" key={s.svcKey} title={`${s.name} running`} />
+                ))}
+              <span className="rdiv" />
+              <button className="ib" title="Logs" onClick={() => setMainRailed(false)}>
+                <Logs size={15} />
+              </button>
+              <span className="grow" />
+              <span className="vtxt">{sel.wt.branch}</span>
+            </div>
           </div>
         ) : (
           <section className="main">

--- a/src/app/DetachedTerminal.tsx
+++ b/src/app/DetachedTerminal.tsx
@@ -1,0 +1,38 @@
+// The detached terminal window's contents. It attaches to the SAME backend PTY
+// (by termId) as the inline lane pane, so the shell/agent keeps running and its
+// output mirrors here — the PTY lives in Rust; this is just another view.
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { Fork, PopIn, Terminal as TerminalIcon } from "../icons";
+import TerminalPane from "./TerminalPane";
+
+export default function DetachedTerminal({ termId, cwd, branch }: { termId: string; cwd: string; branch: string }) {
+  const back = () => getCurrentWindow().close();
+  return (
+    <div className="detwin-body">
+      <div className="detwin-bar" data-tauri-drag-region>
+        <span className="dw-t" data-tauri-drag-region>
+          <span className="fork">
+            <TerminalIcon size={13} />
+          </span>
+          Terminal
+          <span className="br">— {branch}</span>
+        </span>
+        <span className="grow" data-tauri-drag-region />
+        <button className="ib" title="Return to main window" onClick={back}>
+          <PopIn size={13} />
+        </button>
+      </div>
+      <div className="term" style={{ flex: 1, minHeight: 0 }}>
+        <div className="term-body">
+          <TerminalPane termId={termId} cwd={cwd} />
+        </div>
+      </div>
+      <div className="lane-foot" style={{ justifyContent: "flex-end" }}>
+        <span className="fork" style={{ color: "var(--accent)", marginRight: "auto", display: "inline-flex" }}>
+          <Fork size={13} />
+        </span>
+        <span style={{ fontSize: 10.5, color: "var(--faint)", fontFamily: "var(--mono)" }}>{cwd}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/app/SettingsView.tsx
+++ b/src/app/SettingsView.tsx
@@ -14,7 +14,7 @@ import {
   type Settings,
 } from "../ipc";
 import { useStore } from "../store";
-import { Braces, Cube, Database, Download, File, Fork, Plus, Server, Settings as Cog, Terminal, Upload } from "../icons";
+import { Braces, Cube, Database, Download, File, Fork, Plus, Server, Settings as Cog, Sparkle, Terminal, Upload } from "../icons";
 
 const KINDS = ["web", "server", "worker"];
 const FORMATS: { id: ProvisionFormat; label: string }[] = [
@@ -629,6 +629,17 @@ export default function SettingsView({ onClose }: { onClose: () => void }) {
                         value={repo.migrateDb || ""}
                         placeholder="npm run db:migrate (else .worktreemanager.json migrate)"
                         onChange={(e) => patchRepo({ migrateDb: e.target.value })}
+                      />
+                    </div>
+                    <div className="cfg-row">
+                      <label className="fld-label">
+                        <Sparkle size={12} /> Agent command
+                      </label>
+                      <input
+                        className="input mono"
+                        value={repo.agentCommand || ""}
+                        placeholder="claude (also: aider, codex, gemini…)"
+                        onChange={(e) => patchRepo({ agentCommand: e.target.value })}
                       />
                     </div>
                   </div>

--- a/src/app/Sidebar.tsx
+++ b/src/app/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useStore } from "../store";
 import { isLive } from "../types";
-import { Fork, Plus, Search } from "../icons";
+import { Fork, Plus, Search, Sparkle } from "../icons";
 
 export default function Sidebar({ onAdd }: { onAdd: () => void }) {
   const tree = useStore((s) => s.tree);
@@ -8,6 +8,7 @@ export default function Sidebar({ onAdd }: { onAdd: () => void }) {
   const setQuery = useStore((s) => s.setQuery);
   const selKey = useStore((s) => s.selKey);
   const select = useStore((s) => s.select);
+  const agents = useStore((s) => s.agents);
 
   const q = query.toLowerCase();
   const total = tree.reduce((n, r) => n + r.worktrees.length, 0);
@@ -44,6 +45,7 @@ export default function Sidebar({ onAdd }: { onAdd: () => void }) {
                 const running = w.services.filter((s) => isLive(s.status)).length;
                 const dot = running === 0 ? "off" : running === tcount ? "on" : "part";
                 const statusText = running > 0 ? `${running} running` : "idle";
+                const agent = agents[w.wtKey] ?? "off";
                 return (
                   <button
                     key={w.wtKey}
@@ -55,6 +57,11 @@ export default function Sidebar({ onAdd }: { onAdd: () => void }) {
                       <div className="b">{w.branch}</div>
                       <div className="r">{statusText}</div>
                     </span>
+                    {agent === "running" && (
+                      <span className="ag-pip busy" title="Agent working">
+                        <Sparkle size={10} />
+                      </span>
+                    )}
                   </button>
                 );
               })}

--- a/src/app/TerminalPane.tsx
+++ b/src/app/TerminalPane.tsx
@@ -8,6 +8,7 @@
 import { useEffect, useRef } from "react";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
+import { WebglAddon } from "@xterm/addon-webgl";
 import { hasBackend, ipc, on } from "../ipc";
 
 /** base64 (raw PTY bytes) → Uint8Array for xterm.write */
@@ -62,13 +63,23 @@ export default function TerminalPane({
       cursorBlink: true,
       theme: THEME,
       allowProposedApi: true,
-      scrollback: 5000,
+      scrollback: 2500,
     });
     const fit = new FitAddon();
     term.loadAddon(fit);
     term.open(host);
     termRef.current = term;
     fitRef.current = fit;
+
+    // GPU rendering — far faster under heavy output. Fall back to the DOM
+    // renderer if WebGL is unavailable or its context is lost.
+    try {
+      const webgl = new WebglAddon();
+      webgl.onContextLoss(() => webgl.dispose());
+      term.loadAddon(webgl);
+    } catch {
+      /* no WebGL — DOM renderer stays */
+    }
 
     let disposed = false;
     let unlistenData: (() => void) | undefined;

--- a/src/app/TerminalPane.tsx
+++ b/src/app/TerminalPane.tsx
@@ -85,16 +85,28 @@ export default function TerminalPane({ termId, cwd, hidden }: { termId: string; 
       if (e.id === termId && termRef.current) termRef.current.write("\r\n\x1b[38;5;244m[process exited]\x1b[0m\r\n");
     }).then((u) => (disposed ? u() : (unlistenExit = u)));
 
+    // While replaying saved scrollback, xterm re-answers any query escape
+    // sequences (Device Attributes, cursor-position reports) embedded in the
+    // history. Those replies must NOT be forwarded to the PTY, or the shell
+    // prompt echoes them as typed junk ("1;2c22;3R…"). Gate onData until the
+    // rehydration write has finished parsing.
+    let hydrating = false;
     ipc
       .terminalOpen(termId, cwd, term.cols, term.rows)
       .then(() => ipc.terminalGetBuffer(termId))
       .then((buf) => {
-        if (!disposed && buf && termRef.current) termRef.current.write(decode(buf));
+        if (!disposed && buf && termRef.current) {
+          hydrating = true;
+          termRef.current.write(decode(buf), () => {
+            hydrating = false;
+          });
+        }
       })
       .catch((err) => term.write(`\r\n\x1b[31mterminal error: ${String(err)}\x1b[0m\r\n`));
 
-    // keystrokes → PTY (the PTY echoes; no local echo)
+    // keystrokes (and terminal reports) → PTY. The PTY echoes; no local echo.
     const onDataDisp = term.onData((data) => {
+      if (hydrating) return; // suppress replies to replayed history
       ipc.terminalWrite(termId, data).catch(() => {});
     });
 

--- a/src/app/TerminalPane.tsx
+++ b/src/app/TerminalPane.tsx
@@ -28,7 +28,19 @@ const THEME = {
   brightBlack: "#7c7e86",
 };
 
-export default function TerminalPane({ termId, cwd, hidden }: { termId: string; cwd: string; hidden?: boolean }) {
+export default function TerminalPane({
+  termId,
+  cwd,
+  hidden,
+  command,
+}: {
+  termId: string;
+  cwd: string;
+  hidden?: boolean;
+  /** run this command instead of an interactive shell; the session ends (fires
+      terminal:exit) when it exits — used to track agent lifecycle */
+  command?: string;
+}) {
   const hostRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<Terminal | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
@@ -61,6 +73,14 @@ export default function TerminalPane({ termId, cwd, hidden }: { termId: string; 
     let disposed = false;
     let unlistenData: (() => void) | undefined;
     let unlistenExit: (() => void) | undefined;
+    let hydrated = false;
+    // xterm re-answers query escape sequences (Device Attributes, cursor-position
+    // reports) it finds while replaying scrollback; those replies must NOT reach
+    // the PTY or the shell prompt echoes them as junk ("1;2c22;3R…"). Suppressed
+    // only while the snapshot write is parsing.
+    let suppressOut = false;
+    const pending: { seq: number; data: string }[] = [];
+    const writeChunk = (b64: string) => termRef.current?.write(decode(b64));
 
     // fit only when the host is actually laid out — fitting a zero-size or
     // display:none element leaves xterm's renderer without dimensions and throws
@@ -75,40 +95,44 @@ export default function TerminalPane({ termId, cwd, hidden }: { termId: string; 
     };
     requestAnimationFrame(safeFit);
 
-    // live PTY output → xterm. Subscribe before opening so nothing is missed for
-    // a brand-new session; for an existing one we rehydrate right after.
-    on.terminalData((e) => {
-      if (e.id === termId && termRef.current) termRef.current.write(decode(e.data));
-    }).then((u) => (disposed ? u() : (unlistenData = u)));
-
-    on.terminalExit((e) => {
-      if (e.id === termId && termRef.current) termRef.current.write("\r\n\x1b[38;5;244m[process exited]\x1b[0m\r\n");
-    }).then((u) => (disposed ? u() : (unlistenExit = u)));
-
-    // While replaying saved scrollback, xterm re-answers any query escape
-    // sequences (Device Attributes, cursor-position reports) embedded in the
-    // history. Those replies must NOT be forwarded to the PTY, or the shell
-    // prompt echoes them as typed junk ("1;2c22;3R…"). Gate onData until the
-    // rehydration write has finished parsing.
-    let hydrating = false;
-    ipc
-      .terminalOpen(termId, cwd, term.cols, term.rows)
-      .then(() => ipc.terminalGetBuffer(termId))
-      .then((buf) => {
-        if (!disposed && buf && termRef.current) {
-          hydrating = true;
-          termRef.current.write(decode(buf), () => {
-            hydrating = false;
-          });
-        }
-      })
-      .catch((err) => term.write(`\r\n\x1b[31mterminal error: ${String(err)}\x1b[0m\r\n`));
-
     // keystrokes (and terminal reports) → PTY. The PTY echoes; no local echo.
     const onDataDisp = term.onData((data) => {
-      if (hydrating) return; // suppress replies to replayed history
+      if (suppressOut) return;
       ipc.terminalWrite(termId, data).catch(() => {});
     });
+
+    // Register listeners BEFORE opening so no output is missed, then rehydrate
+    // against the snapshot cursor: replay the snapshot, then apply only queued
+    // live events past its seq — no double-render, no gap.
+    (async () => {
+      unlistenData = await on.terminalData((e) => {
+        if (e.id !== termId) return;
+        if (!hydrated) pending.push({ seq: e.seq, data: e.data });
+        else writeChunk(e.data);
+      });
+      unlistenExit = await on.terminalExit((e) => {
+        if (e.id === termId) termRef.current?.write("\r\n\x1b[38;5;244m[process exited]\x1b[0m\r\n");
+      });
+      if (disposed) return;
+
+      try {
+        await ipc.terminalOpen(termId, cwd, term.cols, term.rows, command);
+        const snap = await ipc.terminalGetBuffer(termId);
+        if (disposed || !termRef.current) return;
+        const baseline = snap?.seq ?? 0;
+        if (snap?.buffer) {
+          suppressOut = true;
+          termRef.current.write(decode(snap.buffer), () => {
+            suppressOut = false;
+          });
+        }
+        for (const p of pending) if (p.seq > baseline) writeChunk(p.data);
+        pending.length = 0;
+        hydrated = true;
+      } catch (err) {
+        termRef.current?.write(`\r\n\x1b[31mterminal error: ${String(err)}\x1b[0m\r\n`);
+      }
+    })();
 
     // keep the PTY sized to the widget
     const ro = new ResizeObserver(() => {
@@ -129,7 +153,7 @@ export default function TerminalPane({ termId, cwd, hidden }: { termId: string; 
       fitRef.current = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [termId, cwd]);
+  }, [termId, cwd, command]);
 
   // re-fit when the pane becomes visible (tab toggle) or the lane resizes
   useEffect(() => {

--- a/src/app/TerminalPane.tsx
+++ b/src/app/TerminalPane.tsx
@@ -62,11 +62,18 @@ export default function TerminalPane({ termId, cwd, hidden }: { termId: string; 
     let unlistenData: (() => void) | undefined;
     let unlistenExit: (() => void) | undefined;
 
-    try {
-      fit.fit();
-    } catch {
-      /* host not laid out yet */
-    }
+    // fit only when the host is actually laid out — fitting a zero-size or
+    // display:none element leaves xterm's renderer without dimensions and throws
+    // asynchronously on the next write.
+    const safeFit = () => {
+      if (!host.clientWidth || !host.clientHeight) return;
+      try {
+        fit.fit();
+      } catch {
+        /* ignore */
+      }
+    };
+    requestAnimationFrame(safeFit);
 
     // live PTY output → xterm. Subscribe before opening so nothing is missed for
     // a brand-new session; for an existing one we rehydrate right after.
@@ -93,13 +100,9 @@ export default function TerminalPane({ termId, cwd, hidden }: { termId: string; 
 
     // keep the PTY sized to the widget
     const ro = new ResizeObserver(() => {
-      if (hidden) return;
-      try {
-        fit.fit();
-        ipc.terminalResize(termId, term.cols, term.rows).catch(() => {});
-      } catch {
-        /* ignore */
-      }
+      if (hidden || !host.clientWidth || !host.clientHeight) return;
+      safeFit();
+      ipc.terminalResize(termId, term.cols, term.rows).catch(() => {});
     });
     ro.observe(host);
 
@@ -118,11 +121,13 @@ export default function TerminalPane({ termId, cwd, hidden }: { termId: string; 
 
   // re-fit when the pane becomes visible (tab toggle) or the lane resizes
   useEffect(() => {
-    if (hidden || !fitRef.current || !termRef.current) return;
+    if (hidden) return;
     const id = requestAnimationFrame(() => {
+      const host = hostRef.current;
+      if (!host || !fitRef.current || !termRef.current || !host.clientWidth || !host.clientHeight) return;
       try {
-        fitRef.current!.fit();
-        ipc.terminalResize(termId, termRef.current!.cols, termRef.current!.rows).catch(() => {});
+        fitRef.current.fit();
+        ipc.terminalResize(termId, termRef.current.cols, termRef.current.rows).catch(() => {});
       } catch {
         /* ignore */
       }

--- a/src/app/TerminalPane.tsx
+++ b/src/app/TerminalPane.tsx
@@ -1,0 +1,134 @@
+// A live terminal pane: one xterm.js renderer bound to a backend PTY session.
+//
+// The PTY lives in Rust (keyed by `termId`); this component is the disposable
+// view. On mount it opens/attaches the session, rehydrates scrollback, and
+// streams bytes both ways. On unmount it disposes the widget but LEAVES the PTY
+// running — switching worktrees or toggling the Agent/Shell tab keeps the shell
+// (and any agent in it) alive; we rehydrate from the backend buffer on return.
+import { useEffect, useRef } from "react";
+import { Terminal } from "@xterm/xterm";
+import { FitAddon } from "@xterm/addon-fit";
+import { hasBackend, ipc, on } from "../ipc";
+
+/** base64 (raw PTY bytes) → Uint8Array for xterm.write */
+function decode(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+const THEME = {
+  background: "#191a1d", // --panel-2
+  foreground: "#cfd1d6",
+  cursor: "#5cc7cd", // --accent
+  cursorAccent: "#191a1d",
+  selectionBackground: "rgba(92,199,205,.25)",
+  black: "#191a1d",
+  brightBlack: "#7c7e86",
+};
+
+export default function TerminalPane({ termId, cwd, hidden }: { termId: string; cwd: string; hidden?: boolean }) {
+  const hostRef = useRef<HTMLDivElement>(null);
+  const termRef = useRef<Terminal | null>(null);
+  const fitRef = useRef<FitAddon | null>(null);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+
+    if (!hasBackend()) {
+      host.innerHTML =
+        '<div style="padding:14px;font:12.5px var(--mono);color:var(--faint)">Terminal runs in the Canopy desktop app.</div>';
+      return;
+    }
+
+    const term = new Terminal({
+      fontFamily: 'ui-monospace, "SF Mono", "JetBrains Mono", Menlo, monospace',
+      fontSize: 12.5,
+      lineHeight: 1.25,
+      cursorBlink: true,
+      theme: THEME,
+      allowProposedApi: true,
+      scrollback: 5000,
+    });
+    const fit = new FitAddon();
+    term.loadAddon(fit);
+    term.open(host);
+    termRef.current = term;
+    fitRef.current = fit;
+
+    let disposed = false;
+    let unlistenData: (() => void) | undefined;
+    let unlistenExit: (() => void) | undefined;
+
+    try {
+      fit.fit();
+    } catch {
+      /* host not laid out yet */
+    }
+
+    // live PTY output → xterm. Subscribe before opening so nothing is missed for
+    // a brand-new session; for an existing one we rehydrate right after.
+    on.terminalData((e) => {
+      if (e.id === termId && termRef.current) termRef.current.write(decode(e.data));
+    }).then((u) => (disposed ? u() : (unlistenData = u)));
+
+    on.terminalExit((e) => {
+      if (e.id === termId && termRef.current) termRef.current.write("\r\n\x1b[38;5;244m[process exited]\x1b[0m\r\n");
+    }).then((u) => (disposed ? u() : (unlistenExit = u)));
+
+    ipc
+      .terminalOpen(termId, cwd, term.cols, term.rows)
+      .then(() => ipc.terminalGetBuffer(termId))
+      .then((buf) => {
+        if (!disposed && buf && termRef.current) termRef.current.write(decode(buf));
+      })
+      .catch((err) => term.write(`\r\n\x1b[31mterminal error: ${String(err)}\x1b[0m\r\n`));
+
+    // keystrokes → PTY (the PTY echoes; no local echo)
+    const onDataDisp = term.onData((data) => {
+      ipc.terminalWrite(termId, data).catch(() => {});
+    });
+
+    // keep the PTY sized to the widget
+    const ro = new ResizeObserver(() => {
+      if (hidden) return;
+      try {
+        fit.fit();
+        ipc.terminalResize(termId, term.cols, term.rows).catch(() => {});
+      } catch {
+        /* ignore */
+      }
+    });
+    ro.observe(host);
+
+    return () => {
+      disposed = true;
+      unlistenData?.();
+      unlistenExit?.();
+      onDataDisp.dispose();
+      ro.disconnect();
+      term.dispose();
+      termRef.current = null;
+      fitRef.current = null;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [termId, cwd]);
+
+  // re-fit when the pane becomes visible (tab toggle) or the lane resizes
+  useEffect(() => {
+    if (hidden || !fitRef.current || !termRef.current) return;
+    const id = requestAnimationFrame(() => {
+      try {
+        fitRef.current!.fit();
+        ipc.terminalResize(termId, termRef.current!.cols, termRef.current!.rows).catch(() => {});
+      } catch {
+        /* ignore */
+      }
+    });
+    return () => cancelAnimationFrame(id);
+  }, [hidden, termId]);
+
+  return <div ref={hostRef} className="xterm-host" />;
+}

--- a/src/app/TerminalPane.tsx
+++ b/src/app/TerminalPane.tsx
@@ -116,15 +116,21 @@ export default function TerminalPane({
     // against the snapshot cursor: replay the snapshot, then apply only queued
     // live events past its seq — no double-render, no gap.
     (async () => {
-      unlistenData = await on.terminalData((e) => {
+      // if the effect is torn down before a listen() resolves (StrictMode),
+      // cleanup can't see the unlisten yet — unregister it right here instead,
+      // or the handler leaks and keeps appending after unmount.
+      const u1 = await on.terminalData((e) => {
         if (e.id !== termId) return;
         if (!hydrated) pending.push({ seq: e.seq, data: e.data });
         else writeChunk(e.data);
       });
-      unlistenExit = await on.terminalExit((e) => {
+      if (disposed) return u1();
+      unlistenData = u1;
+      const u2 = await on.terminalExit((e) => {
         if (e.id === termId) termRef.current?.write("\r\n\x1b[38;5;244m[process exited]\x1b[0m\r\n");
       });
-      if (disposed) return;
+      if (disposed) return u2();
+      unlistenExit = u2;
 
       try {
         await ipc.terminalOpen(termId, cwd, term.cols, term.rows, command);

--- a/src/app/WorktreeContext.tsx
+++ b/src/app/WorktreeContext.tsx
@@ -4,6 +4,31 @@
 // that travels with the branch is an open product question — see the handoff.
 import { Fragment, useEffect, useState, type ReactNode } from "react";
 import { Chevron, Copy, Doc, Info, Link as LinkIcon, Plus, Sparkle } from "../icons";
+import { hasBackend } from "../ipc";
+
+const isUrl = (s: string) => /^https?:\/\//i.test(s.trim());
+
+async function openLink(url: string, onToast: (m: string) => void) {
+  try {
+    if (hasBackend()) {
+      const { openUrl } = await import("@tauri-apps/plugin-opener");
+      await openUrl(url);
+    } else {
+      window.open(url, "_blank", "noopener");
+    }
+  } catch (e) {
+    onToast(`Couldn't open link — ${String(e)}`);
+  }
+}
+
+async function copyPrBody(ctx: WtContext, onToast: (m: string) => void) {
+  try {
+    await navigator.clipboard.writeText(composeContextMd(ctx));
+    onToast("Context copied as PR body");
+  } catch (e) {
+    onToast(`Couldn't copy — ${String(e)}`);
+  }
+}
 
 export interface WtContext {
   title: string;
@@ -150,14 +175,22 @@ export function ContextEditor({
           )}
 
           <div className="ctx-links">
-            {ctx.links.map((l) => (
-              <span className="ctx-link" key={l.label} onClick={() => onToast("Opening " + l.label + "…")}>
-                <span className="ic">
-                  <LinkIcon size={11} />
+            {ctx.links.map((l) => {
+              const url = isUrl(l.label);
+              return (
+                <span
+                  className="ctx-link"
+                  key={l.label}
+                  style={url ? undefined : { cursor: "default" }}
+                  onClick={url ? () => openLink(l.label, onToast) : undefined}
+                >
+                  <span className="ic">
+                    <LinkIcon size={11} />
+                  </span>
+                  {l.label}
                 </span>
-                {l.label}
-              </span>
-            ))}
+              );
+            })}
             <span
               className="ctx-link add"
               onClick={() => {
@@ -179,7 +212,7 @@ export function ContextEditor({
               Seeds the agent · becomes the PR body
             </span>
             <span className="grow" />
-            <button className="btn-sm" onClick={() => onToast("Context copied as PR body")}>
+            <button className="btn-sm" onClick={() => copyPrBody(ctx, onToast)}>
               <Copy size={12} />
               Use as PR body
             </button>

--- a/src/app/WorktreeContext.tsx
+++ b/src/app/WorktreeContext.tsx
@@ -1,0 +1,188 @@
+// Per-worktree context: a title + markdown body + links that seed the agent and
+// later become the PR body. Persisted per worktree in localStorage (keyed by
+// wtKey). Whether this should instead live as a committed `.canopy/context.md`
+// that travels with the branch is an open product question — see the handoff.
+import { Fragment, useEffect, useState, type ReactNode } from "react";
+import { Chevron, Copy, Doc, Info, Link as LinkIcon, Plus, Sparkle } from "../icons";
+
+export interface WtContext {
+  title: string;
+  body: string;
+  links: { label: string; kind: string }[];
+}
+
+const EMPTY: WtContext = { title: "", body: "", links: [] };
+
+function load(key: string): WtContext {
+  try {
+    const raw = localStorage.getItem(key);
+    if (raw) return { ...EMPTY, ...JSON.parse(raw) };
+  } catch {
+    /* ignore */
+  }
+  return EMPTY;
+}
+
+/** Load/save a worktree's context, reloading when the selected worktree changes. */
+export function useWtContext(wtKey: string): [WtContext, (c: WtContext) => void] {
+  const key = `canopy.ctx.${wtKey}`;
+  const [ctx, setCtx] = useState<WtContext>(() => load(key));
+  useEffect(() => setCtx(load(key)), [key]);
+  const update = (c: WtContext) => {
+    setCtx(c);
+    try {
+      localStorage.setItem(key, JSON.stringify(c));
+    } catch {
+      /* ignore */
+    }
+  };
+  return [ctx, update];
+}
+
+export const isBlank = (c: WtContext) => !c.title.trim() && !c.body.trim() && c.links.length === 0;
+
+/** Plain-text one-liner of the markdown body, for the lane summary preview. */
+export function bodyPreview(body: string): string {
+  return body
+    .replace(/[#`\-]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Tiny markdown renderer: `## ` headings, `- ` bullets, inline `code`. */
+export function mdRender(src: string): ReactNode[] {
+  const out: ReactNode[] = [];
+  let list: ReactNode[] | null = null;
+  const inline = (s: string) =>
+    s.split(/(`[^`]+`)/g).map((p, j) =>
+      p.startsWith("`") && p.endsWith("`") && p.length > 1 ? (
+        <code key={j}>{p.slice(1, -1)}</code>
+      ) : (
+        <Fragment key={j}>{p}</Fragment>
+      ),
+    );
+  src.split("\n").forEach((raw, i) => {
+    const line = raw.trim();
+    if (line.startsWith("## ")) {
+      if (list) {
+        out.push(<ul key={"u" + i}>{list}</ul>);
+        list = null;
+      }
+      out.push(<h3 key={i}>{line.slice(3)}</h3>);
+    } else if (line.startsWith("- ")) {
+      (list = list || []).push(<li key={i}>{inline(line.slice(2))}</li>);
+    } else if (line) {
+      if (list) {
+        out.push(<ul key={"u" + i}>{list}</ul>);
+        list = null;
+      }
+      out.push(<p key={i}>{inline(line)}</p>);
+    }
+  });
+  if (list) out.push(<ul key="ul-last">{list}</ul>);
+  return out;
+}
+
+/** The full context editor, shown in a modal over the lane. */
+export function ContextEditor({
+  ctx,
+  setCtx,
+  onClose,
+  onSeed,
+  onToast,
+}: {
+  ctx: WtContext;
+  setCtx: (c: WtContext) => void;
+  onClose: () => void;
+  onSeed: () => void;
+  onToast: (m: string) => void;
+}) {
+  const [tab, setTab] = useState<"write" | "prev">("write");
+  return (
+    <div className="ctx-scrim" onMouseDown={onClose}>
+      <div className="ctx-modal" onMouseDown={(e) => e.stopPropagation()}>
+        <div className="ctx-card">
+          <div className="ctx-head">
+            <span className="cs-lbl">
+              <Doc size={12} />
+              Context
+            </span>
+            <span className="grow" />
+            <div className="ctx-seg">
+              <button className={tab === "write" ? "on" : ""} onClick={() => setTab("write")}>
+                Write
+              </button>
+              <button className={tab === "prev" ? "on" : ""} onClick={() => setTab("prev")}>
+                Preview
+              </button>
+            </div>
+            <button className="ib" title="Collapse" onClick={onClose}>
+              <span style={{ display: "inline-flex", transform: "rotate(180deg)" }}>
+                <Chevron size={14} />
+              </span>
+            </button>
+          </div>
+
+          <input
+            className="ctx-title-in"
+            value={ctx.title}
+            placeholder="What is this worktree for?"
+            onChange={(e) => setCtx({ ...ctx, title: e.target.value })}
+          />
+
+          {tab === "write" ? (
+            <textarea
+              className="ctx-md"
+              value={ctx.body}
+              spellCheck={false}
+              placeholder={"## Problem\n…\n\n## Acceptance\n- …"}
+              onChange={(e) => setCtx({ ...ctx, body: e.target.value })}
+            />
+          ) : (
+            <div className="ctx-prev">{mdRender(ctx.body)}</div>
+          )}
+
+          <div className="ctx-links">
+            {ctx.links.map((l) => (
+              <span className="ctx-link" key={l.label} onClick={() => onToast("Opening " + l.label + "…")}>
+                <span className="ic">
+                  <LinkIcon size={11} />
+                </span>
+                {l.label}
+              </span>
+            ))}
+            <span
+              className="ctx-link add"
+              onClick={() => {
+                const label = window.prompt("Paste an issue or PR link (or a label)");
+                if (label && label.trim()) {
+                  const kind = /pull|\/pull\/|pr[\s#]/i.test(label) ? "pr" : "issue";
+                  setCtx({ ...ctx, links: [...ctx.links, { label: label.trim(), kind }] });
+                }
+              }}
+            >
+              <Plus size={11} />
+              Add link
+            </span>
+          </div>
+
+          <div className="ctx-foot">
+            <span className="hint">
+              <Info size={12} />
+              Seeds the agent · becomes the PR body
+            </span>
+            <span className="grow" />
+            <button className="btn-sm" onClick={() => onToast("Context copied as PR body")}>
+              <Copy size={12} />
+              Use as PR body
+            </button>
+            <button className="btn-sm teal" onClick={onSeed}>
+              <Sparkle size={12} />
+              Start agent with this
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/WorktreeContext.tsx
+++ b/src/app/WorktreeContext.tsx
@@ -41,6 +41,13 @@ export function useWtContext(wtKey: string): [WtContext, (c: WtContext) => void]
 
 export const isBlank = (c: WtContext) => !c.title.trim() && !c.body.trim() && c.links.length === 0;
 
+/** Render the context as the markdown seed written to `.canopy/context.md`. */
+export function composeContextMd(c: WtContext): string {
+  let md = `# ${c.title.trim() || "Untitled"}\n\n${c.body.trim()}\n`;
+  if (c.links.length) md += "\n## Links\n" + c.links.map((l) => `- ${l.label}`).join("\n") + "\n";
+  return md;
+}
+
 /** Plain-text one-liner of the markdown body, for the lane summary preview. */
 export function bodyPreview(body: string): string {
   return body

--- a/src/icons.tsx
+++ b/src/icons.tsx
@@ -272,3 +272,76 @@ export const Cube = ({ size = 15 }: P) => (
     <path d="M12 12l8-4.5M12 12v9M12 12L4 7.5" />
   </svg>
 );
+
+// ── Agent lane ──
+export const PopOut = ({ size = 14 }: P) => (
+  <svg {...isvg(size, 1.8)}>
+    <path d="M11 5h-4a2 2 0 0 0 -2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2 -2v-4" />
+    <path d="M13 11l7 -7" />
+    <path d="M15 4h5v5" />
+  </svg>
+);
+
+export const PopIn = ({ size = 14 }: P) => (
+  <svg {...isvg(size, 1.8)}>
+    <path d="M13 19h4a2 2 0 0 0 2 -2v-10a2 2 0 0 0 -2 -2h-10a2 2 0 0 0 -2 2v4" />
+    <path d="M11 13l-7 7" />
+    <path d="M9 20h-5v-5" />
+  </svg>
+);
+
+export const Sparkle = ({ size = 14 }: P) => (
+  <svg {...isvg(size, 1.7)}>
+    <path d="M12 3l1.9 5.1l5.1 1.9l-5.1 1.9l-1.9 5.1l-1.9 -5.1l-5.1 -1.9l5.1 -1.9z" />
+    <path d="M18.5 16.5l.7 1.8l1.8 .7l-1.8 .7l-.7 1.8l-.7 -1.8l-1.8 -.7l1.8 -.7z" />
+  </svg>
+);
+
+export const Doc = ({ size = 14 }: P) => (
+  <svg {...isvg(size, 1.7)}>
+    <path d="M14 3v4a1 1 0 0 0 1 1h4" />
+    <path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z" />
+    <path d="M9 12h6" />
+    <path d="M9 16h4" />
+  </svg>
+);
+
+export const Link = ({ size = 13 }: P) => (
+  <svg {...isvg(size, 1.8)}>
+    <path d="M9 15l6 -6" />
+    <path d="M11 6l.5 -.5a3.5 3.5 0 0 1 5 5l-.5 .5" />
+    <path d="M13 18l-.5 .5a3.5 3.5 0 0 1 -5 -5l.5 -.5" />
+  </svg>
+);
+
+export const ChevRight = ({ size = 14 }: P) => (
+  <svg {...isvg(size)}>
+    <path d="M9 6l6 6l-6 6" />
+  </svg>
+);
+
+export const ChevLeft = ({ size = 14 }: P) => (
+  <svg {...isvg(size)}>
+    <path d="M15 6l-6 6l6 6" />
+  </svg>
+);
+
+export const ExpandH = ({ size = 15 }: P) => (
+  <svg {...isvg(size, 1.8)}>
+    <path d="M4 8v-2a1 1 0 0 1 1 -1h2" />
+    <path d="M4 16v2a1 1 0 0 0 1 1h2" />
+    <path d="M20 8v-2a1 1 0 0 0 -1 -1h-2" />
+    <path d="M20 16v2a1 1 0 0 1 -1 1h-2" />
+    <path d="M9 12h6" />
+    <path d="M11 10l-2 2l2 2" />
+    <path d="M13 10l2 2l-2 2" />
+  </svg>
+);
+
+export const Info = ({ size = 13 }: P) => (
+  <svg {...isvg(size, 1.8)}>
+    <circle cx="12" cy="12" r="9" />
+    <path d="M12 8h.01" />
+    <path d="M11 12h1v4h1" />
+  </svg>
+);

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -103,11 +103,11 @@ export const ipc = {
 
   // embedded terminals (agent lane). `id` is opaque (e.g. `${wtKey}::shell`);
   // `data` on read events is base64 of the raw PTY bytes.
-  terminalOpen: (id: string, cwd: string, cols: number, rows: number) =>
-    invoke<void>("terminal_open", { id, cwd, cols, rows }),
+  terminalOpen: (id: string, cwd: string, cols: number, rows: number, command?: string) =>
+    invoke<void>("terminal_open", { id, cwd, cols, rows, command: command ?? null }),
   terminalWrite: (id: string, data: string) => invoke<void>("terminal_write", { id, data }),
   terminalResize: (id: string, cols: number, rows: number) => invoke<void>("terminal_resize", { id, cols, rows }),
-  terminalGetBuffer: (id: string) => invoke<string | null>("terminal_get_buffer", { id }),
+  terminalGetBuffer: (id: string) => invoke<TerminalSnapshot | null>("terminal_get_buffer", { id }),
   terminalClose: (id: string) => invoke<void>("terminal_close", { id }),
   resolveAgentCommand: (wtKey: string) => invoke<string>("resolve_agent_command", { wtKey }),
 
@@ -174,9 +174,16 @@ export interface TerminalDataEvent {
   id: string;
   /** base64 of raw PTY bytes */
   data: string;
+  /** cumulative byte cursor after this chunk */
+  seq: number;
 }
 export interface TerminalExitEvent {
   id: string;
+}
+/** Scrollback snapshot + the cursor it ends at (race-free rehydrate). */
+export interface TerminalSnapshot {
+  buffer: string;
+  seq: number;
 }
 
 export const on = {

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -98,6 +98,16 @@ export const ipc = {
   saveTextFile: (path: string, contents: string) => invoke<void>("save_text_file", { path, contents }),
 
   getLogs: (svcKey: string) => invoke<LogLine[]>("get_logs", { svcKey }),
+
+  // embedded terminals (agent lane). `id` is opaque (e.g. `${wtKey}::shell`);
+  // `data` on read events is base64 of the raw PTY bytes.
+  terminalOpen: (id: string, cwd: string, cols: number, rows: number) =>
+    invoke<void>("terminal_open", { id, cwd, cols, rows }),
+  terminalWrite: (id: string, data: string) => invoke<void>("terminal_write", { id, data }),
+  terminalResize: (id: string, cols: number, rows: number) => invoke<void>("terminal_resize", { id, cols, rows }),
+  terminalGetBuffer: (id: string) => invoke<string | null>("terminal_get_buffer", { id }),
+  terminalClose: (id: string) => invoke<void>("terminal_close", { id }),
+
   serviceStart: (svcKey: string) => invoke<void>("service_start", { svcKey }),
   serviceStop: (svcKey: string) => invoke<void>("service_stop", { svcKey }),
   serviceRestart: (svcKey: string) => invoke<void>("service_restart", { svcKey }),
@@ -157,6 +167,14 @@ export interface OpEvent {
   state: "progress" | "done" | "error";
   detail: string;
 }
+export interface TerminalDataEvent {
+  id: string;
+  /** base64 of raw PTY bytes */
+  data: string;
+}
+export interface TerminalExitEvent {
+  id: string;
+}
 
 export const on = {
   treeChanged: (cb: (tree: RepoNode[]) => void): Promise<UnlistenFn> =>
@@ -173,6 +191,10 @@ export const on = {
     listen<ResetEvent>("reset:status", (e) => cb(e.payload)),
   worktreeOp: (cb: (e: OpEvent) => void): Promise<UnlistenFn> =>
     listen<OpEvent>("worktree:op", (e) => cb(e.payload)),
+  terminalData: (cb: (e: TerminalDataEvent) => void): Promise<UnlistenFn> =>
+    listen<TerminalDataEvent>("terminal:data", (e) => cb(e.payload)),
+  terminalExit: (cb: (e: TerminalExitEvent) => void): Promise<UnlistenFn> =>
+    listen<TerminalExitEvent>("terminal:exit", (e) => cb(e.payload)),
 };
 
 /** True when running inside the Tauri webview (false in a plain browser tab). */

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -27,6 +27,8 @@ export interface RepoCfg {
   migrateDb: string;
   services: ServiceCfg[];
   customCommands: CustomCmd[];
+  /** agent-lane CLI (empty = built-in default) */
+  agentCommand: string;
 }
 
 export interface Settings {
@@ -107,6 +109,7 @@ export const ipc = {
   terminalResize: (id: string, cols: number, rows: number) => invoke<void>("terminal_resize", { id, cols, rows }),
   terminalGetBuffer: (id: string) => invoke<string | null>("terminal_get_buffer", { id }),
   terminalClose: (id: string) => invoke<void>("terminal_close", { id }),
+  resolveAgentCommand: (wtKey: string) => invoke<string>("resolve_agent_command", { wtKey }),
 
   serviceStart: (svcKey: string) => invoke<void>("service_start", { svcKey }),
   serviceStop: (svcKey: string) => invoke<void>("service_stop", { svcKey }),

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -109,6 +109,9 @@ export const ipc = {
   terminalResize: (id: string, cols: number, rows: number) => invoke<void>("terminal_resize", { id, cols, rows }),
   terminalGetBuffer: (id: string) => invoke<TerminalSnapshot | null>("terminal_get_buffer", { id }),
   terminalClose: (id: string) => invoke<void>("terminal_close", { id }),
+  /** write .canopy/context.md (creates the dir + a self-ignoring .gitignore, never clobbering it) */
+  writeWorktreeContext: (wtPath: string, contents: string) =>
+    invoke<void>("write_worktree_context", { wtPath, contents }),
   resolveAgentCommand: (wtKey: string) => invoke<string>("resolve_agent_command", { wtKey }),
 
   serviceStart: (svcKey: string) => invoke<void>("service_start", { svcKey }),

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import App from "./app/App";
 import "./styles/tokens.css";
 import "./styles/app.css";
+import "./styles/terminal.css";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>

--- a/src/store.ts
+++ b/src/store.ts
@@ -408,6 +408,15 @@ export function initSync(): () => void {
 
   track(on.worktreeOp((e) => appendOpLine(e.wtKey, e.state, e.detail)));
 
+  // agent lifecycle: the agent runs as its own PTY session (`${wtKey}::agent`),
+  // so its exit is the authoritative "agent stopped" signal.
+  track(
+    on.terminalExit((e) => {
+      const suffix = "::agent";
+      if (e.id.endsWith(suffix)) useStore.getState().setAgent(e.id.slice(0, -suffix.length), "off");
+    }),
+  );
+
   track(
     on.serviceStats((e) => {
       useStore.setState((st) => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -33,6 +33,10 @@ interface State {
   /** agent-lane run state per worktree (wtKey → state); survives worktree switch */
   agents: Record<string, "off" | "running">;
   setAgent: (wtKey: string, state: "off" | "running") => void;
+  /** terminal ids currently shown in a detached window — in the store so the
+      placeholder survives a lane remount (worktree switch) */
+  detachedTerms: Set<string>;
+  setTermDetached: (id: string, v: boolean) => void;
   /** focus mode: the middle pane drops to a rail so the terminal takes the window */
   mainRailed: boolean;
   setMainRailed: (v: boolean) => void;
@@ -86,6 +90,8 @@ export function wtLabel(tree: RepoNode[], wtKey: string): string {
 const timers: Record<string, ReturnType<typeof setTimeout>> = {};
 let toastTimer: ReturnType<typeof setTimeout> | undefined;
 const startedAt: Record<string, number> = {}; // svcKey -> ms epoch
+const agentStartedAt: Record<string, number> = {}; // wtKey -> ms epoch (agent start)
+const QUICK_EXIT_MS = 2500; // agent gone this fast after start = it never really ran
 
 function appendLogs(svcKey: string, lines: LogLine[]) {
   useStore.setState((st) => {
@@ -187,7 +193,18 @@ export const useStore = create<State>((set, get) => {
     tabSvcKey: mock[0]?.worktrees[0]?.services[0]?.svcKey ?? null,
     collapsed: false,
     agents: {},
-    setAgent: (wtKey, state) => set((st) => ({ agents: { ...st.agents, [wtKey]: state } })),
+    setAgent: (wtKey, state) => {
+      if (state === "running") agentStartedAt[wtKey] = Date.now();
+      set((st) => ({ agents: { ...st.agents, [wtKey]: state } }));
+    },
+    detachedTerms: new Set(),
+    setTermDetached: (id, v) =>
+      set((st) => {
+        const next = new Set(st.detachedTerms);
+        if (v) next.add(id);
+        else next.delete(id);
+        return { detachedTerms: next };
+      }),
     mainRailed: false,
     setMainRailed: (mainRailed) => set({ mainRailed }),
 
@@ -412,8 +429,19 @@ export function initSync(): () => void {
   // so its exit is the authoritative "agent stopped" signal.
   track(
     on.terminalExit((e) => {
+      // a detached window closing (not the agent) shouldn't touch state
+      useStore.getState().setTermDetached(e.id, false);
       const suffix = "::agent";
-      if (e.id.endsWith(suffix)) useStore.getState().setAgent(e.id.slice(0, -suffix.length), "off");
+      if (!e.id.endsWith(suffix)) return;
+      const wtKey = e.id.slice(0, -suffix.length);
+      // "running" here means it wasn't a user-initiated stop (stop sets off first)
+      const wasRunning = useStore.getState().agents[wtKey] === "running";
+      useStore.getState().setAgent(wtKey, "off");
+      if (wasRunning) {
+        const started = agentStartedAt[wtKey];
+        if (started && Date.now() - started < QUICK_EXIT_MS)
+          useStore.getState().showToast("Agent exited immediately — check the agent command");
+      }
     }),
   );
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -33,6 +33,9 @@ interface State {
   /** agent-lane run state per worktree (wtKey → state); survives worktree switch */
   agents: Record<string, "off" | "running">;
   setAgent: (wtKey: string, state: "off" | "running") => void;
+  /** focus mode: the middle pane drops to a rail so the terminal takes the window */
+  mainRailed: boolean;
+  setMainRailed: (v: boolean) => void;
 
   setQuery: (q: string) => void;
   select: (wtKey: string) => void;
@@ -185,6 +188,8 @@ export const useStore = create<State>((set, get) => {
     collapsed: false,
     agents: {},
     setAgent: (wtKey, state) => set((st) => ({ agents: { ...st.agents, [wtKey]: state } })),
+    mainRailed: false,
+    setMainRailed: (mainRailed) => set({ mainRailed }),
 
     setQuery: (query) => set({ query }),
     select: (wtKey) => set({ selKey: wtKey }),

--- a/src/store.ts
+++ b/src/store.ts
@@ -30,6 +30,9 @@ interface State {
   query: string;
   tabSvcKey: string | null;
   collapsed: boolean;
+  /** agent-lane run state per worktree (wtKey → state); survives worktree switch */
+  agents: Record<string, "off" | "running">;
+  setAgent: (wtKey: string, state: "off" | "running") => void;
 
   setQuery: (q: string) => void;
   select: (wtKey: string) => void;
@@ -180,6 +183,8 @@ export const useStore = create<State>((set, get) => {
     query: "",
     tabSvcKey: mock[0]?.worktrees[0]?.services[0]?.svcKey ?? null,
     collapsed: false,
+    agents: {},
+    setAgent: (wtKey, state) => set((st) => ({ agents: { ...st.agents, [wtKey]: state } })),
 
     setQuery: (query) => set({ query }),
     select: (wtKey) => set({ selKey: wtKey }),

--- a/src/store.ts
+++ b/src/store.ts
@@ -429,8 +429,10 @@ export function initSync(): () => void {
   // so its exit is the authoritative "agent stopped" signal.
   track(
     on.terminalExit((e) => {
-      // a detached window closing (not the agent) shouldn't touch state
-      useStore.getState().setTermDetached(e.id, false);
+      // NB: don't clear the detached flag here — terminal:exit means the PTY
+      // process ended, not that its window closed (that's the tauri://destroyed
+      // handler). Clearing it would re-dock and spawn a new inline shell while
+      // the detached window is still open.
       const suffix = "::agent";
       if (!e.id.endsWith(suffix)) return;
       const wtKey = e.id.slice(0, -suffix.length);

--- a/src/styles/terminal.css
+++ b/src/styles/terminal.css
@@ -240,13 +240,17 @@
   min-height: 0;
   flex: 1;
   background: var(--panel-2);
+  position: relative;
 }
 .lane .term {
   background: transparent;
 }
+/* Tab panes are stacked absolutely and always sized — xterm can't initialize its
+   renderer in a display:none box, so we hide the inactive pane with visibility
+   (keeping its dimensions and its PTY alive) instead of removing it. */
 .term-body {
-  flex: 1;
-  min-height: 0;
+  position: absolute;
+  inset: 0;
   overflow: hidden;
   padding: 6px 8px 8px;
 }
@@ -254,9 +258,10 @@
   width: 100%;
   height: 100%;
 }
-/* the shell keeps running behind the tab — hide its pane instead of unmounting */
 .term-body.hidden {
-  display: none;
+  visibility: hidden;
+  z-index: 0;
+  pointer-events: none;
 }
 
 /* ── agent output (structured transcript over the PTY) ── */

--- a/src/styles/terminal.css
+++ b/src/styles/terminal.css
@@ -6,6 +6,12 @@
 
 @import "@xterm/xterm/css/xterm.css";
 
+/* shared flex spacer used across the lane, context editor, focus rail, and the
+   detached-window header (the design's `.grow`). */
+.grow {
+  flex: 1;
+}
+
 .app.with-lane {
   display: flex;
   position: relative;

--- a/src/styles/terminal.css
+++ b/src/styles/terminal.css
@@ -1,0 +1,682 @@
+/* Agent lane — terminal + context + agent, a first-class right-hand column.
+   Ported from the "Canopy — Agent Lane" design handoff (VariantC). Tokens live
+   in tokens.css. The lane mounts only in the worktree view; the .with-lane
+   modifier switches .app from its 2-col grid to the 3-column flex row the lane
+   needs (and gives it the positioning context the overlay drawer relies on). */
+
+@import "@xterm/xterm/css/xterm.css";
+
+.app.with-lane {
+  display: flex;
+  position: relative;
+}
+.app.with-lane > .sidebar {
+  width: 264px;
+  flex: none;
+}
+.app.with-lane > .main {
+  flex: 1 1 auto;
+  min-width: 460px;
+}
+/* focus mode: the middle pane drops to a rail so the terminal takes the window */
+.app.with-lane > .main.railed {
+  flex: 0 0 52px;
+  width: 52px;
+  min-width: 0;
+  overflow: hidden;
+}
+.main-rail {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 11px;
+  padding: 10px 0;
+  border-right: 1px solid var(--border-soft);
+}
+.main-rail .rdot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--run);
+  box-shadow: 0 0 0 3px var(--run-dim);
+  flex: none;
+}
+.main-rail .rdiv {
+  width: 18px;
+  height: 1px;
+  background: var(--border-soft);
+  flex: none;
+}
+.main-rail .vtxt {
+  writing-mode: vertical-rl;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--faint);
+  margin-top: 4px;
+}
+
+/* ── the lane ── */
+.lane {
+  flex: 0 1 auto;
+  width: 372px;
+  border-left: 1px solid var(--border-soft);
+  background: var(--sidebar);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  transition: width 0.2s ease;
+  position: relative;
+}
+/* CSS ceiling: the lane can never out-grow what's left after the sidebar and the
+   main pane's floor, whatever laneW state says. */
+.lane:not(.overlay) {
+  max-width: calc(100% - 264px - 460px);
+}
+.app:has(.main.railed) .lane:not(.overlay) {
+  max-width: calc(100% - 264px - 52px);
+}
+.lane.resizing {
+  transition: none;
+}
+.lane.collapsed {
+  width: 50px;
+}
+/* drag the lane's left edge to widen the terminal */
+.lane-grip {
+  position: absolute;
+  left: -4px;
+  top: 0;
+  bottom: 0;
+  width: 8px;
+  cursor: col-resize;
+  z-index: 30;
+}
+.lane-grip::after {
+  content: "";
+  position: absolute;
+  left: 3px;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: transparent;
+  transition: background 0.12s;
+}
+.lane-grip:hover::after,
+.lane-grip.on::after {
+  background: var(--accent);
+}
+.lane-head {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 8px 0 14px;
+  height: 62px;
+  border-bottom: 1px solid var(--border-soft);
+}
+.lane-head .lh-t {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.lane-head .lh-t b {
+  font-size: 12.5px;
+  font-weight: 640;
+  color: var(--text);
+}
+.lane-head .lh-t span {
+  font-size: 10.5px;
+  color: var(--faint);
+  font-family: var(--mono);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.lane-rail {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding-top: 14px;
+}
+.lane-rail .vtxt {
+  writing-mode: vertical-rl;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--faint);
+  margin-top: 4px;
+}
+.lane-ctx {
+  flex: none;
+  border-bottom: 1px solid var(--border-soft);
+  padding: 11px 13px;
+  background: rgba(0, 0, 0, 0.14);
+}
+.lane-ctx .lc-lbl {
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--faint);
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+.lane-ctx .lc-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  margin-top: 6px;
+  line-height: 1.4;
+}
+.lane-ctx .lc-body {
+  font-size: 11.5px;
+  color: var(--faint);
+  margin-top: 4px;
+  line-height: 1.55;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.lane-seg {
+  flex: none;
+  display: flex;
+  gap: 3px;
+  padding: 9px 11px;
+  border-bottom: 1px solid var(--border-soft);
+}
+.lane-seg button {
+  flex: 1;
+  height: 28px;
+  border-radius: 8px;
+  border: 0;
+  background: none;
+  color: var(--faint);
+  font-family: var(--sans);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  transition: background 0.1s, color 0.1s;
+}
+.lane-seg button:hover {
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--dim);
+}
+.lane-seg button.on {
+  background: var(--btn);
+  color: var(--text);
+}
+.lane-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.lane-foot {
+  flex: none;
+  padding: 9px 11px;
+  border-top: 1px solid var(--border-soft);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* ── terminal pane ── */
+.term {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  flex: 1;
+  background: var(--panel-2);
+}
+.lane .term {
+  background: transparent;
+}
+.term-body {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  padding: 6px 8px 8px;
+}
+.xterm-host {
+  width: 100%;
+  height: 100%;
+}
+/* the shell keeps running behind the tab — hide its pane instead of unmounting */
+.term-body.hidden {
+  display: none;
+}
+
+/* ── agent output (structured transcript over the PTY) ── */
+.ag-banner {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 7px 11px;
+  margin: 8px 10px 4px;
+  border: 1px solid rgba(92, 199, 205, 0.3);
+  border-radius: 8px;
+  background: var(--accent-dim);
+  color: var(--accent);
+  font-family: var(--sans);
+  font-size: 11.5px;
+}
+.ag-banner .nm {
+  font-weight: 650;
+}
+.ag-banner .sep {
+  color: rgba(92, 199, 205, 0.5);
+}
+.ag-banner .ctxref {
+  color: #9fe0e4;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* "Start agent" affordance — one click, quiet until needed */
+.startagent {
+  height: 27px;
+  padding: 0 10px 0 9px;
+  border-radius: 8px;
+  border: 1px solid rgba(92, 199, 205, 0.3);
+  background: var(--accent-dim);
+  color: var(--accent);
+  font-family: var(--sans);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  flex: none;
+  transition: background 0.12s;
+}
+.startagent:hover {
+  background: rgba(92, 199, 205, 0.26);
+}
+.startagent .ar {
+  opacity: 0.8;
+}
+.agent-live {
+  height: 27px;
+  padding: 0 5px 0 10px;
+  border-radius: 8px;
+  background: var(--accent-dim);
+  color: var(--accent);
+  font-size: 11.5px;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex: none;
+}
+.agent-live.wait {
+  background: var(--warn-dim);
+  color: var(--warn);
+}
+.agent-live .stopx {
+  border: 0;
+  background: none;
+  color: inherit;
+  cursor: pointer;
+  display: inline-flex;
+  padding: 4px;
+  border-radius: 6px;
+  opacity: 0.75;
+}
+.agent-live .stopx:hover {
+  background: rgba(255, 255, 255, 0.1);
+  opacity: 1;
+}
+
+/* agent pip in the sidebar — the only at-a-glance agent signal */
+.ag-pip {
+  flex: none;
+  width: 15px;
+  height: 15px;
+  border-radius: 5px;
+  display: grid;
+  place-items: center;
+  align-self: center;
+}
+.ag-pip.busy {
+  color: var(--accent);
+  background: var(--accent-dim);
+}
+.ag-pip.wait {
+  color: var(--warn);
+  background: var(--warn-dim);
+}
+.ag-pip.busy svg {
+  animation: spin 1.5s linear infinite;
+}
+.ag-pip.wait {
+  animation: pulse 1.6s ease-in-out infinite;
+}
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.42;
+  }
+}
+
+/* ── context surface (lane summary + modal editor) ── */
+.ctx-card {
+  border: 1px solid var(--border);
+  border-radius: 11px;
+  background: var(--panel);
+  overflow: hidden;
+  animation: fade 0.15s ease;
+}
+.ctx-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border-soft);
+}
+.ctx-head .cs-lbl {
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--faint);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.ctx-seg {
+  display: flex;
+  gap: 2px;
+  background: var(--panel-2);
+  border: 1px solid var(--border-soft);
+  border-radius: 8px;
+  padding: 2px;
+}
+.ctx-seg button {
+  height: 22px;
+  padding: 0 10px;
+  border: 0;
+  border-radius: 6px;
+  background: none;
+  color: var(--faint);
+  font-family: var(--sans);
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.1s, color 0.1s;
+}
+.ctx-seg button.on {
+  background: var(--btn);
+  color: var(--text);
+}
+.ctx-title-in {
+  width: 100%;
+  background: none;
+  border: 0;
+  outline: none;
+  color: var(--text);
+  font-family: var(--sans);
+  font-size: 15px;
+  font-weight: 600;
+  padding: 12px 14px 4px;
+}
+.ctx-title-in::placeholder {
+  color: var(--faint);
+}
+.ctx-md {
+  width: 100%;
+  min-height: 104px;
+  background: none;
+  border: 0;
+  outline: none;
+  resize: none;
+  color: var(--dim);
+  font-family: var(--mono);
+  font-size: 12.5px;
+  line-height: 1.7;
+  padding: 4px 14px 12px;
+}
+.ctx-prev {
+  padding: 4px 14px 12px;
+  font-size: 13px;
+  color: var(--dim);
+  line-height: 1.65;
+}
+.ctx-prev h3 {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--faint);
+  margin: 12px 0 5px;
+}
+.ctx-prev h3:first-child {
+  margin-top: 2px;
+}
+.ctx-prev ul {
+  margin: 4px 0;
+  padding-left: 18px;
+}
+.ctx-prev li {
+  margin: 3px 0;
+}
+.ctx-prev code {
+  font-family: var(--mono);
+  font-size: 11.5px;
+  background: var(--panel-2);
+  padding: 1px 5px;
+  border-radius: 4px;
+  color: var(--accent);
+}
+.ctx-prev p {
+  margin: 5px 0;
+}
+.ctx-links {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  flex-wrap: wrap;
+  padding: 0 14px 12px;
+}
+.ctx-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 25px;
+  padding: 0 9px;
+  border-radius: 7px;
+  background: var(--panel-2);
+  border: 1px solid var(--border-soft);
+  color: var(--dim);
+  font-size: 11.5px;
+  cursor: pointer;
+  transition: border-color 0.12s, color 0.12s;
+}
+.ctx-link:hover {
+  border-color: var(--border-pop);
+  color: var(--text);
+}
+.ctx-link .ic {
+  color: var(--faint);
+  display: inline-flex;
+}
+.ctx-link.add {
+  border-style: dashed;
+  color: var(--faint);
+}
+.ctx-foot {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 12px;
+  border-top: 1px solid var(--border-soft);
+  background: rgba(0, 0, 0, 0.14);
+}
+.ctx-foot .hint {
+  font-size: 11px;
+  color: var(--faint);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.btn-sm {
+  height: 28px;
+  padding: 0 11px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--btn);
+  color: var(--dim);
+  font-family: var(--sans);
+  font-size: 12px;
+  font-weight: 550;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  transition: background 0.1s, color 0.1s, border-color 0.1s;
+}
+.btn-sm:hover {
+  background: var(--btn-hover);
+  color: var(--text);
+  border-color: var(--border-pop);
+}
+.btn-sm.teal {
+  background: var(--accent-dim);
+  border-color: rgba(92, 199, 205, 0.32);
+  color: var(--accent);
+}
+.btn-sm.teal:hover {
+  background: rgba(92, 199, 205, 0.26);
+  color: #8fdfe4;
+}
+.ctx-scrim {
+  position: fixed;
+  inset: 0;
+  background: rgba(10, 12, 16, 0.5);
+  backdrop-filter: blur(2px);
+  z-index: 55;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.ctx-modal {
+  width: 520px;
+  max-width: calc(100% - 48px);
+}
+
+/* ── pop-out placeholder + detached window ── */
+.term-ph {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: safe center;
+  gap: 11px;
+  padding: 22px;
+  text-align: center;
+}
+.term-ph > * {
+  flex: none;
+}
+.term-ph .ph-ic {
+  width: 40px;
+  height: 40px;
+  border-radius: 11px;
+  display: grid;
+  place-items: center;
+  background: var(--btn);
+  color: var(--faint);
+}
+.term-ph .ph-t {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--dim);
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+.term-ph .ph-s {
+  font-size: 11.5px;
+  color: var(--faint);
+  max-width: 290px;
+  line-height: 1.5;
+}
+
+/* the detached terminal window (its own OS window body) */
+.detwin-body {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: var(--panel-2);
+  color: var(--text);
+}
+.detwin-bar {
+  height: 38px;
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 0 12px;
+  background: var(--titlebar);
+  border-bottom: 1px solid var(--border-soft);
+}
+.detwin-bar .dw-t {
+  font-size: 12px;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+.detwin-bar .dw-t .fork {
+  color: var(--accent);
+  display: inline-flex;
+}
+.detwin-bar .dw-t .br {
+  font-family: var(--mono);
+  font-weight: 500;
+  color: var(--faint);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@keyframes fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+/* narrow window: the lane becomes an overlay drawer so it costs zero layout
+   width and never squeezes the main pane past its floor. */
+.lane.overlay {
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: min(372px, calc(100% - 300px));
+  z-index: 25;
+  box-shadow: -18px 0 44px -14px rgba(0, 0, 0, 0.55);
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -25,6 +25,9 @@
   --amber: #e6ad5f;
   --red: #e0533d;
   --red-dim: rgba(224, 83, 61, 0.12);
+  /* agent-lane status halos (design handoff names) */
+  --run-dim: var(--green-dim);
+  --warn-dim: rgba(230, 173, 95, 0.14);
 
   /* ── legacy aliases (Settings / modals / branch picker / popover) ── */
   --sidebar-bg: var(--sidebar);

--- a/src/terminal-window.tsx
+++ b/src/terminal-window.tsx
@@ -1,0 +1,20 @@
+// Entry for the detached terminal window. Reads the session id / cwd / branch
+// from the URL and renders the terminal, attaching to the same backend PTY.
+import React from "react";
+import ReactDOM from "react-dom/client";
+import DetachedTerminal from "./app/DetachedTerminal";
+import "./styles/tokens.css";
+import "./styles/terminal.css";
+
+const params = new URLSearchParams(location.search);
+const termId = params.get("id") ?? "";
+const cwd = params.get("cwd") ?? "";
+const branch = params.get("branch") ?? "";
+
+document.body.style.background = "var(--panel-2)";
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <DetachedTerminal termId={termId} cwd={cwd} branch={branch} />
+  </React.StrictMode>,
+);

--- a/src/terminal-window.tsx
+++ b/src/terminal-window.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import DetachedTerminal from "./app/DetachedTerminal";
 import "./styles/tokens.css";
+import "./styles/app.css";
 import "./styles/terminal.css";
 
 const params = new URLSearchParams(location.search);

--- a/terminal.html
+++ b/terminal.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Canopy Terminal</title>
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/terminal-window.tsx"></script>
+  </body>
+</html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,8 @@ export default defineConfig(async () => ({
         main: resolve(__dirname, "index.html"),
         // @ts-expect-error __dirname is a nodejs global
         popover: resolve(__dirname, "popover.html"),
+        // @ts-expect-error __dirname is a nodejs global
+        terminal: resolve(__dirname, "terminal.html"),
       },
     },
   },


### PR DESCRIPTION
## Agent lane — embedded terminal + coding agent + per-worktree context

Implements the **agent lane** (VariantC from the design handoff): a first-class
right-hand column per worktree holding a real terminal, a one-click coding agent
that runs in it, a per-worktree context doc, pop-out, and focus mode.

Builds on the embedded-terminal foundation from #23.

### Why this shape
The lane hosts a genuine **PTY**, so "the agent" is just a coding-agent CLI
(`claude`, `aider`, `codex`, …) running in a shell — its own TUI handles
approvals and questions. Canopy stays a *manager*, not an agent client, and there
is zero per-agent integration code. The terminal is the chat.

### What's included
- **PTY backend** (`terminal.rs`, `portable-pty`) — a session table mirroring the
  services model, a reader thread streaming bytes over `terminal:data`, capped
  scrollback for rehydrate, killed on quit.
- **Terminal** — `xterm.js` renderer bound to the PTY; disposable view that
  rehydrates on remount and keeps the PTY alive across worktree/tab switches.
- **Agent lane** — Agent/Shell tabs (two live PTYs), context summary, collapsed
  rail; the lane is a third flex column in the worktree view.
- **Context surface** — per-worktree title + markdown + links, modal editor with
  Write/Preview, persisted per worktree; written to `.canopy/context.md` on start.
- **Agent run** — Start agent runs the configured CLI in the agent PTY; run state
  is per worktree and drives the header pip, banner, footer chip, and sidebar pip.
- **Resize / focus / overlay** — drag the lane edge, focus mode collapses the
  middle pane to a rail, and below 1180px the lane becomes an overlay drawer.
- **Pop-out** — detach the terminal into its own window that attaches to the same
  PTY; placeholder + "Bring back".
- **Agent command** — per-repo field in Settings → General (default `claude`).

### Notable fixes
- Stop an xterm renderer crash on hidden/unsized tab panes.
- Don't echo replayed-history query replies (`1;2c22;3R…`) back into the shell on
  remount (e.g. the Settings round-trip).

### Testing
- `npm run build` and `cargo check` both green; smoke-tested live via
  `npm run tauri dev` on macOS (shell, agent start/stop, context, resize, focus,
  pop-out, Settings round-trip).

### Known gaps / follow-ups
- Context persists to `localStorage`; committed-`.canopy/context.md`-vs-branch
  ownership is still an open product question (see handoff).
- No structured agent transcript (the prototype's step view is intentionally not
  reproduced — the real agent's TUI renders in the terminal).
- Empty state, multiple concurrent agents, fetched context, and agent-error
  handling are out of scope here (flagged in the handoff).

Closes #23.
