### PR TITLE
Windows support: Job Object process control, Git Bash shell, CI + NSIS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 # CI — the Linux job exists specifically to compile the cfg(not(macos)) code
 # paths (tray fallback, xdg-open, terminal detection) that a macOS `cargo
-# check` never sees. macOS job mirrors local dev.
+# check` never sees. The Windows job compiles the cfg(windows) paths (Job
+# Object process control, Git Bash shell, Windows pg/node paths). macOS mirrors
+# local dev.
 name: ci
 
 on:
@@ -19,6 +21,25 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev \
             libayatana-appindicator3-dev librsvg2-dev build-essential \
             curl wget file libxdo-dev libssl-dev
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+      # tauri::generate_context! embeds ../dist at compile time
+      - run: npm ci
+      - run: npm run build
+      - run: cargo check --locked
+        working-directory: src-tauri
+      - run: cargo test --locked
+        working-directory: src-tauri
+
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 # Release — build installers on a version tag (v0.4.0 → draft GitHub release).
-# macOS: .app + .dmg (arm64). Linux: .deb / .AppImage / .rpm (untested port —
-# artifacts are published so early adopters can try them).
+# macOS: .app + .dmg (arm64). Linux: .deb / .AppImage / .rpm. Windows: NSIS .exe
+# (untested ports — artifacts are published so early adopters can try them).
 name: release
 
 on:
@@ -21,6 +21,8 @@ jobs:
           - platform: macos-latest
             args: --target aarch64-apple-darwin
           - platform: ubuntu-latest
+            args: ""
+          - platform: windows-latest
             args: ""
     runs-on: ${{ matrix.platform }}
     steps:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -29,22 +29,29 @@
    **universal (Intel) build**, **split SettingsView into per-tab modules**.
 
 ## Cross-platform (Linux / Windows) support
-Released builds are macOS **arm64**. The Linux port is underway — the code compiles in CI and the
-macOS-only pieces are cfg-gated — but it has not yet been validated on a real Linux desktop.
+Released builds are macOS **arm64**. The Linux **and Windows** ports are code-complete and compile in
+CI (dedicated `linux` + `windows` jobs, plus NSIS/deb/AppImage/rpm in the release matrix), with the
+macOS-only pieces cfg-gated — but neither has been validated on a real desktop yet.
 
 | Area | Status |
 |---|---|
 | Tray popover | ✅ cfg-gated: NSPanel on macOS, plain window + tray **menu** fallback elsewhere (appindicator delivers no click events) |
-| Shell | ✅ user's `$SHELL` everywhere (zsh/bash/fish; `sh` fallback) |
-| Open editor / file manager / terminal | ✅ per-platform (`open` / `xdg-open` + terminal-emulator detection / `explorer`) |
-| Process control | ✅ POSIX process groups work on Linux; ❌ Windows needs Job Objects / `taskkill /T` |
-| Postgres binaries | ❌ Linux distro paths (`/usr/lib/postgresql/<maj>/bin` etc.) not probed yet — only Postgres.app + PATH |
-| Window chrome | ⚠️ `titleBarStyle: Overlay` is macOS-only; Linux gets stock decorations — needs a look |
-| Packaging | ⚠️ bundle targets include deb/AppImage/rpm but artifacts are unbuilt/untested; signing story per-OS |
-| Real-desktop validation | ❌ tray, popover positioning, transparency under GNOME/KDE compositors |
+| Shell | ✅ user's `$SHELL` everywhere (zsh/bash/fish; `sh` fallback); Windows runs commands through **Git Bash** (`bash -lc`), keeping the POSIX model (`&&`, pipes, `export`) intact |
+| Open editor / file manager / terminal | ✅ per-platform (`open` / `xdg-open` + terminal-emulator detection / `explorer` / `cmd start`) |
+| Process control | ✅ POSIX process groups on macOS/Linux (`killpg`); ✅ Windows **Job Objects** (`KILL_ON_JOB_CLOSE` → OS reaps the tree on crash, so no orphan sweep needed) — see `src-tauri/src/proc.rs` |
+| Postgres binaries | ✅ Windows `C:\Program Files\PostgreSQL\<maj>\bin` probed (Git-Bash PATH form); ❌ Linux distro paths (`/usr/lib/postgresql/<maj>/bin` etc.) still not probed — only Postgres.app + PATH |
+| Pinned Node | ✅ nvm-windows / fnm / Volta layouts probed alongside asdf/nvm/fnm |
+| Window chrome | ⚠️ `titleBarStyle: Overlay` is macOS-only (traffic-light inset now gated to the `mac` class); Linux/Windows get stock decorations — needs a look |
+| Packaging | ⚠️ bundle targets include deb/AppImage/rpm/NSIS but artifacts are unbuilt/untested; signing story per-OS |
+| Real-desktop validation | ❌ tray, popover positioning, DPI, transparency on Windows and under GNOME/KDE compositors |
 
-**Effort:** Linux is *moderate* (pg-path detection + validation pass). Windows is *substantial* —
-the POSIX process-group/signal model that kills whole service trees has no direct equivalent.
+**Effort:** Linux is *moderate* (pg-path detection + validation pass). Windows is now *code-complete*
+(Job Objects replace the POSIX process-group/signal model), pending real-desktop validation.
+
+**Known Windows limitations (follow-ups):** service stop is a hard `TerminateJobObject` (no graceful
+CTRL_BREAK — a GUI app has no console); a PTY shell's background grandchildren may linger (portable-pty
+doesn't expose the child HANDLE to job-wrap); the hidden main window stays in the taskbar (no
+Accessory-mode equivalent); native (not custom) titlebar; no code-signing.
 
 ## v2+ (out of v1 scope)
 - AI-agent workflows: run multiple coding agents in parallel, each in its own isolated, running

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -401,6 +401,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-positioner",
  "tokio",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -4743,8 +4744,8 @@ dependencies = [
  "webview2-com-sys",
  "windows 0.61.3",
  "windows-core 0.61.2",
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
 ]
 
 [[package]]
@@ -4817,6 +4818,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -4860,12 +4871,25 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -4877,8 +4901,8 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
@@ -4908,9 +4932,31 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4962,6 +5008,15 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
@@ -4976,6 +5031,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,13 +23,30 @@ serde = { version = "1", features = ["derive"] }
 # order the user wrote them instead of being alphabetized
 serde_json = { version = "1", features = ["preserve_order"] }
 tokio = { version = "1", features = ["process", "io-util", "sync", "time", "macros", "rt-multi-thread"] }
-libc = "0.2"
 fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs" }
 sysinfo = "0.39.3"
 # embedded per-worktree terminals: a real PTY per session (the agent lane runs
 # the coding-agent CLI inside one). portable-pty is cross-platform (helps Linux).
 portable-pty = "0.8"
 base64 = "0.22"
+
+# POSIX process control (process groups, killpg, localtime_r). On Windows the
+# equivalent lives in the `windows` crate below (Job Objects). See src/proc.rs.
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+# Windows process control: POSIX process groups have no direct equivalent, so
+# each spawned service tree is wrapped in a Job Object (KILL_ON_JOB_CLOSE) and
+# torn down with TerminateJobObject. See src/proc.rs.
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.58", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_JobObjects",
+    "Win32_System_Threading",
+    "Win32_System_Diagnostics_ToolHelp",
+    "Win32_System_Time",
+] }
 
 # macOS-only: the tray popover is a non-activating NSPanel. Other platforms fall
 # back to a plain borderless window (see src/tray.rs).

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -98,16 +98,23 @@ fn pg_path_prefix_for(server_major: Option<u32>) -> String {
         candidates.push(format!("/Applications/Postgres.app/Contents/Versions/{maj}/bin"));
         candidates.push(format!("/opt/homebrew/opt/postgresql@{maj}/bin"));
         candidates.push(format!("/usr/local/opt/postgresql@{maj}/bin"));
+        #[cfg(target_os = "windows")]
+        candidates.push(format!("C:\\Program Files\\PostgreSQL\\{maj}\\bin"));
     }
     candidates.push("/Applications/Postgres.app/Contents/Versions/latest/bin".into());
     for major in (12..=18).rev() {
         candidates.push(format!("/Applications/Postgres.app/Contents/Versions/{major}/bin"));
         candidates.push(format!("/opt/homebrew/opt/postgresql@{major}/bin"));
         candidates.push(format!("/usr/local/opt/postgresql@{major}/bin"));
+        #[cfg(target_os = "windows")]
+        candidates.push(format!("C:\\Program Files\\PostgreSQL\\{major}\\bin"));
     }
     for dir in candidates {
-        if Path::new(&dir).join("pg_dump").exists() {
-            return format!("export PATH={}:\"$PATH\"; ", q(&dir));
+        let p = Path::new(&dir);
+        // pg_dump on Windows is pg_dump.exe; the command runs under Git Bash so
+        // the emitted PATH entry is converted to MSYS form (see toolchain::bash_path)
+        if p.join("pg_dump").exists() || p.join("pg_dump.exe").exists() {
+            return format!("export PATH={}:\"$PATH\"; ", q(&crate::toolchain::bash_path(&dir)));
         }
     }
     String::new()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod commands;
 mod db;
 mod git;
+mod proc;
 mod services;
 mod settings;
 mod setup;
@@ -75,6 +76,8 @@ pub fn run() {
             }
 
             // headless smoke test of the process layer: WTM_SELFTEST=<svcKey>
+            // (Unix-only: it pokes pgids with killpg to verify the group died)
+            #[cfg(unix)]
             if let Ok(key) = std::env::var("WTM_SELFTEST") {
                 let handle = app.handle().clone();
                 tauri::async_runtime::spawn(async move {
@@ -87,7 +90,7 @@ pub fn run() {
                             let (running, pgid) = {
                                 let table = handle.state::<ProcTable>();
                                 let procs = table.procs.lock().unwrap();
-                                (procs.contains_key(&key), procs.get(&key).map(|p| p.pgid))
+                                (procs.contains_key(&key), procs.get(&key).map(|p| crate::proc::group_key(&p.group) as i32))
                             };
                             let log_len = {
                                 let table = handle.state::<ProcTable>();

--- a/src-tauri/src/proc.rs
+++ b/src-tauri/src/proc.rs
@@ -175,12 +175,16 @@ mod imp {
         if Thread32First(snap, &mut entry).is_ok() {
             loop {
                 if entry.th32OwnerProcessID == pid {
+                    // a CREATE_SUSPENDED process has exactly one thread (the
+                    // primary) at this point — resume it, and only count success
+                    // if ResumeThread didn't report failure (u32::MAX). Otherwise
+                    // the process would stay frozen while marked "running".
                     if let Ok(hthread) = OpenThread(THREAD_SUSPEND_RESUME, false, entry.th32ThreadID) {
-                        ResumeThread(hthread);
+                        let prev = ResumeThread(hthread);
                         let _ = CloseHandle(hthread);
-                        resumed = true;
-                        break;
+                        resumed = prev != u32::MAX;
                     }
+                    break;
                 }
                 if Thread32Next(snap, &mut entry).is_err() {
                     break;
@@ -195,15 +199,18 @@ mod imp {
         }
     }
 
+    // Exit the job with code 0 so the service waiter treats a user-requested stop
+    // as `Stopped`, not `Error` (a non-zero code routes to SvcStatus::Error in
+    // services.rs — mirroring how a SIGTERM'd Unix process reports no exit code).
     pub fn terminate_group(g: &ProcGroup) {
         unsafe {
-            let _ = TerminateJobObject(g.job.0, 1);
+            let _ = TerminateJobObject(g.job.0, 0);
         }
     }
 
     pub fn kill_group(g: &ProcGroup) {
         unsafe {
-            let _ = TerminateJobObject(g.job.0, 1);
+            let _ = TerminateJobObject(g.job.0, 0);
         }
     }
 

--- a/src-tauri/src/proc.rs
+++ b/src-tauri/src/proc.rs
@@ -1,0 +1,239 @@
+// Cross-platform process-group control.
+//
+// Canopy spawns each dev service (and each PTY shell) as a *tree* of processes
+// and must be able to tear the whole tree down — a dev server forks watchers,
+// bundler workers, nodemon supervisors, etc. On POSIX this is a process group
+// (`process_group(0)` + `killpg`). Windows has no process groups, so the tree is
+// wrapped in a Job Object with `KILL_ON_JOB_CLOSE`; `TerminateJobObject` kills
+// it, and the OS auto-reaps the job when Canopy exits/crashes (which is why the
+// persisted-pgid crash sweep in services.rs/terminal.rs is Unix-only).
+//
+// Everything OS-specific lives behind this module's small API so services.rs and
+// terminal.rs never mention libc or the windows crate.
+
+/// Opaque handle to a spawned process group / job.
+/// Unix: the child's process-group id. Windows: a Job Object HANDLE.
+pub use imp::ProcGroup;
+
+/// Configure a Command for group isolation *before* spawn.
+/// Unix: `.process_group(0)`. Windows: `CREATE_SUSPENDED | CREATE_NEW_PROCESS_GROUP`.
+pub use imp::prepare_group_command;
+
+/// Establish the group for a freshly-spawned child and return its handle.
+/// Unix: pgid == child pid (already running). Windows: create the Job, assign the
+/// (suspended) child, then resume it so every descendant is captured race-free.
+pub use imp::attach_group;
+
+/// Graceful stop (maps to SIGTERM). Windows: `TerminateJobObject` (whole tree).
+pub use imp::terminate_group;
+
+/// Hard kill (maps to SIGKILL). Windows: `TerminateJobObject` (idempotent).
+pub use imp::kill_group;
+
+/// A stable identity for the group (Unix: pgid; Windows: child pid). Only used by
+/// the Unix-gated selftest/logging — the stop-race guard uses `generation`.
+#[allow(unused_imports)]
+pub use imp::group_key;
+
+/// Local UTC offset in seconds, for log timestamps (no chrono dependency).
+pub use imp::local_utc_offset_secs;
+
+// ───────────────────────────── Unix ─────────────────────────────
+#[cfg(unix)]
+mod imp {
+    use tokio::process::Command;
+
+    pub struct ProcGroup {
+        pgid: i32,
+    }
+
+    pub fn prepare_group_command(cmd: &mut Command) {
+        cmd.process_group(0);
+    }
+
+    pub fn attach_group(pid: u32) -> Result<ProcGroup, String> {
+        // `process_group(0)` made the child its own group leader: pgid == pid.
+        Ok(ProcGroup { pgid: pid as i32 })
+    }
+
+    pub fn terminate_group(g: &ProcGroup) {
+        unsafe {
+            libc::killpg(g.pgid, libc::SIGTERM);
+        }
+    }
+
+    pub fn kill_group(g: &ProcGroup) {
+        unsafe {
+            libc::killpg(g.pgid, libc::SIGKILL);
+        }
+    }
+
+    pub fn group_key(g: &ProcGroup) -> i64 {
+        g.pgid as i64
+    }
+
+    pub fn local_utc_offset_secs() -> i64 {
+        // localtime_r-based offset; cheap and correct for display purposes
+        unsafe {
+            let t = libc::time(std::ptr::null_mut());
+            let mut tm: libc::tm = std::mem::zeroed();
+            libc::localtime_r(&t, &mut tm);
+            tm.tm_gmtoff as i64
+        }
+    }
+}
+
+// ──────────────────────────── Windows ────────────────────────────
+#[cfg(windows)]
+mod imp {
+    use tokio::process::Command;
+    use windows::core::PCWSTR;
+    use windows::Win32::Foundation::{CloseHandle, HANDLE};
+    use windows::Win32::System::Diagnostics::ToolHelp::{
+        CreateToolhelp32Snapshot, Thread32First, Thread32Next, TH32CS_SNAPTHREAD, THREADENTRY32,
+    };
+    use windows::Win32::System::JobObjects::{
+        AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation, SetInformationJobObject,
+        TerminateJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+    };
+    use windows::Win32::System::Threading::{
+        OpenProcess, OpenThread, ResumeThread, CREATE_NEW_PROCESS_GROUP, CREATE_SUSPENDED, PROCESS_SET_QUOTA,
+        PROCESS_TERMINATE, THREAD_SUSPEND_RESUME,
+    };
+    use windows::Win32::System::Time::{GetTimeZoneInformation, TIME_ZONE_INFORMATION};
+
+    /// GetTimeZoneInformation returns this (2) when daylight-saving is in effect.
+    const TIME_ZONE_ID_DAYLIGHT: u32 = 2;
+
+    /// Owns a Job Object HANDLE. Closing the last handle triggers
+    /// KILL_ON_JOB_CLOSE, tearing down the whole tree — which is exactly what we
+    /// want when the entry is dropped on stop / exit / crash.
+    struct OwnedJobHandle(HANDLE);
+
+    // A Windows kernel HANDLE is a process-wide table index with no thread
+    // affinity; passing it between threads is sound, and all access is serialized
+    // behind the ProcTable mutex.
+    unsafe impl Send for OwnedJobHandle {}
+    unsafe impl Sync for OwnedJobHandle {}
+
+    impl Drop for OwnedJobHandle {
+        fn drop(&mut self) {
+            unsafe {
+                let _ = CloseHandle(self.0);
+            }
+        }
+    }
+
+    pub struct ProcGroup {
+        job: OwnedJobHandle,
+        pid: u32,
+    }
+
+    pub fn prepare_group_command(cmd: &mut Command) {
+        // Spawn suspended so we can assign the child to its Job *before* it runs
+        // (and thus before it can fork workers that would escape the job).
+        // NEW_PROCESS_GROUP leaves room for a future CTRL_BREAK graceful stop.
+        cmd.creation_flags(CREATE_SUSPENDED.0 | CREATE_NEW_PROCESS_GROUP.0);
+    }
+
+    pub fn attach_group(pid: u32) -> Result<ProcGroup, String> {
+        unsafe {
+            let job = CreateJobObjectW(None, PCWSTR::null()).map_err(|e| format!("CreateJobObject: {e}"))?;
+            let job = OwnedJobHandle(job);
+
+            let mut info = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+            info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+            SetInformationJobObject(
+                job.0,
+                JobObjectExtendedLimitInformation,
+                &info as *const _ as *const core::ffi::c_void,
+                std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            )
+            .map_err(|e| format!("SetInformationJobObject: {e}"))?;
+
+            let hproc = OpenProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, false, pid)
+                .map_err(|e| format!("OpenProcess: {e}"))?;
+            let assign = AssignProcessToJobObject(job.0, hproc);
+            let _ = CloseHandle(hproc);
+            assign.map_err(|e| format!("AssignProcessToJobObject: {e}"))?;
+
+            resume_primary_thread(pid)?;
+            Ok(ProcGroup { job, pid })
+        }
+    }
+
+    /// Resume the child's primary thread (the process was created suspended).
+    /// tokio's Command doesn't surface the child's thread handle, so find it via a
+    /// toolhelp snapshot filtered on the child pid.
+    unsafe fn resume_primary_thread(pid: u32) -> Result<(), String> {
+        let snap = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0).map_err(|e| format!("snapshot: {e}"))?;
+        let mut entry = THREADENTRY32 {
+            dwSize: std::mem::size_of::<THREADENTRY32>() as u32,
+            ..Default::default()
+        };
+        let mut resumed = false;
+        if Thread32First(snap, &mut entry).is_ok() {
+            loop {
+                if entry.th32OwnerProcessID == pid {
+                    if let Ok(hthread) = OpenThread(THREAD_SUSPEND_RESUME, false, entry.th32ThreadID) {
+                        ResumeThread(hthread);
+                        let _ = CloseHandle(hthread);
+                        resumed = true;
+                        break;
+                    }
+                }
+                if Thread32Next(snap, &mut entry).is_err() {
+                    break;
+                }
+            }
+        }
+        let _ = CloseHandle(snap);
+        if resumed {
+            Ok(())
+        } else {
+            Err("could not resume child's primary thread".into())
+        }
+    }
+
+    pub fn terminate_group(g: &ProcGroup) {
+        unsafe {
+            let _ = TerminateJobObject(g.job.0, 1);
+        }
+    }
+
+    pub fn kill_group(g: &ProcGroup) {
+        unsafe {
+            let _ = TerminateJobObject(g.job.0, 1);
+        }
+    }
+
+    pub fn group_key(g: &ProcGroup) -> i64 {
+        g.pid as i64
+    }
+
+    pub fn local_utc_offset_secs() -> i64 {
+        // Windows `Bias` is the negative of the POSIX offset: UTC = local + Bias
+        // (minutes). Effective bias includes the seasonal component.
+        unsafe {
+            let mut tzi = TIME_ZONE_INFORMATION::default();
+            let id = GetTimeZoneInformation(&mut tzi);
+            let seasonal = if id == TIME_ZONE_ID_DAYLIGHT {
+                tzi.DaylightBias
+            } else {
+                tzi.StandardBias
+            };
+            -((tzi.Bias + seasonal) as i64) * 60
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// Cross-platform sanity check — exercises the per-OS offset code (including
+    /// the Windows GetTimeZoneInformation path in CI) and guards the sign bug.
+    #[test]
+    fn utc_offset_is_within_range() {
+        let off = super::local_utc_offset_secs();
+        assert!(off.abs() <= 14 * 3600, "utc offset out of range: {off}s");
+    }
+}

--- a/src-tauri/src/services.rs
+++ b/src-tauri/src/services.rs
@@ -1,4 +1,4 @@
-use crate::settings::{OrphanProc, ServiceCfg};
+use crate::settings::ServiceCfg;
 use crate::state::{AppState, SvcStatus};
 use serde::Serialize;
 use std::collections::{HashMap, VecDeque};
@@ -32,24 +32,15 @@ fn chrono_time() -> String {
     // HH:MM:SS local time without pulling in chrono
     let now = std::time::SystemTime::now();
     let secs = now.duration_since(UNIX_EPOCH).unwrap().as_secs();
-    let offset = local_utc_offset_secs();
+    let offset = crate::proc::local_utc_offset_secs();
     let local = (secs as i64 + offset).rem_euclid(86_400);
     format!("{:02}:{:02}:{:02}", local / 3600, (local % 3600) / 60, local % 60)
 }
 
-fn local_utc_offset_secs() -> i64 {
-    // localtime_r-based offset; cheap and correct for display purposes
-    unsafe {
-        let t = libc::time(std::ptr::null_mut());
-        let mut tm: libc::tm = std::mem::zeroed();
-        libc::localtime_r(&t, &mut tm);
-        tm.tm_gmtoff as i64
-    }
-}
-
 pub struct ProcEntry {
     pub pid: u32,
-    pub pgid: i32,
+    /// process-group / job handle used to tear down the whole child tree
+    pub group: crate::proc::ProcGroup,
     pub started_at: Instant,
     pub started_unix: u64,
     /// generation guard: stop() bumps this so a stale waiter doesn't clobber state
@@ -121,7 +112,12 @@ pub fn push_log(app: &AppHandle, key: &str, line: LogLine) {
     let _ = app.emit("service:log", &LogEvent { svc_key: key, lines: vec![line] });
 }
 
+/// Persist live service pgids so a crash can be swept on next launch. Unix-only:
+/// on Windows the Job Object's KILL_ON_JOB_CLOSE makes the OS reap the tree when
+/// Canopy dies, so there is nothing to persist or sweep.
+#[cfg(unix)]
 fn persist_orphans(app: &AppHandle) {
+    use crate::settings::OrphanProc;
     let table = app.state::<ProcTable>();
     let orphans: Vec<OrphanProc> = table
         .procs
@@ -130,7 +126,7 @@ fn persist_orphans(app: &AppHandle) {
         .iter()
         .map(|(k, p)| OrphanProc {
             svc_key: k.clone(),
-            pgid: p.pgid,
+            pgid: crate::proc::group_key(&p.group) as i32,
             spawn_time_secs: p.started_unix,
         })
         .collect();
@@ -142,6 +138,9 @@ fn persist_orphans(app: &AppHandle) {
     };
     let _ = crate::settings::save_runtime(app, &runtime);
 }
+
+#[cfg(windows)]
+fn persist_orphans(_app: &AppHandle) {}
 
 /// Resolve a service's config + worktree env (PORT etc.) from settings.
 fn resolve_service(app: &AppHandle, key: &str) -> Result<(ServiceCfg, String, HashMap<String, String>), String> {
@@ -217,8 +216,10 @@ pub async fn start_service(app: &AppHandle, key: &str) -> Result<(), String> {
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .process_group(0)
         .kill_on_drop(false);
+    // isolate the child (+ its whole tree) in its own process group / job so we
+    // can tear it all down on stop (see proc.rs)
+    crate::proc::prepare_group_command(&mut cmd);
 
     let mut child = cmd.spawn().map_err(|e| {
         set_status(app, key, SvcStatus::Error, None, None);
@@ -227,7 +228,17 @@ pub async fn start_service(app: &AppHandle, key: &str) -> Result<(), String> {
     })?;
 
     let pid = child.id().unwrap_or(0);
-    let pgid = pid as i32; // process_group(0) => pgid == child pid
+    // establish the group (Windows: assigns the suspended child to a Job and
+    // resumes it). On failure the child would linger — kill it and bail.
+    let group = match crate::proc::attach_group(pid) {
+        Ok(g) => g,
+        Err(e) => {
+            let _ = child.kill().await;
+            set_status(app, key, SvcStatus::Error, None, None);
+            push_log(app, key, LogLine::now("err", format!("group setup failed: {e}")));
+            return Err(format!("group setup failed: {e}"));
+        }
+    };
     let started_unix = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
 
     let generation = {
@@ -235,7 +246,7 @@ pub async fn start_service(app: &AppHandle, key: &str) -> Result<(), String> {
         let generation = table.next_gen();
         table.procs.lock().unwrap().insert(
             key.to_string(),
-            ProcEntry { pid, pgid, started_at: Instant::now(), started_unix, generation },
+            ProcEntry { pid, group, started_at: Instant::now(), started_unix, generation },
         );
         generation
     };
@@ -366,33 +377,32 @@ fn classify_line(text: &str, from_stderr: bool) -> &'static str {
 }
 
 pub async fn stop_service(app: &AppHandle, key: &str) -> Result<(), String> {
-    let pgid = {
+    // graceful terminate under the lock (we need the group handle); capture the
+    // generation so a restart during the grace window isn't hard-killed by us.
+    let generation = {
         let table = app.state::<ProcTable>();
         let procs = table.procs.lock().unwrap();
         match procs.get(key) {
-            Some(p) => p.pgid,
+            Some(p) => {
+                crate::proc::terminate_group(&p.group);
+                p.generation
+            }
             None => return Ok(()), // not running
         }
     };
 
     set_status(app, key, SvcStatus::Stopping, None, None);
-    unsafe {
-        libc::killpg(pgid, libc::SIGTERM);
-    }
 
-    // grace period, then SIGKILL if the group is still alive
+    // grace period, then hard kill if the *same* process is still tracked
     let app2 = app.clone();
     let key2 = key.to_string();
     tauri::async_runtime::spawn(async move {
         tokio::time::sleep(STOP_GRACE).await;
-        let still_tracked = {
-            let table = app2.state::<ProcTable>();
-            let procs = table.procs.lock().unwrap();
-            procs.get(&key2).map(|p| p.pgid) == Some(pgid)
-        };
-        if still_tracked {
-            unsafe {
-                libc::killpg(pgid, libc::SIGKILL);
+        let table = app2.state::<ProcTable>();
+        let procs = table.procs.lock().unwrap();
+        if let Some(p) = procs.get(&key2) {
+            if p.generation == generation {
+                crate::proc::kill_group(&p.group);
             }
         }
     });
@@ -543,7 +553,9 @@ pub async fn reset_db(app: &AppHandle, wt_key: &str) -> Result<(), String> {
 
 /// Startup sweep: kill process groups left over from a crash. Only kills when
 /// the group leader still exists and its start time matches what we recorded
-/// (avoids killing a recycled PID).
+/// (avoids killing a recycled PID). Unix-only — on Windows KILL_ON_JOB_CLOSE
+/// makes the OS reap the tree when Canopy dies, so there are no orphans to sweep.
+#[cfg(unix)]
 pub fn sweep_orphans(app: &AppHandle) {
     let orphans = {
         let state = app.state::<AppState>();
@@ -571,7 +583,12 @@ pub fn sweep_orphans(app: &AppHandle) {
     let _ = crate::settings::save_runtime(app, &runtime);
 }
 
+#[cfg(windows)]
+pub fn sweep_orphans(_app: &AppHandle) {}
+
 /// Compare recorded spawn time against the process's actual start time (±5s).
+/// Unix-only (uses `ps`); only the Unix crash sweep calls it.
+#[cfg(unix)]
 pub(crate) fn proc_start_time_matches(pid: u32, recorded_secs: u64) -> bool {
     let out = std::process::Command::new("ps")
         .args(["-o", "lstart=", "-p", &pid.to_string()])

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -434,8 +434,17 @@ fn upsert_yaml_str(existing: &str, pairs: &[(String, String)]) -> String {
 
 /// A provision path must stay inside its root: relative, no `..` components.
 fn check_contained(p: &str, what: &str) -> Result<(), String> {
+    use std::path::Component;
     let path = Path::new(p);
-    if path.is_absolute() || path.components().any(|c| matches!(c, std::path::Component::ParentDir)) {
+    // On Windows a leading-`/` path (`/etc/hosts`) is *rooted* but not *absolute*
+    // (no drive), yet `join` still resolves it onto the current drive and escapes
+    // the root — so reject `has_root()` and drive prefixes (`C:\`, `C:foo`) too.
+    let escapes = path.is_absolute()
+        || path.has_root()
+        || path
+            .components()
+            .any(|c| matches!(c, Component::ParentDir | Component::Prefix(_)));
+    if escapes {
         return Err(format!("provision {what} '{p}' must be a relative path without '..'"));
     }
     Ok(())

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -121,6 +121,9 @@ pub fn open(
     let shell = crate::toolchain::user_shell();
     let mut cmd = CommandBuilder::new(&shell);
     let name = std::path::Path::new(&shell).file_name().and_then(|s| s.to_str()).unwrap_or("");
+    // on Windows the shell is `bash.exe`; normalize so the family checks below
+    // (login flag, and the `-i` interactive flag) match as they do on Unix
+    let name = name.strip_suffix(".exe").unwrap_or(name);
     if !matches!(name, "sh" | "dash") {
         cmd.arg("-l");
     }
@@ -138,8 +141,15 @@ pub fn open(
     cmd.cwd(cwd);
     cmd.env("TERM", "xterm-256color");
     if let Some(bin) = crate::toolchain::pinned_node_bin(cwd) {
-        let path = std::env::var("PATH").unwrap_or_default();
-        cmd.env("PATH", format!("{bin}:{path}"));
+        // prepend to PATH using the OS separator (';' on Windows, ':' elsewhere)
+        // and native path form — this is the process env bash.exe inherits, not a
+        // bash-internal PATH string.
+        let existing = std::env::var_os("PATH").unwrap_or_default();
+        let mut dirs = vec![std::path::PathBuf::from(&bin)];
+        dirs.extend(std::env::split_paths(&existing));
+        if let Ok(joined) = std::env::join_paths(dirs) {
+            cmd.env("PATH", joined);
+        }
     }
 
     let child = pair.slave.spawn_command(cmd).map_err(|e| format!("spawn failed: {e}"))?;

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -12,6 +12,7 @@
 use base64::Engine;
 use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize};
 use serde::Serialize;
+#[cfg(unix)]
 use crate::settings::TermOrphan;
 use crate::state::AppState;
 use std::collections::{HashMap, VecDeque};
@@ -47,8 +48,12 @@ pub struct PtySession {
     /// generation guard: a fast reopen under the same id bumps this so a stale
     /// reader thread doesn't remove/exit the replacement session.
     generation: u64,
-    /// child pgid (session leader) + spawn time, persisted for crash-orphan sweep
+    /// child pgid (session leader) + spawn time, persisted for the Unix
+    /// crash-orphan sweep. On Windows there is no sweep (portable-pty's ConPTY
+    /// child is killed directly), so these go unread there.
+    #[allow(dead_code)]
     pgid: i32,
+    #[allow(dead_code)]
     started_unix: u64,
 }
 
@@ -285,7 +290,9 @@ pub fn close_all(table: &TermTable) {
 }
 
 /// Snapshot live sessions' pgids into persisted runtime state, so a crash can be
-/// cleaned up on next launch (mirrors the service orphan sweep).
+/// cleaned up on next launch (mirrors the service orphan sweep). Unix-only — see
+/// `sweep_orphans`.
+#[cfg(unix)]
 fn persist_orphans(app: &AppHandle) {
     let table = app.state::<TermTable>();
     let orphans: Vec<TermOrphan> = table
@@ -304,8 +311,17 @@ fn persist_orphans(app: &AppHandle) {
     let _ = crate::settings::save_runtime(app, &runtime);
 }
 
+#[cfg(windows)]
+fn persist_orphans(_app: &AppHandle) {}
+
 /// Startup: kill terminal process groups left over from a crashed previous run
-/// (only when the group leader still exists and its start time matches).
+/// (only when the group leader still exists and its start time matches). Unix-only
+/// — on Windows portable-pty's ConPTY child is killed directly and there is no
+/// pgid to sweep (a documented limitation: PTY grandchildren may linger).
+#[cfg(windows)]
+pub fn sweep_orphans(_app: &AppHandle) {}
+
+#[cfg(unix)]
 pub fn sweep_orphans(app: &AppHandle) {
     let orphans = {
         let state = app.state::<AppState>();

--- a/src-tauri/src/toolchain.rs
+++ b/src-tauri/src/toolchain.rs
@@ -53,13 +53,22 @@ fn bin_for_version(version: &str) -> Option<String> {
     ];
     #[cfg(target_os = "windows")]
     {
-        // nvm-windows drops node.exe directly under %APPDATA%\nvm\vX (no bin/);
-        // fnm and Volta keep their own layouts under %LOCALAPPDATA%.
+        // nvm-windows drops node.exe directly under %APPDATA%\nvm\vX (no bin/).
         if let Ok(appdata) = std::env::var("APPDATA") {
             candidates.push(format!("{appdata}\\nvm\\v{version}"));
         }
+        // fnm's default data dir on Windows is %APPDATA%\fnm (roaming); also honor
+        // an explicit FNM_DIR and the older %LOCALAPPDATA%\fnm layout.
+        let fnm_bases = [
+            std::env::var("FNM_DIR").ok(),
+            std::env::var("APPDATA").ok().map(|p| format!("{p}\\fnm")),
+            std::env::var("LOCALAPPDATA").ok().map(|p| format!("{p}\\fnm")),
+        ];
+        for base in fnm_bases.into_iter().flatten() {
+            candidates.push(format!("{base}\\node-versions\\v{version}\\installation"));
+        }
+        // Volta
         if let Ok(local) = std::env::var("LOCALAPPDATA") {
-            candidates.push(format!("{local}\\fnm\\node-versions\\v{version}\\installation"));
             candidates.push(format!("{local}\\Volta\\tools\\image\\node\\{version}"));
         }
     }

--- a/src-tauri/src/toolchain.rs
+++ b/src-tauri/src/toolchain.rs
@@ -32,15 +32,59 @@ fn read_pin(dir: &Path) -> Option<String> {
     None
 }
 
+/// The user's home directory. `$HOME` on Unix; `%USERPROFILE%` (with `$HOME`
+/// honored if a shell like Git Bash set it) on Windows.
+fn home_dir() -> Option<String> {
+    std::env::var("HOME")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .or_else(|| std::env::var("USERPROFILE").ok().filter(|s| !s.is_empty()))
+}
+
 fn bin_for_version(version: &str) -> Option<String> {
-    let home = std::env::var("HOME").ok()?;
-    let candidates = [
+    let home = home_dir()?;
+    // `mut` is only exercised under cfg(windows) where extra candidates are pushed
+    #[allow(unused_mut)]
+    let mut candidates = vec![
         format!("{home}/.asdf/installs/nodejs/{version}/bin"),
         format!("{home}/.asdf/installs/nodejs/v{version}/bin"),
         format!("{home}/.nvm/versions/node/v{version}/bin"),
         format!("{home}/.local/share/fnm/node-versions/v{version}/installation/bin"),
     ];
-    candidates.into_iter().find(|c| Path::new(c).join("node").exists())
+    #[cfg(target_os = "windows")]
+    {
+        // nvm-windows drops node.exe directly under %APPDATA%\nvm\vX (no bin/);
+        // fnm and Volta keep their own layouts under %LOCALAPPDATA%.
+        if let Ok(appdata) = std::env::var("APPDATA") {
+            candidates.push(format!("{appdata}\\nvm\\v{version}"));
+        }
+        if let Ok(local) = std::env::var("LOCALAPPDATA") {
+            candidates.push(format!("{local}\\fnm\\node-versions\\v{version}\\installation"));
+            candidates.push(format!("{local}\\Volta\\tools\\image\\node\\{version}"));
+        }
+    }
+    candidates.into_iter().find(|c| {
+        let p = Path::new(c);
+        p.join("node").exists() || p.join("node.exe").exists()
+    })
+}
+
+/// Convert a native path into a form the command shell accepts on PATH. On
+/// Windows commands run through Git Bash, whose PATH wants MSYS form
+/// (`C:\Users\me` → `/c/Users/me`); elsewhere it's the identity.
+#[cfg(target_os = "windows")]
+pub(crate) fn bash_path(p: &str) -> String {
+    let p = p.replace('\\', "/");
+    if let Some((drive, rest)) = p.split_once(":/") {
+        if drive.len() == 1 {
+            return format!("/{}/{}", drive.to_lowercase(), rest);
+        }
+    }
+    p
+}
+#[cfg(not(target_os = "windows"))]
+pub(crate) fn bash_path(p: &str) -> String {
+    p.to_string()
 }
 
 /// Walk up from `dir` looking for a Node pin; return the bin dir of that version
@@ -60,21 +104,71 @@ pub fn pinned_node_bin(dir: &str) -> Option<String> {
 /// prepend runs after the login shell's profile, so it wins over asdf/nvm shims.
 pub fn with_pinned_node(cwd: &str, command: &str) -> String {
     match pinned_node_bin(cwd) {
-        Some(bin) => format!("export PATH=\"{bin}:$PATH\"; {command}"),
+        Some(bin) => format!("export PATH=\"{}:$PATH\"; {command}", bash_path(&bin)),
         None => command.to_string(),
     }
 }
 
 /// The shell Canopy runs commands through. Honors `$SHELL` (so bash/fish/etc.
-/// users get their own shell + profile), falling back to zsh on macOS and sh
-/// elsewhere. Commands run as a *login* shell so version managers (nvm/asdf/
-/// volta) and the user's PATH are initialized.
+/// users get their own shell + profile), falling back to zsh on macOS, Git Bash
+/// on Windows, and sh on other Unix. Commands run as a *login* shell so version
+/// managers (nvm/asdf/volta) and the user's PATH are initialized.
 pub fn user_shell() -> String {
-    std::env::var("SHELL")
+    if let Some(s) = std::env::var("SHELL")
         .ok()
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty() && Path::new(s).exists())
-        .unwrap_or_else(|| if cfg!(target_os = "macos") { "/bin/zsh".into() } else { "/bin/sh".into() })
+    {
+        return s;
+    }
+    default_shell()
+}
+
+#[cfg(target_os = "windows")]
+fn default_shell() -> String {
+    // Windows runs commands through Git for Windows' bash, keeping the whole
+    // POSIX execution model (&&, pipes, export, quoting) working unchanged.
+    find_git_bash().unwrap_or_else(|| "bash.exe".into())
+}
+#[cfg(target_os = "macos")]
+fn default_shell() -> String {
+    "/bin/zsh".into()
+}
+#[cfg(all(unix, not(target_os = "macos")))]
+fn default_shell() -> String {
+    "/bin/sh".into()
+}
+
+/// Locate Git for Windows' `bash.exe`. `$SHELL` in Git Bash is an MSYS virtual
+/// path (`/usr/bin/bash`) that a native process can't stat, so probe the known
+/// install locations, then fall back to `where bash`.
+#[cfg(target_os = "windows")]
+fn find_git_bash() -> Option<String> {
+    let mut candidates: Vec<String> = Vec::new();
+    for var in ["ProgramFiles", "ProgramW6432", "ProgramFiles(x86)"] {
+        if let Ok(p) = std::env::var(var) {
+            candidates.push(format!("{p}\\Git\\bin\\bash.exe"));
+        }
+    }
+    if let Ok(la) = std::env::var("LOCALAPPDATA") {
+        candidates.push(format!("{la}\\Programs\\Git\\bin\\bash.exe"));
+    }
+    for c in &candidates {
+        if Path::new(c).exists() {
+            return Some(c.clone());
+        }
+    }
+    if let Ok(out) = std::process::Command::new("where").arg("bash").output() {
+        if out.status.success() {
+            if let Some(line) = String::from_utf8_lossy(&out.stdout).lines().next() {
+                let line = line.trim();
+                if !line.is_empty() {
+                    return Some(line.to_string());
+                }
+            }
+        }
+    }
+    None
 }
 
 /// Build `(shell, argv)` to run `cmdline` through the user's shell. Flags are
@@ -84,6 +178,8 @@ pub fn user_shell() -> String {
 pub fn shell_argv(cmdline: &str) -> (String, Vec<String>) {
     let shell = user_shell();
     let name = Path::new(&shell).file_name().and_then(|s| s.to_str()).unwrap_or("");
+    // on Windows the shell is `bash.exe`; normalize so family checks below match
+    let name = name.strip_suffix(".exe").unwrap_or(name);
     let mut args: Vec<String> = Vec::new();
     if !matches!(name, "sh" | "dash") {
         args.push("-l".into());

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,12 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./app/App";
+import { applyPlatformClass } from "./platform";
 import "./styles/tokens.css";
 import "./styles/app.css";
 import "./styles/terminal.css";
+
+applyPlatformClass();
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -1,0 +1,8 @@
+// Tag <html> with the OS so CSS can adapt window chrome. Only macOS uses
+// titleBarStyle: Overlay (traffic lights inset into our toolbar); every other
+// platform gets a native titlebar and no inset. Call once at startup.
+export function applyPlatformClass(): void {
+  const ua = navigator.userAgent;
+  const isMac = /Mac|iPhone|iPad|iPod/.test(ua);
+  document.documentElement.classList.add(isMac ? "mac" : "win");
+}

--- a/src/popover.tsx
+++ b/src/popover.tsx
@@ -3,8 +3,11 @@ import ReactDOM from "react-dom/client";
 import Popover from "./popover/Popover";
 import { initSync, useStore } from "./store";
 import { hasBackend } from "./ipc";
+import { applyPlatformClass } from "./platform";
 import "./styles/tokens.css";
 import "./styles/popover.css";
+
+applyPlatformClass();
 
 const GUTTER_X = 0; // window hugs the card (no shadow gutter)
 const GUTTER_Y = 0;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -19,9 +19,14 @@
   display: flex;
   align-items: center;
   gap: 2px;
-  padding: 0 8px 0 80px; /* left clears the native macOS traffic lights (Overlay) */
+  padding: 0 8px; /* non-macOS: native titlebar, no traffic-light inset */
   background: var(--titlebar);
   border-bottom: 1px solid var(--border-soft);
+}
+/* macOS uses titleBarStyle: Overlay — inset the left so the toolbar clears the
+   native traffic lights (the `mac` class is set on <html> at startup). */
+.mac .topbar {
+  padding-left: 80px;
 }
 .topbar .tb-brand {
   display: flex;

--- a/src/styles/onboarding.css
+++ b/src/styles/onboarding.css
@@ -22,9 +22,13 @@
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 0 12px 0 80px; /* clears the native traffic lights */
+  padding: 0 12px; /* non-macOS: native titlebar, no traffic-light inset */
   background: var(--titlebar);
   border-bottom: 1px solid var(--border-soft);
+}
+/* macOS traffic-light inset (see app.css) */
+.mac .ob-root .ob-tb {
+  padding-left: 80px;
 }
 .ob-root .ob-tb-title {
   display: flex;

--- a/src/terminal-window.tsx
+++ b/src/terminal-window.tsx
@@ -3,9 +3,12 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import DetachedTerminal from "./app/DetachedTerminal";
+import { applyPlatformClass } from "./platform";
 import "./styles/tokens.css";
 import "./styles/app.css";
 import "./styles/terminal.css";
+
+applyPlatformClass();
 
 const params = new URLSearchParams(location.search);
 const termId = params.get("id") ?? "";


### PR DESCRIPTION
Closes #26 · Part of #22

Brings Windows to the same bar the Linux port is at today — the code compiles in CI, is code-complete, and is **not yet validated on a real Windows desktop**. Two decisions shaped it: commands run through **Git Bash** on Windows (keeping the whole POSIX execution model — `.worktreemanager.json` setup, `&&`, pipes, `export`, the `pg_dump | pg_restore` pipe — working unchanged), and POSIX process groups map to **Windows Job Objects**.

## Process control (`src-tauri/src/proc.rs`, new)
- Cross-platform process-group abstraction. Unix keeps `process_group(0)` / `killpg`; Windows wraps each service tree in a **Job Object** with `KILL_ON_JOB_CLOSE` — spawn suspended → `AssignProcessToJobObject` → resume the primary thread (so no forked worker escapes the job), torn down with `TerminateJobObject`.
- `KILL_ON_JOB_CLOSE` means the OS reaps the whole tree when Canopy exits/crashes, so the persisted-pgid crash sweep is **Unix-only** (Windows no-ops).
- `services.rs` / `terminal.rs` store a `ProcGroup` handle instead of a bare pgid; the stop-race guard now compares `generation` (strictly more correct on Unix too). `localtime_r` timestamp offset moved behind the same module (`GetTimeZoneInformation` on Windows).

## Shell, toolchain, DB (`toolchain.rs`, `db.rs`)
- `user_shell()` locates Git for Windows' `bash.exe`; the existing `-l -c` argv logic is reused unchanged.
- Pinned-Node discovery gains nvm-windows / fnm / Volta layouts + `USERPROFILE` home fallback; injected PATH entries are converted to Git-Bash (MSYS) form.
- Postgres path probing gains `C:\Program Files\PostgreSQL\<maj>\bin`.

## UI + build
- `<html>` is tagged with the OS; the macOS traffic-light inset (`titleBarStyle: Overlay`) is gated to `.mac`, so Windows/Linux don't get a wasted 80px inset.
- `Cargo.toml`: `libc` → `cfg(unix)`; `windows` crate (Job Objects) under `cfg(windows)`.
- CI: new `windows-latest` job (`cargo check` + `cargo test`); `windows-latest` added to the release matrix (NSIS `.exe`).

## Verification
- ✅ macOS: `npm run build`, `cargo check --locked`, `cargo test --lib` (13 tests) — Unix path intact.
- ✅ Windows `windows`-crate API type-checked locally via `cargo check --target x86_64-pc-windows-msvc` in an isolated crate (caught three real 0.58 API issues, all fixed). The full Windows compile / NSIS build is the CI gate.

## Known Windows limitations (follow-ups)
Hard `TerminateJobObject` stop (no graceful CTRL_BREAK — a GUI app has no console); PTY grandchildren may linger; hidden main window stays in the taskbar; native (not custom) titlebar; no code-signing.