### PR TITLE
add worktree removal from sidebar

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { initSync, useStore } from "../store";
-import { isLive } from "../types";
+import { isLive, WorktreeNode } from "../types";
 import { ChevRight, Fork, Logs, Plus, Refresh, Settings } from "../icons";
 import Sidebar from "./Sidebar";
 import WorktreeHeader from "./WorktreeHeader";
@@ -23,7 +23,7 @@ export default function App() {
   const [, setTick] = useState(0);
   const [showSettings, setShowSettings] = useState(false);
   const [showNewWt, setShowNewWt] = useState(false);
-  const [removeWt, setRemoveWt] = useState(false);
+  const [removeWtFor, setRemoveWtFor] = useState<WorktreeNode | null>(null);
   const [showOnboarding, setShowOnboarding] = useState(false);
   const [obDismissed, setObDismissed] = useState(false);
 
@@ -73,7 +73,7 @@ export default function App() {
       </div>
 
       <div className={"app" + (!showSettings && sel?.wt ? " with-lane" : "")}>
-        <Sidebar onAdd={() => setShowNewWt(true)} />
+        <Sidebar onAdd={() => setShowNewWt(true)} onRemove={(wt) => setRemoveWtFor(wt)} />
 
         {showSettings ? (
           <SettingsView onClose={() => setShowSettings(false)} />
@@ -109,7 +109,7 @@ export default function App() {
             <WorktreeHeader
               repo={sel.repo}
               wt={sel.wt}
-              onRemove={() => setRemoveWt(true)}
+              onRemove={() => setRemoveWtFor(sel.wt)}
               onOpenSettings={() => setShowSettings(true)}
             />
             <div className="block">
@@ -135,7 +135,7 @@ export default function App() {
       </div>
 
       {showNewWt && <NewWorktreeModal repoId={sel?.repo.repoId ?? ""} onClose={() => setShowNewWt(false)} />}
-      {removeWt && sel?.wt && <RemoveWorktreeModal wt={sel.wt} onClose={() => setRemoveWt(false)} />}
+      {removeWtFor && <RemoveWorktreeModal wt={removeWtFor} onClose={() => setRemoveWtFor(null)} />}
       {onboardingActive && (
         <Onboarding
           onClose={() => {

--- a/src/app/Sidebar.tsx
+++ b/src/app/Sidebar.tsx
@@ -1,8 +1,8 @@
 import { useStore } from "../store";
-import { isLive } from "../types";
-import { Fork, Plus, Search, Sparkle } from "../icons";
+import { isLive, WorktreeNode } from "../types";
+import { Fork, Plus, Search, Sparkle, Trash } from "../icons";
 
-export default function Sidebar({ onAdd }: { onAdd: () => void }) {
+export default function Sidebar({ onAdd, onRemove }: { onAdd: () => void; onRemove?: (wt: WorktreeNode) => void }) {
   const tree = useStore((s) => s.tree);
   const query = useStore((s) => s.query);
   const setQuery = useStore((s) => s.setQuery);
@@ -60,6 +60,18 @@ export default function Sidebar({ onAdd }: { onAdd: () => void }) {
                     {agent === "running" && (
                       <span className="ag-pip busy" title="Agent working">
                         <Sparkle size={10} />
+                      </span>
+                    )}
+                    {!w.isMain && onRemove && (
+                      <span
+                        className="wt-rm"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onRemove(w);
+                        }}
+                        title="Remove worktree"
+                      >
+                        <Trash size={14} />
                       </span>
                     )}
                   </button>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -192,6 +192,24 @@
   color: var(--faint);
   margin-top: 1px;
 }
+.wt .wt-rm {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--faint);
+  opacity: 0;
+  transition: opacity 0.1s, color 0.1s;
+  padding: 4px;
+  border-radius: 4px;
+  margin-left: auto;
+}
+.wt:hover .wt-rm {
+  opacity: 1;
+}
+.wt .wt-rm:hover {
+  background: var(--btn-hover);
+  color: var(--text);
+}
 .sb-foot {
   padding: 8px;
   border-top: 1px solid var(--border-soft);


### PR DESCRIPTION
Closes #9

This PR implements the ability to delete a worktree directly from the sidebar, which saves a lot of clicking when cleaning up stale worktrees.

### Changes:
- **Sidebar UI**: Added a hover-revealed trash icon to non-main worktree rows in `Sidebar.tsx`. 
- **State Handling**: Updated `App.tsx` to handle a specific `WorktreeNode` for removal (`removeWtFor`), rather than relying solely on the currently selected worktree context. 
- **Styling**: Added `.wt-rm` styles to `app.css` so the icon stays hidden and fades in smoothly when the row is hovered.
- **Safety**: The new button safely hooks into the existing `RemoveWorktreeModal`, ensuring the dirty-check and confirmation steps are always preserved.

### Verification:
- `npx tsc --noEmit` passes
- `npm run build` succeeds
