### PR TITLE
Agent lane: multiple agents & terminals per worktree, clickable paths, resize fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@tauri-apps/plugin-dialog": "^2.7.2",
         "@tauri-apps/plugin-opener": "^2",
         "@xterm/addon-fit": "^0.10.0",
+        "@xterm/addon-web-links": "^0.12.0",
         "@xterm/addon-webgl": "^0.18.0",
         "@xterm/xterm": "^5.5.0",
         "react": "^19.1.0",
@@ -1002,6 +1003,12 @@
       "peerDependencies": {
         "@xterm/xterm": "^5.0.0"
       }
+    },
+    "node_modules/@xterm/addon-web-links": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-web-links/-/addon-web-links-0.12.0.tgz",
+      "integrity": "sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==",
+      "license": "MIT"
     },
     "node_modules/@xterm/addon-webgl": {
       "version": "0.18.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@tauri-apps/plugin-dialog": "^2.7.2",
     "@tauri-apps/plugin-opener": "^2",
     "@xterm/addon-fit": "^0.10.0",
+    "@xterm/addon-web-links": "^0.12.0",
     "@xterm/addon-webgl": "^0.18.0",
     "@xterm/xterm": "^5.5.0",
     "react": "^19.1.0",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -67,6 +67,7 @@ pub async fn add_repo(app: AppHandle, path: String) -> Result<RepoCfg, String> {
         services: Vec::new(),
         custom_commands: Vec::new(),
         agent_command: String::new(),
+        agents: Vec::new(),
     };
 
     let updated = {
@@ -429,7 +430,34 @@ pub async fn open_in_editor(app: AppHandle, wt_key: String) -> Result<(), String
         s.editor.command.clone()
     };
     let editor = if editor.trim().is_empty() { "code".to_string() } else { editor };
-    let (shell, shargs) = crate::toolchain::shell_argv(&format!("{editor} '{wt_key}'"));
+    let (shell, shargs) = crate::toolchain::shell_argv(&format!("{editor} {}", crate::toolchain::sh_quote(&wt_key)));
+    tokio::process::Command::new(shell)
+        .args(&shargs)
+        .spawn()
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+/// Open a worktree-contained file in the selected editor. Relative paths are
+/// resolved from the worktree root; canonicalization rejects traversal and
+/// symlinks that leave it before any shell command is launched.
+#[tauri::command]
+pub async fn open_file_in_editor(app: AppHandle, wt_key: String, path: String) -> Result<(), String> {
+    let root = std::fs::canonicalize(&wt_key).map_err(|e| format!("worktree path: {e}"))?;
+    let requested = std::path::PathBuf::from(&path);
+    let candidate = if requested.is_absolute() { requested } else { root.join(requested) };
+    let file = std::fs::canonicalize(&candidate).map_err(|e| format!("file path: {e}"))?;
+    if !file.starts_with(&root) {
+        return Err("File must be inside the selected worktree".into());
+    }
+    let editor = {
+        let state = app.state::<AppState>();
+        let s = state.settings.read().unwrap();
+        s.editor.command.clone()
+    };
+    let editor = if editor.trim().is_empty() { "code".to_string() } else { editor };
+    let file = crate::toolchain::sh_quote(&file.to_string_lossy());
+    let (shell, shargs) = crate::toolchain::shell_argv(&format!("{editor} {file}"));
     tokio::process::Command::new(shell)
         .args(&shargs)
         .spawn()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -204,6 +204,7 @@ pub fn run() {
             commands::worktree_stop_all,
             commands::reset_db,
             commands::open_in_editor,
+            commands::open_file_in_editor,
             commands::reveal_in_finder,
             commands::open_terminal,
             commands::open_port,

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -62,6 +62,20 @@ pub struct RepoCfg {
     /// `claude`, `aider`, `codex`). Empty = fall back to the built-in default.
     #[serde(default)]
     pub agent_command: String,
+    /// Selectable agent launchers for the worktree agent lane. Kept alongside
+    /// `agent_command` so existing settings files upgrade without data loss.
+    #[serde(default)]
+    pub agents: Vec<AgentCfg>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase", default)]
+pub struct AgentCfg {
+    pub id: String,
+    pub name: String,
+    pub command: String,
+    /// Append Canopy's initial handoff as the first CLI prompt argument.
+    pub prompt_on_launch: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -52,9 +52,24 @@ pub struct PtySession {
     started_unix: u64,
 }
 
+/// The final scrollback of a session whose process has exited, kept so the UI
+/// can still show what it printed. The PTY, child and reader are all gone by
+/// then — this is just bytes.
+struct ExitedBuffer {
+    scrollback: Vec<u8>,
+    seq: u64,
+    at: Instant,
+}
+
+/// How many exited sessions keep their output. Past this the oldest is dropped,
+/// so a long session of starting and stopping agents can't grow without bound.
+const EXITED_CAP: usize = 24;
+
 #[derive(Default)]
 pub struct TermTable {
     pub sessions: Mutex<HashMap<String, PtySession>>,
+    /// scrollback of exited sessions, by id (see `ExitedBuffer`)
+    exited: Mutex<HashMap<String, ExitedBuffer>>,
     next_gen: AtomicU64,
 }
 
@@ -115,6 +130,9 @@ pub fn open(
     if sessions.contains_key(id) {
         return Ok(()); // already running — idempotent attach
     }
+    // A restart reuses the id; the previous run's retained output would
+    // otherwise be replayed as though the new process had printed it.
+    table.exited.lock().unwrap().remove(id);
 
     let pair = native_pty_system()
         .openpty(PtySize { rows, cols, pixel_width: 0, pixel_height: 0 })
@@ -195,19 +213,29 @@ pub fn open(
                     // append to scrollback and advance the cursor atomically, so
                     // the emitted seq always matches a chunk boundary.
                     let mut seq = 0;
+                    let mut ours = false;
                     if let Some(table) = app.try_state::<TermTable>() {
                         if let Some(sess) = table.sessions.lock().unwrap().get_mut(&id) {
-                            sess.scrollback.extend(chunk.iter().copied());
-                            let overflow = sess.scrollback.len().saturating_sub(SCROLLBACK_CAP);
-                            if overflow > 0 {
-                                sess.scrollback.drain(0..overflow);
+                            // Same generation guard the exit path uses: a restart
+                            // reopens this id, and bytes this (now stale) reader
+                            // drains afterwards must not be appended to — or
+                            // emitted as — the replacement session's output.
+                            if sess.generation == generation {
+                                sess.scrollback.extend(chunk.iter().copied());
+                                let overflow = sess.scrollback.len().saturating_sub(SCROLLBACK_CAP);
+                                if overflow > 0 {
+                                    sess.scrollback.drain(0..overflow);
+                                }
+                                sess.seq += n as u64;
+                                sess.last_activity = Instant::now();
+                                seq = sess.seq;
+                                ours = true;
                             }
-                            sess.seq += n as u64;
-                            sess.last_activity = Instant::now();
-                            seq = sess.seq;
                         }
                     }
-                    let _ = app.emit("terminal:data", &DataEvent { id: &id, data: b64(chunk), seq });
+                    if ours {
+                        let _ = app.emit("terminal:data", &DataEvent { id: &id, data: b64(chunk), seq });
+                    }
                 }
                 Err(_) => break,
             }
@@ -219,7 +247,20 @@ pub fn open(
             let mut sessions = table.sessions.lock().unwrap();
             match sessions.get(&id) {
                 Some(s) if s.generation == generation => {
-                    sessions.remove(&id);
+                    // Keep what it printed: the UI shows an exited tab read-only
+                    // until it's closed or restarted, and without this the output
+                    // would die with the session the moment the process ended.
+                    let sess = sessions.remove(&id).unwrap();
+                    let mut exited = table.exited.lock().unwrap();
+                    if exited.len() >= EXITED_CAP {
+                        if let Some(oldest) = exited.iter().min_by_key(|(_, b)| b.at).map(|(k, _)| k.clone()) {
+                            exited.remove(&oldest);
+                        }
+                    }
+                    exited.insert(
+                        id.clone(),
+                        ExitedBuffer { scrollback: sess.scrollback.into_iter().collect(), seq: sess.seq, at: Instant::now() },
+                    );
                     true
                 }
                 _ => false,
@@ -256,20 +297,29 @@ pub fn resize(table: &TermTable, id: &str, cols: u16, rows: u16) -> Result<(), S
 }
 
 /// Scrollback snapshot + its end cursor, for a re-mounting window to rehydrate.
-/// `None` when the session doesn't exist (never opened, or exited).
+/// Falls back to the retained buffer of an exited session, so a tab that ended
+/// while its worktree wasn't selected can still be read. `None` only when the id
+/// was never opened (or has since been closed).
 pub fn get_buffer(table: &TermTable, id: &str) -> Option<BufferSnapshot> {
-    let sessions = table.sessions.lock().unwrap();
-    sessions.get(id).map(|s| {
+    if let Some(s) = table.sessions.lock().unwrap().get(id) {
         let bytes: Vec<u8> = s.scrollback.iter().copied().collect();
-        BufferSnapshot { buffer: b64(&bytes), seq: s.seq }
-    })
+        return Some(BufferSnapshot { buffer: b64(&bytes), seq: s.seq });
+    }
+    table
+        .exited
+        .lock()
+        .unwrap()
+        .get(id)
+        .map(|b| BufferSnapshot { buffer: b64(&b.scrollback), seq: b.seq })
 }
 
-/// Kill and drop a session.
+/// Kill and drop a session, including any retained output — closing a tab is the
+/// point at which the user is done with it.
 pub fn close(table: &TermTable, id: &str) {
     if let Some(mut sess) = table.sessions.lock().unwrap().remove(id) {
         let _ = sess.child.kill();
     }
+    table.exited.lock().unwrap().remove(id);
 }
 
 /// Close a session and refresh the persisted orphan list (command path).
@@ -286,6 +336,7 @@ pub fn close_worktree(app: &AppHandle, table: &TermTable, wt_key: &str) {
     for id in &ids {
         close(table, id);
     }
+    table.exited.lock().unwrap().retain(|k, _| !k.starts_with(&prefix));
     if !ids.is_empty() {
         persist_orphans(app);
     }
@@ -297,6 +348,7 @@ pub fn close_all(table: &TermTable) {
     for (_, mut sess) in sessions.drain() {
         let _ = sess.child.kill();
     }
+    table.exited.lock().unwrap().clear();
 }
 
 /// Snapshot live sessions' pgids into persisted runtime state, so a crash can be

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -86,6 +86,15 @@ fn b64(bytes: &[u8]) -> String {
     base64::engine::general_purpose::STANDARD.encode(bytes)
 }
 
+/// The kind of a session id — `"agent"` or `"shell"`. A worktree holds any
+/// number of each, so ids carry an instance suffix (`…::agent#3`); the wtKey is
+/// a filesystem path and never contains `::`, so the last segment is the kind.
+/// Ids from before multi-session (`…::agent`) parse the same way.
+fn kind_of(id: &str) -> &str {
+    let last = id.rsplit("::").next().unwrap_or("");
+    last.split('#').next().unwrap_or("")
+}
+
 /// Open (or no-op if already open) a terminal session `id` in `cwd`. With no
 /// `command` it runs an interactive login shell; with one it runs that command
 /// under a login shell (so the session ends — firing `terminal:exit` — when the
@@ -132,6 +141,12 @@ pub fn open(
     }
     cmd.cwd(cwd);
     cmd.env("TERM", "xterm-256color");
+    // Every agent profile can read the same durable handoff even when it opts
+    // out of positional prompts because its CLI has a different interface.
+    if kind_of(id) == "agent" {
+        cmd.env("CANOPY_CONTEXT_FILE", std::path::Path::new(cwd).join(".canopy/context.md"));
+        cmd.env("CANOPY_WORKTREE", cwd);
+    }
     if let Some(bin) = crate::toolchain::pinned_node_bin(cwd) {
         let path = std::env::var("PATH").unwrap_or_default();
         cmd.env("PATH", format!("{bin}:{path}"));
@@ -333,6 +348,21 @@ pub fn sweep_orphans(app: &AppHandle) {
     let _ = crate::settings::save_runtime(app, &runtime);
 }
 
+#[cfg(test)]
+mod tests {
+    use super::kind_of;
+
+    #[test]
+    fn kind_of_reads_multi_session_ids() {
+        assert_eq!(kind_of("/Users/me/wt/feature#1::agent#3"), "agent");
+        assert_eq!(kind_of("/Users/me/wt/feature#1::shell#12"), "shell");
+        // ids written before multi-session carried no instance suffix
+        assert_eq!(kind_of("/Users/me/wt/feature::agent"), "agent");
+        assert_eq!(kind_of("/Users/me/wt/feature::shell"), "shell");
+        assert_eq!(kind_of("nonsense"), "nonsense");
+    }
+}
+
 /// Sweep idle SHELL sessions (bounds long-run resource growth). Killing the
 /// child makes its reader hit EOF, which removes the session and emits
 /// `terminal:exit`. Agent sessions are exempt — a quiet agent may just be
@@ -340,7 +370,7 @@ pub fn sweep_orphans(app: &AppHandle) {
 pub fn sweep_idle(table: &TermTable) {
     let mut sessions = table.sessions.lock().unwrap();
     for (id, sess) in sessions.iter_mut() {
-        if id.ends_with("::shell") && sess.last_activity.elapsed() > IDLE_LIMIT {
+        if kind_of(id) == "shell" && sess.last_activity.elapsed() > IDLE_LIMIT {
             let _ = sess.child.kill();
         }
     }

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -356,6 +356,9 @@ mod tests {
     fn kind_of_reads_multi_session_ids() {
         assert_eq!(kind_of("/Users/me/wt/feature#1::agent#3"), "agent");
         assert_eq!(kind_of("/Users/me/wt/feature#1::shell#12"), "shell");
+        // ids carry a per-launch nonce so a webview reload can't reuse one
+        assert_eq!(kind_of("/Users/me/wt/x::agent#mfz1a2b-4"), "agent");
+        assert_eq!(kind_of("/Users/me/wt/x::shell#mfz1a2b-11"), "shell");
         // ids written before multi-session carried no instance suffix
         assert_eq!(kind_of("/Users/me/wt/feature::agent"), "agent");
         assert_eq!(kind_of("/Users/me/wt/feature::shell"), "shell");

--- a/src-tauri/src/toolchain.rs
+++ b/src-tauri/src/toolchain.rs
@@ -93,9 +93,34 @@ pub fn shell_argv(cmdline: &str) -> (String, Vec<String>) {
     (shell, args)
 }
 
+/// Wrap `s` as a single POSIX shell word. Inside single quotes every byte is
+/// literal, so the only case needing care is `'` itself: close the quote, emit
+/// an escaped quote, reopen — `'\''`. (Applying the *double*-quote idiom here,
+/// `'\"'\"'`, silently mangles any path containing an apostrophe.)
+pub fn sh_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::shell_argv;
+    use super::{sh_quote, shell_argv};
+
+    #[test]
+    fn sh_quote_round_trips_through_the_shell() {
+        assert_eq!(sh_quote("/tmp/plain.txt"), "'/tmp/plain.txt'");
+        assert_eq!(sh_quote("/tmp/it's.txt"), r"'/tmp/it'\''s.txt'");
+        // spaces, globs and command substitution stay inert
+        assert_eq!(sh_quote("/a b/$(rm -rf ~)/*.rs"), "'/a b/$(rm -rf ~)/*.rs'");
+        // and the shell actually parses it back to the original
+        for raw in ["/tmp/it's.txt", "/a b/c.rs", "/x/$(echo hi).ts", "/q/\"dq\".ts"] {
+            let out = std::process::Command::new("sh")
+                .arg("-c")
+                .arg(format!("printf %s {}", sh_quote(raw)))
+                .output()
+                .expect("sh");
+            assert_eq!(String::from_utf8_lossy(&out.stdout), raw, "round-trip failed for {raw}");
+        }
+    }
 
     #[test]
     fn shell_argv_passes_login_and_command_separately() {

--- a/src/app/AgentLane.tsx
+++ b/src/app/AgentLane.tsx
@@ -30,27 +30,41 @@ function DetachedPlaceholder({ onBack }: { onBack: () => void }) {
   );
 }
 
-/** Shown for a tab whose PTY has exited and whose output this lane instance
-    never rendered (e.g. it exited, then the worktree was switched away and
-    back). Mounting a terminal here would silently re-run the command. */
-function EndedPlaceholder({ session, onRestart, onClose }: { session: LaneSession; onRestart: () => void; onClose: () => void }) {
+/** A tab whose process has exited: its output stays readable (the backend keeps
+    the final scrollback), shown read-only above a bar offering restart/close.
+    The pane must never *open* a session here — that would re-run the command
+    without the user asking. */
+function EndedSession({
+  session,
+  cwd,
+  hidden,
+  onRestart,
+  onClose,
+}: {
+  session: LaneSession;
+  cwd: string;
+  hidden: boolean;
+  onRestart: () => void;
+  onClose: () => void;
+}) {
   return (
-    <div className="term-ph">
-      <span className="ph-ic">
-        {session.kind === "agent" ? <Sparkle size={19} /> : <TerminalIcon size={19} />}
-      </span>
-      <span className="ph-t">{session.title} ended</span>
-      <span className="ph-s">The session's process exited. Restart it in place, or close the tab.</span>
-      <span style={{ display: "flex", gap: 8 }}>
+    <div className="term-ended">
+      <div className="te-bar">
+        {session.kind === "agent" ? <Sparkle size={12} /> : <TerminalIcon size={12} />}
+        <span className="te-t">{session.title} ended</span>
+        <span className="grow" />
         <button className="btn-sm" onClick={onRestart}>
-          <Play size={13} />
+          <Play size={12} />
           Restart
         </button>
         <button className="btn-sm" onClick={onClose}>
-          <X size={13} />
-          Close tab
+          <X size={12} />
+          Close
         </button>
-      </span>
+      </div>
+      <div className="te-body">
+        <TerminalPane key={session.gen} termId={session.id} cwd={cwd} hidden={hidden} readOnly />
+      </div>
     </div>
   );
 }
@@ -145,16 +159,6 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
 
   const active = sessions.find((s) => s.id === activeId) ?? sessions[0] ?? null;
   const liveAgents = sessions.filter((s) => s.kind === "agent" && s.running).length;
-
-  // Ids whose terminal this lane instance has actually rendered. An exited tab
-  // outside this set gets the "ended" placeholder instead of a TerminalPane —
-  // mounting one would re-open the PTY and re-run the command. Recorded in an
-  // effect rather than during render (render must stay side-effect free); the
-  // `s.running` check below covers the frame before this runs.
-  const rendered = useRef<Set<string>>(new Set());
-  useEffect(() => {
-    for (const s of sessions) if (s.running) rendered.current.add(s.id);
-  }, [sessions]);
 
   useEffect(() => {
     if (!hasBackend()) return;
@@ -300,10 +304,34 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
   /** "Claude", then "Claude 2", … — tab labels stay tellable apart at a glance.
       Reads live store state, not this render's snapshot, so two launches in the
       same tick can't both claim the unsuffixed name. */
+  /** Arrow keys move between tabs; Home/End jump to the ends. Selection follows
+      focus, which is the expected behaviour for a tablist of live terminals. */
+  const onTabKey = (e: React.KeyboardEvent, id: string) => {
+    const keys = ["ArrowRight", "ArrowLeft", "Home", "End"];
+    if (!keys.includes(e.key)) return;
+    const i = sessions.findIndex((s) => s.id === id);
+    if (i < 0) return;
+    e.preventDefault();
+    const to =
+      e.key === "Home"
+        ? 0
+        : e.key === "End"
+          ? sessions.length - 1
+          : (i + (e.key === "ArrowRight" ? 1 : -1) + sessions.length) % sessions.length;
+    const next = sessions[to];
+    if (!next) return;
+    setActiveTerm(wt.wtKey, next.id);
+    requestAnimationFrame(() => tabsRef.current?.querySelector<HTMLElement>(`[data-tab="${CSS.escape(next.id)}"]`)?.focus());
+  };
+
   const uniqueTitle = (base: string) => {
     const live = useStore.getState().sessions[wt.wtKey] ?? NO_SESSIONS;
-    const taken = live.filter((s) => s.title === base || s.title.startsWith(`${base} `)).length;
-    return taken === 0 ? base : `${base} ${taken + 1}`;
+    // probe for the first free suffix rather than counting matches: closing
+    // "Claude 2" while "Claude 3" is open would otherwise hand out a second
+    // "Claude 3", leaving two tabs indistinguishable.
+    const taken = new Set(live.map((s) => s.title));
+    if (!taken.has(base)) return base;
+    for (let n = 2; ; n++) if (!taken.has(`${base} ${n}`)) return `${base} ${n}`;
   };
 
   // Start a coding agent as its OWN PTY session (the terminal *is* the chat).
@@ -515,30 +543,34 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
           would just be an empty bar — it appears with the first tab. */}
       {sessions.length > 0 && (
       <div className="lane-tabs">
-        <div className="lt-scroll" ref={tabsRef}>
+        <div className="lt-scroll" ref={tabsRef} role="tablist" aria-label="Terminal sessions">
           {sessions.map((s) => (
             <span
               key={s.id}
               className={"lt" + (s.id === active?.id ? " on" : "") + (s.running ? "" : " ended")}
-              title={`${s.title}${s.running ? "" : " — ended"}`}
-              onClick={() => setActiveTerm(wt.wtKey, s.id)}
               onAuxClick={(e) => {
                 if (e.button === 1) closeSession(s.id); // middle-click closes, as in an editor
               }}
             >
-              {s.kind === "agent" ? <Sparkle size={11} /> : <TerminalIcon size={11} />}
-              <span className="lt-n">{s.title}</span>
-              <span className={"lt-d" + (s.running ? " live" : "")} />
-              <span
-                className="lt-x"
-                title="Close tab"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  closeSession(s.id);
-                }}
+              {/* roving tabindex: only the selected tab is in the tab order, and
+                  arrows move between them — the standard tablist pattern */}
+              <button
+                className="lt-main"
+                role="tab"
+                data-tab={s.id}
+                aria-selected={s.id === active?.id}
+                tabIndex={s.id === active?.id ? 0 : -1}
+                title={`${s.title}${s.running ? "" : " — ended"}`}
+                onClick={() => setActiveTerm(wt.wtKey, s.id)}
+                onKeyDown={(e) => onTabKey(e, s.id)}
               >
+                {s.kind === "agent" ? <Sparkle size={11} /> : <TerminalIcon size={11} />}
+                <span className="lt-n">{s.title}</span>
+                <span className={"lt-d" + (s.running ? " live" : "")} />
+              </button>
+              <button className="lt-x" title="Close tab" aria-label={`Close ${s.title}`} onClick={() => closeSession(s.id)}>
                 <X size={11} />
-              </span>
+              </button>
             </span>
           ))}
         </div>
@@ -576,15 +608,29 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
             sessions.map((s) => {
               const on = s.id === active?.id;
               return (
-                <div className={"term-body" + (on ? "" : " hidden")} key={s.id}>
+                <div
+                  className={"term-body" + (on ? "" : " hidden")}
+                  key={s.id}
+                  role="tabpanel"
+                  aria-label={s.title}
+                  // NB: not the `hidden` attribute — that is display:none, which
+                  // leaves xterm's renderer without dimensions (see terminal.css)
+                  aria-hidden={!on}
+                >
                   {detached.has(s.id) ? (
                     <DetachedPlaceholder onBack={() => bringBack(s.id)} />
-                  ) : s.running || rendered.current.has(s.id) ? (
+                  ) : s.running ? (
                     // `gen` in the key forces a full remount on restart, which is
                     // what re-creates the PTY under the same id.
                     <TerminalPane key={s.gen} termId={s.id} cwd={wt.path} hidden={!on} command={s.command} />
                   ) : (
-                    <EndedPlaceholder session={s} onRestart={() => restartSession(s.id)} onClose={() => closeSession(s.id)} />
+                    <EndedSession
+                      session={s}
+                      cwd={wt.path}
+                      hidden={!on}
+                      onRestart={() => restartSession(s.id)}
+                      onClose={() => closeSession(s.id)}
+                    />
                   )}
                 </div>
               );

--- a/src/app/AgentLane.tsx
+++ b/src/app/AgentLane.tsx
@@ -4,19 +4,11 @@
 // store; switching tabs, or switching worktrees, keeps them all alive.
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { RepoNode, WorktreeNode } from "../types";
-import { nextTermId, useStore, type LaneSession } from "../store";
+import { laneLabel, nextTermId, useStore, type LaneSession } from "../store";
 import { hasBackend, ipc, type AgentCfg } from "../ipc";
 import { ChevLeft, ChevRight, Doc, ExpandH, Play, Plus, PopIn, PopOut, Spinner, Sparkle, Terminal as TerminalIcon, X } from "../icons";
 import TerminalPane from "./TerminalPane";
 import { ContextEditor, bodyPreview, composeAgentPrompt, composeContextMd, isBlank, runtimeFor, useWtContext } from "./WorktreeContext";
-
-/** Deterministic, injective window label for a detached terminal (hex of the id's
-    UTF-8 bytes) — a lossy replace could collide two worktrees onto one window. */
-const laneLabel = (id: string) =>
-  "term-" +
-  Array.from(new TextEncoder().encode(id))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
 
 function DetachedPlaceholder({ onBack }: { onBack: () => void }) {
   return (
@@ -156,9 +148,13 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
 
   // Ids whose terminal this lane instance has actually rendered. An exited tab
   // outside this set gets the "ended" placeholder instead of a TerminalPane —
-  // mounting one would re-open the PTY and re-run the command.
+  // mounting one would re-open the PTY and re-run the command. Recorded in an
+  // effect rather than during render (render must stay side-effect free); the
+  // `s.running` check below covers the frame before this runs.
   const rendered = useRef<Set<string>>(new Set());
-  for (const s of sessions) if (s.running) rendered.current.add(s.id);
+  useEffect(() => {
+    for (const s of sessions) if (s.running) rendered.current.add(s.id);
+  }, [sessions]);
 
   useEffect(() => {
     if (!hasBackend()) return;

--- a/src/app/AgentLane.tsx
+++ b/src/app/AgentLane.tsx
@@ -1,14 +1,14 @@
 // The agent lane (VariantC) — a first-class right-hand column holding the
-// per-worktree context, the coding agent, and a shell. Both the Agent and Shell
-// tabs are backed by their own live PTY (see TerminalPane); toggling between
-// them keeps both sessions alive.
-import { useEffect, useRef, useState } from "react";
+// per-worktree context and any number of agent / shell tabs. Every tab is
+// backed by its own live PTY (see TerminalPane) and by a LaneSession in the
+// store; switching tabs, or switching worktrees, keeps them all alive.
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { RepoNode, WorktreeNode } from "../types";
-import { useStore } from "../store";
-import { hasBackend, ipc } from "../ipc";
-import { ChevLeft, ChevRight, Doc, ExpandH, PopIn, PopOut, Spinner, Sparkle, Terminal as TerminalIcon, X } from "../icons";
+import { nextTermId, useStore, type LaneSession } from "../store";
+import { hasBackend, ipc, type AgentCfg } from "../ipc";
+import { ChevLeft, ChevRight, Doc, ExpandH, Play, Plus, PopIn, PopOut, Spinner, Sparkle, Terminal as TerminalIcon, X } from "../icons";
 import TerminalPane from "./TerminalPane";
-import { ContextEditor, bodyPreview, composeContextMd, isBlank, useWtContext } from "./WorktreeContext";
+import { ContextEditor, bodyPreview, composeAgentPrompt, composeContextMd, isBlank, runtimeFor, useWtContext } from "./WorktreeContext";
 
 /** Deterministic, injective window label for a detached terminal (hex of the id's
     UTF-8 bytes) — a lossy replace could collide two worktrees onto one window. */
@@ -38,21 +38,55 @@ function DetachedPlaceholder({ onBack }: { onBack: () => void }) {
   );
 }
 
-function AgentIdle({ onStart }: { onStart: () => void }) {
+/** Shown for a tab whose PTY has exited and whose output this lane instance
+    never rendered (e.g. it exited, then the worktree was switched away and
+    back). Mounting a terminal here would silently re-run the command. */
+function EndedPlaceholder({ session, onRestart, onClose }: { session: LaneSession; onRestart: () => void; onClose: () => void }) {
+  return (
+    <div className="term-ph">
+      <span className="ph-ic">
+        {session.kind === "agent" ? <Sparkle size={19} /> : <TerminalIcon size={19} />}
+      </span>
+      <span className="ph-t">{session.title} ended</span>
+      <span className="ph-s">The session's process exited. Restart it in place, or close the tab.</span>
+      <span style={{ display: "flex", gap: 8 }}>
+        <button className="btn-sm" onClick={onRestart}>
+          <Play size={13} />
+          Restart
+        </button>
+        <button className="btn-sm" onClick={onClose}>
+          <X size={13} />
+          Close tab
+        </button>
+      </span>
+    </div>
+  );
+}
+
+/** Empty lane: pick which agent to start, or drop straight into a shell. */
+function LaneIdle({ agents, onAgent, onShell }: { agents: AgentCfg[]; onAgent: (a: AgentCfg) => void; onShell: () => void }) {
   return (
     <div className="term-ph">
       <span className="ph-ic">
         <Sparkle size={19} />
       </span>
-      <span className="ph-t">No agent running</span>
+      <span className="ph-t">Nothing running here</span>
       <span className="ph-s">
-        Start the coding agent in this worktree. It runs in a real terminal, seeded with the context above.
+        Start a coding agent in this worktree — it runs in a real terminal, seeded with the context above. Run as many as you like, side by side.
       </span>
-      <button className="startagent" onClick={onStart}>
-        <Sparkle size={13} />
-        Start agent
-        <span className="ar">▸</span>
-      </button>
+      <span className="ph-actions">
+        {agents.map((a) => (
+          <button className="startagent" key={a.id} onClick={() => onAgent(a)}>
+            <Sparkle size={13} />
+            {a.name}
+            <span className="ar">▸</span>
+          </button>
+        ))}
+        <button className="btn-sm" onClick={onShell}>
+          <TerminalIcon size={13} />
+          New shell
+        </button>
+      </span>
     </div>
   );
 }
@@ -70,47 +104,120 @@ const DEFAULT_LANE = 372;
 // past its floor — it becomes an overlay drawer instead (see the handoff).
 const TIGHT = 1180;
 
-type Tab = "agent" | "shell";
+const NO_SESSIONS: LaneSession[] = [];
+const defaultAgent = (legacy: string): AgentCfg => ({ id: "default", name: "Claude", command: legacy.trim() || "claude", promptOnLaunch: true });
+const shellQuote = (value: string) => `'${value.replace(/'/g, `'"'"'`)}'`;
 
 export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNode }) {
   const showToast = useStore((s) => s.showToast);
-  const agentState = useStore((s) => s.agents[wt.wtKey] ?? "off");
-  const setAgent = useStore((s) => s.setAgent);
   const mainRailed = useStore((s) => s.mainRailed);
   const setMainRailed = useStore((s) => s.setMainRailed);
+  // Sessions live in the store so they survive this lane remounting on worktree
+  // switch — the PTYs behind them keep running either way.
+  const sessions = useStore((s) => s.sessions[wt.wtKey] ?? NO_SESSIONS);
+  const activeId = useStore((s) => s.activeTerm[wt.wtKey] ?? null);
+  const openSession = useStore((s) => s.openSession);
+  const closeSession = useStore((s) => s.closeSession);
+  const stopSession = useStore((s) => s.stopSession);
+  const restartSession = useStore((s) => s.restartSession);
+  const setActiveTerm = useStore((s) => s.setActiveTerm);
   // detached tracking lives in the store so it survives this lane remounting on
   // worktree switch (the window stays open; the placeholder must persist).
   const detached = useStore((s) => s.detachedTerms);
   const setTermDetached = useStore((s) => s.setTermDetached);
+  const settingsRev = useStore((s) => s.settingsRev);
   const [collapsed, setCollapsed] = useState(() => localStorage.getItem(COLLAPSE_KEY) === "1");
-  const [tab, setTab] = useState<Tab>("agent");
   const [ctxOpen, setCtxOpen] = useState(false);
   const [ctx, setCtx] = useWtContext(wt.wtKey);
+  // laneW is the width the user *asked* for; shownW below is it clamped to what
+  // currently fits. Keeping them separate means a narrow window never destroys
+  // the chosen width — it comes back when there's room again.
   const [laneW, setLaneW] = useState(() => Number(localStorage.getItem(WIDTH_KEY)) || DEFAULT_LANE);
+  const [rowW, setRowW] = useState(0);
+  /** mirrors laneW so the focus effect can read it without re-subscribing */
+  const laneWRef = useRef(laneW);
+  laneWRef.current = laneW;
   const [resizing, setResizing] = useState(false);
   const [tight, setTight] = useState(() => window.innerWidth < TIGHT);
-  // resolved agent CLI, set on the first Start; only needed to *create* the
-  // agent PTY — remounts while it's already running attach without it.
-  const [agentCmd, setAgentCmd] = useState<string | null>(null);
+  const [agents, setAgents] = useState<AgentCfg[]>([defaultAgent("")]);
+  const [addOpen, setAddOpen] = useState(false);
   const asideRef = useRef<HTMLElement>(null);
-  // the shell terminal is lazily mounted the first time its tab is shown, then
-  // kept mounted (hidden) so its PTY keeps running in the background.
-  const shellActivated = useRef(false);
-  if (tab === "shell") shellActivated.current = true;
+  const addRef = useRef<HTMLDivElement>(null);
+  const tabsRef = useRef<HTMLDivElement>(null);
+  /** pointer x + rendered lane width at mousedown, so the drag is a pure delta */
+  const dragRef = useRef<{ x: number; w: number } | null>(null);
+  /** width to restore when leaving focus mode, + the transition edge it keys off */
+  const preFocusW = useRef<number | null>(null);
+  const wasRailed = useRef(mainRailed);
+  const runtime = useMemo(() => runtimeFor(repo, wt), [repo, wt]);
+
+  const active = sessions.find((s) => s.id === activeId) ?? sessions[0] ?? null;
+  const liveAgents = sessions.filter((s) => s.kind === "agent" && s.running).length;
+
+  // Ids whose terminal this lane instance has actually rendered. An exited tab
+  // outside this set gets the "ended" placeholder instead of a TerminalPane —
+  // mounting one would re-open the PTY and re-run the command.
+  const rendered = useRef<Set<string>>(new Set());
+  for (const s of sessions) if (s.running) rendered.current.add(s.id);
+
+  useEffect(() => {
+    if (!hasBackend()) return;
+    let alive = true;
+    ipc
+      .getSettings()
+      .then((settings) => {
+        if (!alive) return;
+        const configured = settings.repos.find((r) => r.id === repo.repoId);
+        const next = (configured?.agents ?? []).filter((a) => a.id.trim() && a.command.trim());
+        setAgents(next.length ? next : [defaultAgent(configured?.agentCommand || "")]);
+      })
+      .catch(() => {});
+    return () => {
+      alive = false;
+    };
+  }, [repo.repoId, settingsRev]);
 
   useEffect(() => {
     localStorage.setItem(COLLAPSE_KEY, collapsed ? "1" : "0");
   }, [collapsed]);
   useEffect(() => {
-    localStorage.setItem(WIDTH_KEY, String(laneW));
-  }, [laneW]);
+    // focus mode blows the lane up to fill the window — persisting that would
+    // make the next launch start at the ceiling instead of the chosen width
+    if (!mainRailed) localStorage.setItem(WIDTH_KEY, String(laneW));
+  }, [laneW, mainRailed]);
 
-  // room available for the lane at a given main-pane floor
-  const availFor = (railed: boolean) => {
-    const body = asideRef.current?.parentElement;
-    if (!body) return null;
-    return body.clientWidth - SIDE - (railed ? RAIL : MIN_MAIN);
+  // keep the focused tab in view — a new tab is appended past the right edge
+  // once the strip overflows, and switching tabs can target an off-screen one.
+  useEffect(() => {
+    tabsRef.current?.querySelector(".lt.on")?.scrollIntoView({ block: "nearest", inline: "nearest" });
+  }, [activeId, sessions.length]);
+
+  // close the "+" menu on an outside click / Escape
+  useEffect(() => {
+    if (!addOpen) return;
+    const away = (e: MouseEvent) => {
+      if (!addRef.current?.contains(e.target as Node)) setAddOpen(false);
+    };
+    const esc = (e: KeyboardEvent) => e.key === "Escape" && setAddOpen(false);
+    window.addEventListener("mousedown", away);
+    window.addEventListener("keydown", esc);
+    return () => {
+      window.removeEventListener("mousedown", away);
+      window.removeEventListener("keydown", esc);
+    };
+  }, [addOpen]);
+
+  // Widest the lane may be at a given main-pane floor. Never returns below
+  // MIN_LANE — a too-narrow window used to report zero room, which silently
+  // killed the drag outright instead of just clamping it.
+  const maxLaneFor = (railed: boolean) => {
+    const w = rowW || asideRef.current?.parentElement?.clientWidth || 0;
+    if (!w) return null;
+    return Math.max(MIN_LANE, w - SIDE - (railed ? RAIL : MIN_MAIN));
   };
+  const maxLane = maxLaneFor(mainRailed);
+  /** what actually gets rendered: the requested width, capped to what fits */
+  const shownW = Math.round(Math.min(Math.max(laneW, MIN_LANE), maxLane ?? Infinity));
 
   // narrow-window fallback: overlay drawer + auto-collapse on first crossing
   useEffect(() => {
@@ -129,60 +236,160 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
     return () => window.removeEventListener("resize", onResize);
   }, [setMainRailed]);
 
-  // single source of truth for lane-width validity: clamp on mount, on window
-  // resize, and whenever focus mode changes the main pane's floor.
+  // React to focus mode rather than handling it in the toggle: the collapsed
+  // rail un-rails via its own buttons (App.tsx), so a handler-based restore left
+  // the lane blown up whenever focus was exited from there. Keyed on the
+  // transition so an unrelated re-render can't re-trigger it.
   useEffect(() => {
-    if (tight) return;
-    const clamp = () => {
-      const avail = availFor(mainRailed);
-      if (avail == null || avail < MIN_LANE) return;
-      setLaneW((w) => Math.min(w, avail));
-    };
-    clamp();
-    window.addEventListener("resize", clamp);
-    return () => window.removeEventListener("resize", clamp);
+    if (mainRailed === wasRailed.current) return;
+    wasRailed.current = mainRailed;
+    if (mainRailed) {
+      preFocusW.current = laneWRef.current;
+      const max = maxLaneFor(true);
+      if (max != null) setLaneW(max);
+    } else {
+      setLaneW(preFocusW.current ?? DEFAULT_LANE);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mainRailed, tight]);
+  }, [mainRailed]);
 
-  // drag the lane's left edge to resize
+  // Track the row's width so the ceiling can be applied at render time. Writing
+  // the clamp back into laneW instead made two writers race for it (a window
+  // resize or a focus toggle could overwrite the width the user just dragged),
+  // and lost the original width when the window grew back.
+  useEffect(() => {
+    const body = asideRef.current?.parentElement;
+    if (!body) return;
+    const measure = () => setRowW(body.clientWidth);
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(body);
+    return () => ro.disconnect();
+  }, []);
+
+  // Drag the lane's left edge to resize. Tracked as a delta from where the drag
+  // started rather than against the container's right edge: the pointer then
+  // stays glued to the grip even when the rendered width is clamped mid-drag
+  // (hitting MIN_LANE or the ceiling), instead of the edge creeping away.
   useEffect(() => {
     if (!resizing) return;
+    const origin = dragRef.current;
+    if (!origin) return;
     const move = (e: MouseEvent) => {
-      const body = asideRef.current?.parentElement;
-      if (!body) return;
-      const avail = availFor(mainRailed);
-      if (avail == null || avail < MIN_LANE) return; // no room to resize here
-      const right = body.getBoundingClientRect().right;
-      setLaneW(Math.round(Math.min(avail, Math.max(MIN_LANE, right - e.clientX))));
+      const max = maxLaneFor(mainRailed);
+      if (max == null) return;
+      setLaneW(Math.round(Math.min(max, Math.max(MIN_LANE, origin.w + (origin.x - e.clientX)))));
     };
     const up = () => setResizing(false);
     window.addEventListener("mousemove", move);
     window.addEventListener("mouseup", up);
+    // a drag over text would otherwise select half the app as it passes
     document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
     return () => {
       window.removeEventListener("mousemove", move);
       window.removeEventListener("mouseup", up);
       document.body.style.cursor = "";
+      document.body.style.userSelect = "";
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resizing, mainRailed]);
 
   // focus mode: collapse the middle pane to a rail, give the lane the rest
   const toggleFocus = () => {
-    if (!mainRailed) {
-      setMainRailed(true);
-      const avail = availFor(true);
-      if (avail != null) setLaneW(Math.max(MIN_LANE, avail));
-      showToast("Terminal focus — worktree details collapsed");
-    } else {
-      setMainRailed(false);
-      const avail = availFor(false);
-      setLaneW(avail == null ? DEFAULT_LANE : Math.min(DEFAULT_LANE, Math.max(MIN_LANE, avail)));
+    if (!mainRailed) showToast("Terminal focus — worktree details collapsed");
+    setMainRailed(!mainRailed);
+  };
+
+  /** "Claude", then "Claude 2", … — tab labels stay tellable apart at a glance.
+      Reads live store state, not this render's snapshot, so two launches in the
+      same tick can't both claim the unsuffixed name. */
+  const uniqueTitle = (base: string) => {
+    const live = useStore.getState().sessions[wt.wtKey] ?? NO_SESSIONS;
+    const taken = live.filter((s) => s.title === base || s.title.startsWith(`${base} `)).length;
+    return taken === 0 ? base : `${base} ${taken + 1}`;
+  };
+
+  // Start a coding agent as its OWN PTY session (the terminal *is* the chat).
+  // Running it as the session's command means the session ends — and the tab
+  // flips to "ended" — exactly when the agent exits. The context is written to
+  // .canopy/context.md first so the agent can read the full handoff.
+  const startAgent = async (profile: AgentCfg) => {
+    setCtxOpen(false);
+    setAddOpen(false);
+    const id = nextTermId(wt.wtKey, "agent");
+    const title = uniqueTitle(profile.name || "Agent");
+    if (!hasBackend()) {
+      openSession({ id, wtKey: wt.wtKey, kind: "agent", title, agentId: profile.id, command: "agent" });
+      showToast(`${title} — ${repo.name} · ${wt.branch}`);
+      return;
+    }
+    try {
+      // Always write the handoff: even a blank user brief includes the branch,
+      // database and resolved service ports the agent needs to work safely.
+      await ipc.writeWorktreeContext(wt.path, composeContextMd(ctx, runtime));
+      const prompt = composeAgentPrompt(ctx, runtime);
+      // A profile can opt out for CLIs that do not accept an initial positional
+      // prompt; those still receive CANOPY_CONTEXT_FILE via the context file.
+      const command = profile.promptOnLaunch ? `${profile.command} ${shellQuote(prompt)}` : profile.command;
+      openSession({ id, wtKey: wt.wtKey, kind: "agent", title, agentId: profile.id, command });
+      showToast(`${title} started — ${repo.name} · ${wt.branch}`);
+    } catch (e) {
+      showToast(`Agent start failed — ${String(e)}`);
     }
   };
 
-  const shellId = `${wt.wtKey}::shell`;
-  const agentId = `${wt.wtKey}::agent`;
+  const startShell = () => {
+    setAddOpen(false);
+    const id = nextTermId(wt.wtKey, "shell");
+    openSession({ id, wtKey: wt.wtKey, kind: "shell", title: uniqueTitle("Shell") });
+  };
+
+  // Pop a terminal into its own OS window that attaches to the SAME PTY. The
+  // lane shows a placeholder while detached; closing the window (or "Bring
+  // back") re-docks it — the shell never stops.
+  const popOut = async (id: string) => {
+    if (!hasBackend()) {
+      showToast("Pop-out is available in the desktop app");
+      return;
+    }
+    const { WebviewWindow } = await import("@tauri-apps/api/webviewWindow");
+    const label = laneLabel(id);
+    const existing = await WebviewWindow.getByLabel(label);
+    if (existing) {
+      existing.setFocus();
+      return;
+    }
+    const sess = sessions.find((s) => s.id === id);
+    const title = sess?.title ?? "Terminal";
+    // carry the command: if this window is the one that ends up *creating* the
+    // PTY (the tab was popped out before its session existed), it must launch
+    // the agent, not a bare login shell.
+    const cmd = sess?.command ? `&cmd=${encodeURIComponent(sess.command)}` : "";
+    const url = `terminal.html?id=${encodeURIComponent(id)}&cwd=${encodeURIComponent(wt.path)}&branch=${encodeURIComponent(wt.branch)}&title=${encodeURIComponent(title)}${cmd}`;
+    const win = new WebviewWindow(label, {
+      url,
+      width: 560,
+      height: 360,
+      minWidth: 360,
+      minHeight: 220,
+      title: `${title} — ${wt.branch}`,
+      decorations: false,
+      resizable: true,
+    });
+    win.once("tauri://created", () => setTermDetached(id, true));
+    win.once("tauri://error", () => showToast("Could not open terminal window"));
+    win.once("tauri://destroyed", () => setTermDetached(id, false));
+  };
+
+  const bringBack = async (id: string) => {
+    if (hasBackend()) {
+      const { WebviewWindow } = await import("@tauri-apps/api/webviewWindow");
+      const w = await WebviewWindow.getByLabel(laneLabel(id));
+      await w?.close();
+    }
+    setTermDetached(id, false);
+  };
 
   if (collapsed) {
     return (
@@ -193,24 +400,11 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
           </button>
         </div>
         <div className="lane-rail">
-          <button
-            className="ib"
-            title="Agent"
-            onClick={() => {
-              setCollapsed(false);
-              setTab("agent");
-            }}
-          >
+          <button className="ib" title={`Agents${liveAgents ? ` — ${liveAgents} running` : ""}`} onClick={() => setCollapsed(false)}>
             <Sparkle size={15} />
+            {liveAgents > 0 && <span className="rail-n">{liveAgents}</span>}
           </button>
-          <button
-            className="ib"
-            title="Shell"
-            onClick={() => {
-              setCollapsed(false);
-              setTab("shell");
-            }}
-          >
+          <button className="ib" title="Shells" onClick={() => setCollapsed(false)}>
             <TerminalIcon size={15} />
           </button>
           <button
@@ -229,99 +423,34 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
     );
   }
 
-  // Start the coding agent as its OWN PTY session (the terminal *is* the chat).
-  // Running it as the session's command means the session ends — and the run
-  // state clears via terminal:exit — exactly when the agent exits. The context,
-  // if any, is written to .canopy/context.md first so the agent can read it.
-  const startAgent = async () => {
-    setCtxOpen(false);
-    setTab("agent");
-    if (!hasBackend()) {
-      setAgentCmd("agent");
-      setAgent(wt.wtKey, "running");
-      showToast(`Agent — ${repo.name} · ${wt.branch}`);
-      return;
-    }
-    try {
-      if (!isBlank(ctx)) {
-        // writes .canopy/context.md (+ a self-ignoring .gitignore it won't
-        // clobber); propagate failure — don't claim "seeded" if it failed
-        await ipc.writeWorktreeContext(wt.path, composeContextMd(ctx));
-      }
-      const cmd = (await ipc.resolveAgentCommand(wt.wtKey)) || "claude";
-      setAgentCmd(cmd);
-      setAgent(wt.wtKey, "running"); // TerminalPane mounts and creates the PTY with `cmd`
-      showToast(`Agent started — ${repo.name} · ${wt.branch}`);
-    } catch (e) {
-      showToast(`Agent start failed — ${String(e)}`);
-    }
-  };
-
-  // Kill the agent PTY; terminal:exit then clears run state (see the store).
-  const stopAgent = () => {
-    setAgent(wt.wtKey, "off");
-    if (hasBackend()) ipc.terminalClose(agentId).catch(() => {});
-    showToast("Agent stopped");
-  };
-
-  // Pop a terminal into its own OS window that attaches to the SAME PTY. The
-  // lane shows a placeholder while detached; closing the window (or "Bring
-  // back") re-docks it — the shell never stops.
-  const popOut = async (id: string) => {
-    if (!hasBackend()) {
-      showToast("Pop-out is available in the desktop app");
-      return;
-    }
-    const { WebviewWindow } = await import("@tauri-apps/api/webviewWindow");
-    const label = laneLabel(id);
-    const existing = await WebviewWindow.getByLabel(label);
-    if (existing) {
-      existing.setFocus();
-      return;
-    }
-    const url = `terminal.html?id=${encodeURIComponent(id)}&cwd=${encodeURIComponent(wt.path)}&branch=${encodeURIComponent(wt.branch)}`;
-    const win = new WebviewWindow(label, {
-      url,
-      width: 560,
-      height: 360,
-      minWidth: 360,
-      minHeight: 220,
-      title: `Terminal — ${wt.branch}`,
-      decorations: false,
-      resizable: true,
-    });
-    win.once("tauri://created", () => setTermDetached(id, true));
-    win.once("tauri://error", () => showToast("Could not open terminal window"));
-    win.once("tauri://destroyed", () => setTermDetached(id, false));
-  };
-
-  const bringBack = async (id: string) => {
-    if (hasBackend()) {
-      const { WebviewWindow } = await import("@tauri-apps/api/webviewWindow");
-      const w = await WebviewWindow.getByLabel(laneLabel(id));
-      await w?.close();
-    }
-    setTermDetached(id, false);
-  };
-
   return (
     <aside
       ref={asideRef}
       className={"lane" + (tight ? " overlay" : "") + (resizing ? " resizing" : "")}
-      style={tight ? undefined : { width: laneW }}
+      style={tight ? undefined : { width: shownW }}
     >
       {!tight && (
         <span
           className={"lane-grip" + (resizing ? " on" : "")}
+          title="Drag to resize · double-click to reset"
           onMouseDown={(e) => {
             e.preventDefault();
+            // seed from the *rendered* width, not laneW — they can differ after
+            // a window resize clamps the lane, and the drag must start where
+            // the user actually sees the edge.
+            const w = asideRef.current?.getBoundingClientRect().width ?? laneW;
+            dragRef.current = { x: e.clientX, w };
             setResizing(true);
+          }}
+          onDoubleClick={() => {
+            const max = maxLaneFor(mainRailed);
+            setLaneW(max == null ? DEFAULT_LANE : Math.min(DEFAULT_LANE, max));
           }}
         />
       )}
       <div className="lane-head">
         <span
-          className={"ag-pip" + (agentState === "running" ? " busy" : "")}
+          className={"ag-pip" + (liveAgents > 0 ? " busy" : "")}
           style={{ width: 26, height: 26, borderRadius: 8, background: "var(--accent-dim)", color: "var(--accent)" }}
         >
           <Sparkle size={14} />
@@ -331,14 +460,16 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
           <span>{wt.branch}</span>
         </div>
         <span className="grow" />
-        {/* only pop out a tab that actually has a session — popping the agent
-            tab while idle would open a plain shell under the ::agent id and a
-            later Start would falsely see the agent as already running. */}
-        {(tab === "shell" || agentState === "running") && (
+        {active && (
           <button
             className="ib"
-            title="Open in a separate window"
-            onClick={() => popOut(tab === "agent" ? agentId : shellId)}
+            title={active.running ? `Open ${active.title} in a separate window` : `Restart ${active.title} in a separate window`}
+            onClick={() => {
+              // an ended tab has no PTY behind it; restart so the detached
+              // window attaches to a real session rather than a bare shell
+              if (!active.running) restartSession(active.id);
+              popOut(active.id);
+            }}
           >
             <PopOut size={14} />
           </button>
@@ -384,65 +515,116 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
         )}
       </div>
 
-      <div className="lane-seg">
-        <button className={tab === "agent" ? "on" : ""} onClick={() => setTab("agent")}>
-          <Sparkle size={12} />
-          Agent
-        </button>
-        <button className={tab === "shell" ? "on" : ""} onClick={() => setTab("shell")}>
-          <TerminalIcon size={12} />
-          Shell
-        </button>
-      </div>
-
-      {tab === "agent" && agentState === "running" && (
-        <div className="ag-banner">
-          <Sparkle size={13} />
-          <span className="nm">agent</span>
-          <span className="sep">·</span>
-          <span className="ctxref">
-            {isBlank(ctx) ? "running in this worktree" : `seeded with “${ctx.title || "context"}”`}
-          </span>
+      {/* with nothing running the idle pane carries the launchers, so the strip
+          would just be an empty bar — it appears with the first tab. */}
+      {sessions.length > 0 && (
+      <div className="lane-tabs">
+        <div className="lt-scroll" ref={tabsRef}>
+          {sessions.map((s) => (
+            <span
+              key={s.id}
+              className={"lt" + (s.id === active?.id ? " on" : "") + (s.running ? "" : " ended")}
+              title={`${s.title}${s.running ? "" : " — ended"}`}
+              onClick={() => setActiveTerm(wt.wtKey, s.id)}
+              onAuxClick={(e) => {
+                if (e.button === 1) closeSession(s.id); // middle-click closes, as in an editor
+              }}
+            >
+              {s.kind === "agent" ? <Sparkle size={11} /> : <TerminalIcon size={11} />}
+              <span className="lt-n">{s.title}</span>
+              <span className={"lt-d" + (s.running ? " live" : "")} />
+              <span
+                className="lt-x"
+                title="Close tab"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  closeSession(s.id);
+                }}
+              >
+                <X size={11} />
+              </span>
+            </span>
+          ))}
         </div>
+        <div className="lt-add" ref={addRef}>
+          <button className="ib" title="New agent or shell" onClick={() => setAddOpen((v) => !v)}>
+            <Plus size={15} />
+          </button>
+          {addOpen && (
+            <div className="lt-menu">
+              <div className="lt-menu-h">Coding agents</div>
+              {agents.map((a) => (
+                <button key={a.id} onClick={() => startAgent(a)}>
+                  <Sparkle size={12} />
+                  {a.name}
+                </button>
+              ))}
+              <div className="lt-menu-sep" />
+              <button onClick={startShell}>
+                <TerminalIcon size={12} />
+                Shell
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
       )}
 
       <div className="lane-body">
         <div className="term">
-          <div className={"term-body" + (tab === "agent" ? "" : " hidden")}>
-            {detached.has(agentId) ? (
-              <DetachedPlaceholder onBack={() => bringBack(agentId)} />
-            ) : agentState === "running" ? (
-              <TerminalPane termId={agentId} cwd={wt.path} hidden={tab !== "agent"} command={agentCmd ?? undefined} />
-            ) : (
-              <AgentIdle onStart={startAgent} />
-            )}
-          </div>
-          {shellActivated.current && (
-            <div className={"term-body" + (tab === "shell" ? "" : " hidden")}>
-              {detached.has(shellId) ? (
-                <DetachedPlaceholder onBack={() => bringBack(shellId)} />
-              ) : (
-                <TerminalPane termId={shellId} cwd={wt.path} hidden={tab !== "shell"} />
-              )}
+          {sessions.length === 0 ? (
+            <div className="term-body">
+              <LaneIdle agents={agents} onAgent={startAgent} onShell={startShell} />
             </div>
+          ) : (
+            sessions.map((s) => {
+              const on = s.id === active?.id;
+              return (
+                <div className={"term-body" + (on ? "" : " hidden")} key={s.id}>
+                  {detached.has(s.id) ? (
+                    <DetachedPlaceholder onBack={() => bringBack(s.id)} />
+                  ) : s.running || rendered.current.has(s.id) ? (
+                    // `gen` in the key forces a full remount on restart, which is
+                    // what re-creates the PTY under the same id.
+                    <TerminalPane key={s.gen} termId={s.id} cwd={wt.path} hidden={!on} command={s.command} />
+                  ) : (
+                    <EndedPlaceholder session={s} onRestart={() => restartSession(s.id)} onClose={() => closeSession(s.id)} />
+                  )}
+                </div>
+              );
+            })
           )}
         </div>
       </div>
 
       <div className="lane-foot">
-        {agentState === "running" ? (
+        {active?.running ? (
           <span className="agent-live" style={{ flex: 1 }}>
-            <Spinner size={12} />
-            Agent working
+            {active.kind === "agent" ? <Spinner size={12} /> : <TerminalIcon size={12} />}
+            {active.kind === "agent" ? `${active.title} working` : `${active.title} running`}
             <span className="grow" />
-            <button className="stopx" title="Stop agent" onClick={stopAgent}>
+            <button className="stopx" title={`Stop ${active.title}`} onClick={() => stopSession(active.id)}>
               <X size={12} />
             </button>
           </span>
+        ) : active ? (
+          <>
+            <button className="btn-sm" style={{ flex: 1, justifyContent: "center" }} onClick={() => restartSession(active.id)}>
+              <Play size={13} />
+              Restart {active.title}
+            </button>
+            <button className="btn-sm" title="Close tab" onClick={() => closeSession(active.id)}>
+              <X size={13} />
+            </button>
+          </>
         ) : (
-          <button className="startagent" style={{ flex: 1, justifyContent: "center", height: 30 }} onClick={startAgent}>
+          <button
+            className="startagent"
+            style={{ flex: 1, justifyContent: "center", height: 30 }}
+            onClick={() => agents[0] && startAgent(agents[0])}
+          >
             <Sparkle size={13} />
-            Start agent
+            Start {agents[0]?.name || "agent"}
             <span className="ar">▸</span>
           </button>
         )}
@@ -452,8 +634,10 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
         <ContextEditor
           ctx={ctx}
           setCtx={setCtx}
+          runtime={runtime}
+          wtKey={wt.wtKey}
           onClose={() => setCtxOpen(false)}
-          onSeed={startAgent}
+          onSeed={() => agents[0] && startAgent(agents[0])}
           onToast={showToast}
         />
       )}

--- a/src/app/DetachedTerminal.tsx
+++ b/src/app/DetachedTerminal.tsx
@@ -5,7 +5,22 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import { Fork, PopIn, Terminal as TerminalIcon } from "../icons";
 import TerminalPane from "./TerminalPane";
 
-export default function DetachedTerminal({ termId, cwd, branch }: { termId: string; cwd: string; branch: string }) {
+export default function DetachedTerminal({
+  termId,
+  cwd,
+  branch,
+  title = "Terminal",
+  command,
+}: {
+  termId: string;
+  cwd: string;
+  branch: string;
+  /** the lane tab's label, so several detached windows stay tellable apart */
+  title?: string;
+  /** the agent command, used only if this window creates the PTY (attaching to
+      an existing session ignores it — `terminal_open` is idempotent) */
+  command?: string;
+}) {
   const back = () => getCurrentWindow().close();
   return (
     <div className="detwin-body">
@@ -14,7 +29,7 @@ export default function DetachedTerminal({ termId, cwd, branch }: { termId: stri
           <span className="fork">
             <TerminalIcon size={13} />
           </span>
-          Terminal
+          {title}
           <span className="br">— {branch}</span>
         </span>
         <span className="grow" data-tauri-drag-region />
@@ -24,7 +39,7 @@ export default function DetachedTerminal({ termId, cwd, branch }: { termId: stri
       </div>
       <div className="term" style={{ flex: 1, minHeight: 0 }}>
         <div className="term-body">
-          <TerminalPane termId={termId} cwd={cwd} />
+          <TerminalPane termId={termId} cwd={cwd} command={command} />
         </div>
       </div>
       <div className="lane-foot" style={{ justifyContent: "flex-end" }}>

--- a/src/app/NewWorktreeModal.tsx
+++ b/src/app/NewWorktreeModal.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { hasBackend, ipc } from "../ipc";
 import { useStore } from "../store";
+import { seedWtContext } from "./WorktreeContext";
 import { Fork, Refresh, Search, Spinner } from "../icons";
 
 interface OpEvent {
@@ -114,6 +115,10 @@ export default function NewWorktreeModal({ repoId, onClose }: { repoId: string; 
   const [fetching, setFetching] = useState(false);
   const [progress, setProgress] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [pr, setPr] = useState("");
+  const [prDescription, setPrDescription] = useState("");
+  const [issue, setIssue] = useState("");
+  const [issueDescription, setIssueDescription] = useState("");
 
   const localItems: BranchItem[] = branches.local.map((b) => ({ name: b, kind: "local" as const }));
   const remoteItems: BranchItem[] = branches.remote.map((b) => ({ name: b, kind: "remote" as const }));
@@ -187,6 +192,9 @@ export default function NewWorktreeModal({ repoId, onClose }: { repoId: string; 
         return;
       }
       const wtPath = await ipc.createWorktree({ repoId: repo, ...payload });
+      // The runtime details (ports/database) are derived from the authoritative
+      // tree after creation; seed the human handoff now, keyed by the new path.
+      seedWtContext(wtPath, { title: payload.branch, pr, prDescription, issue, issueDescription });
       showToast(`Worktree ready — ${payload.branch}`);
       select(wtPath);
       onClose();
@@ -273,6 +281,16 @@ export default function NewWorktreeModal({ repoId, onClose }: { repoId: string; 
               placeholder="search branches and tags…"
             />
           )}
+
+          <details className="handoff-fields">
+            <summary>Agent handoff <span>optional PR / issue context</span></summary>
+            <label className="set-label">Pull request</label>
+            <input className="set-input" value={pr} placeholder="https://github.com/org/repo/pull/123" onChange={(e) => setPr(e.target.value)} disabled={busy} />
+            <textarea className="set-input handoff-desc" value={prDescription} placeholder="What the PR changes or needs reviewed" onChange={(e) => setPrDescription(e.target.value)} disabled={busy} />
+            <label className="set-label">Issue</label>
+            <input className="set-input" value={issue} placeholder="https://github.com/org/repo/issues/123" onChange={(e) => setIssue(e.target.value)} disabled={busy} />
+            <textarea className="set-input handoff-desc" value={issueDescription} placeholder="Problem, acceptance criteria, and constraints" onChange={(e) => setIssueDescription(e.target.value)} disabled={busy} />
+          </details>
 
           {busy && (
             <div className="modal-progress">

--- a/src/app/SettingsView.tsx
+++ b/src/app/SettingsView.tsx
@@ -9,6 +9,7 @@ import {
   ipc,
   type ProvisionEntry,
   type ProvisionFormat,
+  type AgentCfg,
   type RepoCfg,
   type ServiceCfg,
   type Settings,
@@ -30,6 +31,28 @@ const uid = (p: string) => `${p}-${++_uid}`;
 
 function emptyService(): ServiceCfg {
   return { id: "", name: "", kind: "server", command: "", cwd: "", basePort: null, env: {} };
+}
+
+let agentSeq = 0;
+function emptyAgent(): AgentCfg {
+  // ids only need to be stable and unique within the repo — they key React rows
+  // and let the lane remember which profile a running tab came from.
+  return { id: `agent-${Date.now().toString(36)}-${agentSeq++}`, name: "", command: "", promptOnLaunch: true };
+}
+
+/** One-click starting points; the command is still fully editable afterwards. */
+const PRESET_AGENTS = [
+  { name: "Claude", command: "claude" },
+  { name: "Codex", command: "codex" },
+  { name: "Gemini", command: "gemini" },
+];
+
+/** Fold a pre-multi-agent `agentCommand` into the agents list so the editor has
+    exactly one representation to work with. The legacy field is left in place
+    for older builds reading the same settings file. */
+function migrateAgents(r: RepoCfg): RepoCfg {
+  if (r.agents?.length || !r.agentCommand?.trim()) return { ...r, agents: r.agents ?? [] };
+  return { ...r, agents: [{ ...emptyAgent(), name: "Agent", command: r.agentCommand.trim() }] };
 }
 
 /* ── client-side provision model (adds stable ids for React keys) ── */
@@ -211,11 +234,12 @@ function FileCard({ card, patch, remove }: { card: FileCardT; patch: (c: FileCar
   );
 }
 
-type TabId = "general" | "services" | "commands" | "files" | "setup";
+type TabId = "general" | "services" | "agents" | "commands" | "files" | "setup";
 
 export default function SettingsView({ onClose }: { onClose: () => void }) {
   const showToast = useStore((s) => s.showToast);
   const tree = useStore((s) => s.tree);
+  const bumpSettings = useStore((s) => s.bumpSettings);
   const [settings, setSettings] = useState<Settings | null>(null);
   const [saving, setSaving] = useState(false);
   const [selected, setSelected] = useState<string>("app"); // "app" or repo.id
@@ -238,7 +262,7 @@ export default function SettingsView({ onClose }: { onClose: () => void }) {
     ipc
       .getSettings()
       .then((s) => {
-        setSettings(s);
+        setSettings({ ...s, repos: s.repos.map(migrateAgents) });
         if (s.repos[0]) setSelected(s.repos[0].id);
         s.repos.forEach((r) => {
           ipc
@@ -304,6 +328,7 @@ export default function SettingsView({ onClose }: { onClose: () => void }) {
         ...r,
         services: r.services.filter((s) => s.id.trim() && s.command.trim()),
         customCommands: (r.customCommands || []).filter((c) => c.label.trim() && c.command.trim()),
+        agents: (r.agents || []).filter((a) => a.id.trim() && a.name.trim() && a.command.trim()),
       })),
     };
     setSaving(true);
@@ -329,6 +354,7 @@ export default function SettingsView({ onClose }: { onClose: () => void }) {
           return; // keep the view open so nothing is silently lost
         }
       }
+      bumpSettings(); // the agent lane re-reads its launcher list off this
       showToast("Settings saved");
       onClose();
     } catch (e) {
@@ -403,6 +429,7 @@ export default function SettingsView({ onClose }: { onClose: () => void }) {
   const TABS: { id: TabId; label: string; ic: typeof Cog; count?: number; isNew?: boolean }[] = [
     { id: "general", label: "General", ic: Cog },
     { id: "services", label: "Services", ic: Server, count: repo?.services.length },
+    { id: "agents", label: "Agents", ic: Sparkle, count: repo?.agents?.length, isNew: true },
     { id: "commands", label: "Commands", ic: Terminal, count: repo?.customCommands?.length },
     { id: "files", label: "Files", ic: File, count: cards.length, isNew: true },
     { id: "setup", label: "Setup", ic: Cube, count: setup.length },
@@ -633,16 +660,87 @@ export default function SettingsView({ onClose }: { onClose: () => void }) {
                     </div>
                     <div className="cfg-row">
                       <label className="fld-label">
-                        <Sparkle size={12} /> Agent command
+                        <Sparkle size={12} /> Coding agents
                       </label>
-                      <input
-                        className="input mono"
-                        value={repo.agentCommand || ""}
-                        placeholder="claude (also: aider, codex, gemini…)"
-                        onChange={(e) => patchRepo({ agentCommand: e.target.value })}
-                      />
+                      <span className="cfg-xref">
+                        {repo.agents?.length
+                          ? `${repo.agents.length} configured — ${repo.agents.map((a) => a.name || "unnamed").join(", ")}`
+                          : "None configured yet — the lane falls back to claude."}
+                        <button className="btn sm ghost" onClick={() => setTab("agents")}>
+                          <Sparkle size={13} /> Manage agents
+                        </button>
+                      </span>
                     </div>
                   </div>
+                </div>
+              )}
+
+              {tab === "agents" && (
+                <div className="rd-pane">
+                  <div className="pane-title">
+                    <div>
+                      <h3>
+                        Coding agents <span className="newpill">NEW</span>
+                      </h3>
+                      <p>
+                        Launchers in the agent lane's <b>+</b> menu — run as many at once as you like, each in its own tab. Commands run in the
+                        worktree with <span className="mono">$CANOPY_CONTEXT_FILE</span> exported.
+                      </p>
+                    </div>
+                    <div className="pane-actions">
+                      {PRESET_AGENTS.map((p) => (
+                        <button
+                          key={p.name}
+                          className="btn sm ghost"
+                          title={`Add ${p.name} (${p.command})`}
+                          onClick={() => patchRepo({ agents: [...(repo.agents || []), { ...emptyAgent(), ...p }] })}
+                        >
+                          <Plus size={13} />
+                          {p.name}
+                        </button>
+                      ))}
+                      <button className="btn sm primary" onClick={() => patchRepo({ agents: [...(repo.agents || []), emptyAgent()] })}>
+                        <Plus size={13} />
+                        Add agent
+                      </button>
+                    </div>
+                  </div>
+                  {(repo.agents || []).length === 0 ? (
+                    <div className="empty">
+                      <span>
+                        No agents configured — the lane falls back to <code>claude</code>. Add one above, or e.g. <code>Codex</code> ={" "}
+                        <code>codex</code>.
+                      </span>
+                    </div>
+                  ) : (
+                    <div className="set-svc-table">
+                      {(repo.agents || []).map((a, ai) => {
+                        const cur = repo.agents || [];
+                        const upd = (p: Partial<AgentCfg>) => patchRepo({ agents: cur.map((x, i) => (i === ai ? { ...x, ...p } : x)) });
+                        return (
+                          <div className="agent-row" key={a.id || ai}>
+                            <span className="ag-ic">
+                              <Sparkle size={13} />
+                            </span>
+                            <input className="input" value={a.name} placeholder="Claude" onChange={(e) => upd({ name: e.target.value })} />
+                            <input
+                              className="input mono"
+                              value={a.command}
+                              placeholder="claude --permission-mode acceptEdits"
+                              onChange={(e) => upd({ command: e.target.value })}
+                            />
+                            <label className="set-check compact" title="Pass the worktree handoff (task, PR, issue, ports, database) as the CLI's first prompt argument">
+                              <input type="checkbox" checked={a.promptOnLaunch !== false} onChange={(e) => upd({ promptOnLaunch: e.target.checked })} />
+                              Send prompt
+                            </label>
+                            <button className="del" title="Remove agent" onClick={() => patchRepo({ agents: cur.filter((_, i) => i !== ai) })}>
+                              ✕
+                            </button>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
                 </div>
               )}
 

--- a/src/app/SettingsView.tsx
+++ b/src/app/SettingsView.tsx
@@ -324,12 +324,20 @@ export default function SettingsView({ onClose }: { onClose: () => void }) {
     if (!settings) return;
     const cleaned: Settings = {
       ...settings,
-      repos: settings.repos.map((r) => ({
-        ...r,
-        services: r.services.filter((s) => s.id.trim() && s.command.trim()),
-        customCommands: (r.customCommands || []).filter((c) => c.label.trim() && c.command.trim()),
-        agents: (r.agents || []).filter((a) => a.id.trim() && a.name.trim() && a.command.trim()),
-      })),
+      repos: settings.repos.map((r) => {
+        const agents = (r.agents || []).filter((a) => a.id.trim() && a.name.trim() && a.command.trim());
+        return {
+          ...r,
+          services: r.services.filter((s) => s.id.trim() && s.command.trim()),
+          customCommands: (r.customCommands || []).filter((c) => c.label.trim() && c.command.trim()),
+          agents,
+          // Keep the legacy field in step with the list it was migrated into.
+          // Left stale, deleting the migrated profile would leave the old command
+          // behind, and the lane — which falls back to it when the list is empty —
+          // would keep launching an agent the settings UI no longer shows.
+          agentCommand: agents[0]?.command ?? "",
+        };
+      }),
     };
     setSaving(true);
     try {

--- a/src/app/Sidebar.tsx
+++ b/src/app/Sidebar.tsx
@@ -8,7 +8,7 @@ export default function Sidebar({ onAdd, onRemove }: { onAdd: () => void; onRemo
   const setQuery = useStore((s) => s.setQuery);
   const selKey = useStore((s) => s.selKey);
   const select = useStore((s) => s.select);
-  const agents = useStore((s) => s.agents);
+  const sessions = useStore((s) => s.sessions);
 
   const q = query.toLowerCase();
   const total = tree.reduce((n, r) => n + r.worktrees.length, 0);
@@ -45,7 +45,7 @@ export default function Sidebar({ onAdd, onRemove }: { onAdd: () => void; onRemo
                 const running = w.services.filter((s) => isLive(s.status)).length;
                 const dot = running === 0 ? "off" : running === tcount ? "on" : "part";
                 const statusText = running > 0 ? `${running} running` : "idle";
-                const agent = agents[w.wtKey] ?? "off";
+                const liveAgents = (sessions[w.wtKey] ?? []).filter((s) => s.kind === "agent" && s.running).length;
                 return (
                   <button
                     key={w.wtKey}
@@ -57,9 +57,10 @@ export default function Sidebar({ onAdd, onRemove }: { onAdd: () => void; onRemo
                       <div className="b">{w.branch}</div>
                       <div className="r">{statusText}</div>
                     </span>
-                    {agent === "running" && (
-                      <span className="ag-pip busy" title="Agent working">
+                    {liveAgents > 0 && (
+                      <span className="ag-pip busy" title={`${liveAgents} agent${liveAgents > 1 ? "s" : ""} working`}>
                         <Sparkle size={10} />
+                        {liveAgents > 1 && <b className="ag-n">{liveAgents}</b>}
                       </span>
                     )}
                     {!w.isMain && onRemove && (

--- a/src/app/TerminalPane.tsx
+++ b/src/app/TerminalPane.tsx
@@ -11,6 +11,7 @@ import { FitAddon } from "@xterm/addon-fit";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { hasBackend, ipc, on } from "../ipc";
+import { useStore } from "../store";
 
 /** Open a URL in the user's browser (never in the app's own webview). */
 async function openExternal(url: string) {
@@ -107,9 +108,11 @@ export default function TerminalPane({
 
     // http(s) links → the user's browser, never this webview.
     term.loadAddon(
+      // failures surface as a toast, not by writing into the buffer — that
+      // would read as output from the process and pollute copied scrollback
       new WebLinksAddon((event, uri) => {
         event?.preventDefault();
-        openExternal(uri).catch((e) => term.write(`\r\n\x1b[31mcouldn't open link: ${String(e)}\x1b[0m\r\n`));
+        openExternal(uri).catch((e) => useStore.getState().showToast(`Couldn't open link — ${String(e)}`));
       }),
     );
 
@@ -134,7 +137,7 @@ export default function TerminalPane({
               event?.preventDefault();
               // the :line:col tail is dropped — the editor command takes a path
               ipc.openFileInEditor(cwd, path).catch((e) => {
-                term.write(`\r\n\x1b[31mcouldn't open ${path}: ${String(e)}\x1b[0m\r\n`);
+                useStore.getState().showToast(`Couldn't open ${path} — ${String(e)}`);
               });
             },
           });

--- a/src/app/TerminalPane.tsx
+++ b/src/app/TerminalPane.tsx
@@ -69,6 +69,7 @@ export default function TerminalPane({
   cwd,
   hidden,
   command,
+  readOnly,
 }: {
   termId: string;
   cwd: string;
@@ -76,6 +77,10 @@ export default function TerminalPane({
   /** run this command instead of an interactive shell; the session ends (fires
       terminal:exit) when it exits — used to track agent lifecycle */
   command?: string;
+  /** Show a finished session's retained output without opening a PTY. Opening
+      one here would re-run `command`, which is exactly what the user didn't
+      ask for; input is swallowed since there's nothing to write to. */
+  readOnly?: boolean;
 }) {
   const hostRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<Terminal | null>(null);
@@ -183,7 +188,7 @@ export default function TerminalPane({
 
     // keystrokes (and terminal reports) → PTY. The PTY echoes; no local echo.
     const onDataDisp = term.onData((data) => {
-      if (suppressOut) return;
+      if (suppressOut || readOnly) return;
       ipc.terminalWrite(termId, data).catch(() => {});
     });
 
@@ -208,7 +213,9 @@ export default function TerminalPane({
       unlistenExit = u2;
 
       try {
-        await ipc.terminalOpen(termId, cwd, term.cols, term.rows, command);
+        // read-only replays a finished session's retained buffer; opening would
+        // spawn a process the user didn't ask to restart
+        if (!readOnly) await ipc.terminalOpen(termId, cwd, term.cols, term.rows, command);
         const snap = await ipc.terminalGetBuffer(termId);
         if (disposed || !termRef.current) return;
         const baseline = snap?.seq ?? 0;
@@ -230,7 +237,7 @@ export default function TerminalPane({
     const ro = new ResizeObserver(() => {
       if (hidden || !host.clientWidth || !host.clientHeight) return;
       safeFit();
-      ipc.terminalResize(termId, term.cols, term.rows).catch(() => {});
+      if (!readOnly) ipc.terminalResize(termId, term.cols, term.rows).catch(() => {});
     });
     ro.observe(host);
 
@@ -246,7 +253,7 @@ export default function TerminalPane({
       fitRef.current = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [termId, cwd, command]);
+  }, [termId, cwd, command, readOnly]);
 
   // re-fit when the pane becomes visible (tab toggle) or the lane resizes
   useEffect(() => {

--- a/src/app/TerminalPane.tsx
+++ b/src/app/TerminalPane.tsx
@@ -6,10 +6,27 @@
 // running — switching worktrees or toggling the Agent/Shell tab keeps the shell
 // (and any agent in it) alive; we rehydrate from the backend buffer on return.
 import { useEffect, useRef } from "react";
-import { Terminal } from "@xterm/xterm";
+import { Terminal, type IBufferLine, type ILink } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebglAddon } from "@xterm/addon-webgl";
+import { WebLinksAddon } from "@xterm/addon-web-links";
 import { hasBackend, ipc, on } from "../ipc";
+
+/** Open a URL in the user's browser (never in the app's own webview). */
+async function openExternal(url: string) {
+  if (!hasBackend()) {
+    window.open(url, "_blank", "noopener");
+    return;
+  }
+  const { openUrl } = await import("@tauri-apps/plugin-opener");
+  await openUrl(url);
+}
+
+// File paths as build tools and agents print them: `src/app/Foo.tsx:12:3`,
+// `./x/y.ts`, `/abs/path.rs`. Requires a slash and an extension so ordinary
+// prose ("2:30", "v1.2") isn't turned into a link. The optional :line:col tail
+// is captured so it can be stripped before the path is resolved.
+const FILE_RE = /(?:^|[\s"'`([<])((?:\.{0,2}\/)?(?:[\w.@~+-]+\/)+[\w.@+-]+\.\w{1,8})((?::\d+){0,2})/g;
 
 /** base64 (raw PTY bytes) → Uint8Array for xterm.write */
 function decode(b64: string): Uint8Array {
@@ -25,8 +42,25 @@ const THEME = {
   cursor: "#5cc7cd", // --accent
   cursorAccent: "#191a1d",
   selectionBackground: "rgba(92,199,205,.25)",
+  // Keep the terminal's ANSI colors explicit. Supplying only black/brightBlack
+  // lets renderer/platform defaults vary, which made colored CLI output appear
+  // monochrome after the lane theme was introduced.
   black: "#191a1d",
+  red: "#f07178",
+  green: "#7bd88f",
+  yellow: "#f5c76b",
+  blue: "#82aaff",
+  magenta: "#c792ea",
+  cyan: "#5cc7cd",
+  white: "#cfd1d6",
   brightBlack: "#7c7e86",
+  brightRed: "#ff8f91",
+  brightGreen: "#a6e3a1",
+  brightYellow: "#ffd580",
+  brightBlue: "#9cc3ff",
+  brightMagenta: "#e0b7ff",
+  brightCyan: "#8ae7eb",
+  brightWhite: "#f4f5f7",
 };
 
 export default function TerminalPane({
@@ -70,6 +104,44 @@ export default function TerminalPane({
     term.open(host);
     termRef.current = term;
     fitRef.current = fit;
+
+    // http(s) links → the user's browser, never this webview.
+    term.loadAddon(
+      new WebLinksAddon((event, uri) => {
+        event?.preventDefault();
+        openExternal(uri).catch((e) => term.write(`\r\n\x1b[31mcouldn't open link: ${String(e)}\x1b[0m\r\n`));
+      }),
+    );
+
+    // File paths → the configured editor. The backend resolves them against the
+    // worktree root and refuses anything that escapes it, so a path printed by
+    // some arbitrary process can't be used to open a file elsewhere on disk.
+    const fileLinks = term.registerLinkProvider({
+      provideLinks(y, cb) {
+        const line: IBufferLine | undefined = term.buffer.active.getLine(y - 1);
+        if (!line) return cb(undefined);
+        const text = line.translateToString(true);
+        const links: ILink[] = [];
+        for (const m of text.matchAll(FILE_RE)) {
+          const path = m[1];
+          // m.index points at the leading delimiter (if any), not the path
+          const start = (m.index ?? 0) + m[0].length - path.length - m[2].length;
+          links.push({
+            // xterm columns are 1-based and ranges are inclusive
+            range: { start: { x: start + 1, y }, end: { x: start + path.length + m[2].length, y } },
+            text: path + m[2],
+            activate: (event) => {
+              event?.preventDefault();
+              // the :line:col tail is dropped — the editor command takes a path
+              ipc.openFileInEditor(cwd, path).catch((e) => {
+                term.write(`\r\n\x1b[31mcouldn't open ${path}: ${String(e)}\x1b[0m\r\n`);
+              });
+            },
+          });
+        }
+        cb(links.length ? links : undefined);
+      },
+    });
 
     // GPU rendering — far faster under heavy output. Fall back to the DOM
     // renderer if WebGL is unavailable or its context is lost.
@@ -163,6 +235,7 @@ export default function TerminalPane({
       disposed = true;
       unlistenData?.();
       unlistenExit?.();
+      fileLinks.dispose();
       onDataDisp.dispose();
       ro.disconnect();
       term.dispose();

--- a/src/app/WorktreeContext.tsx
+++ b/src/app/WorktreeContext.tsx
@@ -3,8 +3,9 @@
 // wtKey). Whether this should instead live as a committed `.canopy/context.md`
 // that travels with the branch is an open product question — see the handoff.
 import { Fragment, useEffect, useState, type ReactNode } from "react";
-import { Chevron, Copy, Doc, Info, Link as LinkIcon, Plus, Sparkle } from "../icons";
-import { hasBackend } from "../ipc";
+import { Chevron, Copy, Doc, File, Info, Link as LinkIcon, Plus, Sparkle } from "../icons";
+import { hasBackend, ipc } from "../ipc";
+import type { RepoNode, WorktreeNode } from "../types";
 
 const isUrl = (s: string) => /^https?:\/\//i.test(s.trim());
 
@@ -34,9 +35,32 @@ export interface WtContext {
   title: string;
   body: string;
   links: { label: string; kind: string }[];
+  files: string[];
+  pr: string;
+  prDescription: string;
+  issue: string;
+  issueDescription: string;
 }
 
-const EMPTY: WtContext = { title: "", body: "", links: [] };
+const EMPTY: WtContext = { title: "", body: "", links: [], files: [], pr: "", prDescription: "", issue: "", issueDescription: "" };
+
+export interface WorktreeRuntime {
+  repo: string;
+  branch: string;
+  path: string;
+  dbName: string | null;
+  ports: { name: string; port: number }[];
+}
+
+export function runtimeFor(repo: RepoNode, wt: WorktreeNode): WorktreeRuntime {
+  return {
+    repo: repo.name,
+    branch: wt.branch,
+    path: wt.path,
+    dbName: wt.dbName,
+    ports: wt.services.flatMap((s) => (s.port == null ? [] : [{ name: s.name, port: s.port }])),
+  };
+}
 
 function load(key: string): WtContext {
   try {
@@ -64,13 +88,39 @@ export function useWtContext(wtKey: string): [WtContext, (c: WtContext) => void]
   return [ctx, update];
 }
 
-export const isBlank = (c: WtContext) => !c.title.trim() && !c.body.trim() && c.links.length === 0;
+/** Seed a newly-created worktree before it is first opened in the lane. */
+export function seedWtContext(wtKey: string, partial: Partial<WtContext>) {
+  const next = { ...EMPTY, ...partial };
+  try {
+    localStorage.setItem(`canopy.ctx.${wtKey}`, JSON.stringify(next));
+  } catch {
+    /* local storage is an enhancement, not a creation dependency */
+  }
+}
+
+export const isBlank = (c: WtContext) =>
+  !c.title.trim() && !c.body.trim() && !c.pr.trim() && !c.prDescription.trim() && !c.issue.trim() && !c.issueDescription.trim() && c.links.length === 0 && c.files.length === 0;
 
 /** Render the context as the markdown seed written to `.canopy/context.md`. */
-export function composeContextMd(c: WtContext): string {
+export function composeContextMd(c: WtContext, runtime?: WorktreeRuntime): string {
   let md = `# ${c.title.trim() || "Untitled"}\n\n${c.body.trim()}\n`;
+  if (c.pr.trim() || c.prDescription.trim()) md += `\n## Pull request\n${c.pr.trim() ? `${c.pr.trim()}\n` : ""}${c.prDescription.trim()}\n`;
+  if (c.issue.trim() || c.issueDescription.trim()) md += `\n## Issue\n${c.issue.trim() ? `${c.issue.trim()}\n` : ""}${c.issueDescription.trim()}\n`;
+  if (runtime) {
+    md += `\n## Worktree\n- Repository: ${runtime.repo}\n- Branch: ${runtime.branch}\n- Path: ${runtime.path}\n`;
+    md += `- Database: ${runtime.dbName || "not configured"}\n`;
+    md += runtime.ports.length ? `- Ports: ${runtime.ports.map((p) => `${p.name} :${p.port}`).join(", ")}\n` : "- Ports: none configured\n";
+  }
+  if (c.files.length) md += "\n## Files\n" + c.files.map((f) => `- ${f}`).join("\n") + "\n";
   if (c.links.length) md += "\n## Links\n" + c.links.map((l) => `- ${l.label}`).join("\n") + "\n";
   return md;
+}
+
+/** The compact message passed to an agent at launch; the complete handoff is
+ * on disk so agents that support rich prompts can read it without truncation. */
+export function composeAgentPrompt(c: WtContext, runtime: WorktreeRuntime): string {
+  const focus = c.title.trim() || c.issueDescription.trim() || c.prDescription.trim() || c.body.trim() || "the assigned worktree task";
+  return `Work on ${focus}. Read the complete Canopy handoff at ${runtime.path}/.canopy/context.md before making changes. Worktree: ${runtime.repo}/${runtime.branch}; database: ${runtime.dbName || "not configured"}; ports: ${runtime.ports.map((p) => `${p.name}:${p.port}`).join(", ") || "none"}.`;
 }
 
 /** Plain-text one-liner of the markdown body, for the lane summary preview. */
@@ -119,17 +169,31 @@ export function mdRender(src: string): ReactNode[] {
 export function ContextEditor({
   ctx,
   setCtx,
+  runtime,
+  wtKey,
   onClose,
   onSeed,
   onToast,
 }: {
   ctx: WtContext;
   setCtx: (c: WtContext) => void;
+  runtime: WorktreeRuntime;
+  wtKey: string;
   onClose: () => void;
   onSeed: () => void;
   onToast: (m: string) => void;
 }) {
   const [tab, setTab] = useState<"write" | "prev">("write");
+  const resourceClick = (kind: "link" | "file", value: string, e: React.MouseEvent) => {
+    if (!e.metaKey && !e.ctrlKey) return;
+    e.preventDefault();
+    if (kind === "link") {
+      if (isUrl(value)) openLink(value, onToast);
+      else onToast("That resource is not a browser link");
+    } else if (hasBackend()) {
+      ipc.openFileInEditor(wtKey, value).catch((err) => onToast(`Couldn't open file — ${String(err)}`));
+    } else onToast("Opening files needs the desktop app");
+  };
   return (
     <div className="ctx-scrim" onMouseDown={onClose}>
       <div className="ctx-modal" onMouseDown={(e) => e.stopPropagation()}>
@@ -162,6 +226,15 @@ export function ContextEditor({
             onChange={(e) => setCtx({ ...ctx, title: e.target.value })}
           />
 
+          <div className="ctx-references">
+            <label>Pull request</label>
+            <input value={ctx.pr} placeholder="https://github.com/org/repo/pull/123" onChange={(e) => setCtx({ ...ctx, pr: e.target.value })} />
+            <textarea value={ctx.prDescription} placeholder="What the PR changes / what to verify" onChange={(e) => setCtx({ ...ctx, prDescription: e.target.value })} />
+            <label>Issue</label>
+            <input value={ctx.issue} placeholder="https://github.com/org/repo/issues/123" onChange={(e) => setCtx({ ...ctx, issue: e.target.value })} />
+            <textarea value={ctx.issueDescription} placeholder="Problem, acceptance criteria, and constraints" onChange={(e) => setCtx({ ...ctx, issueDescription: e.target.value })} />
+          </div>
+
           {tab === "write" ? (
             <textarea
               className="ctx-md"
@@ -175,14 +248,20 @@ export function ContextEditor({
           )}
 
           <div className="ctx-links">
+            {ctx.pr.trim() && <span className="ctx-link" title="Cmd/Ctrl-click to open in browser" onClick={(e) => resourceClick("link", ctx.pr, e)}><LinkIcon size={11} /> PR</span>}
+            {ctx.issue.trim() && <span className="ctx-link" title="Cmd/Ctrl-click to open in browser" onClick={(e) => resourceClick("link", ctx.issue, e)}><LinkIcon size={11} /> Issue</span>}
+            {ctx.files.map((file) => (
+              <span className="ctx-link" key={file} title="Cmd/Ctrl-click to open in your selected editor" onClick={(e) => resourceClick("file", file, e)}>
+                <File size={11} />{file}
+              </span>
+            ))}
             {ctx.links.map((l) => {
-              const url = isUrl(l.label);
               return (
                 <span
                   className="ctx-link"
                   key={l.label}
-                  style={url ? undefined : { cursor: "default" }}
-                  onClick={url ? () => openLink(l.label, onToast) : undefined}
+                  title="Cmd/Ctrl-click to open in browser"
+                  onClick={(e) => resourceClick("link", l.label, e)}
                 >
                   <span className="ic">
                     <LinkIcon size={11} />
@@ -204,6 +283,19 @@ export function ContextEditor({
               <Plus size={11} />
               Add link
             </span>
+            <span className="ctx-link add" onClick={() => {
+              const file = window.prompt("Relative path inside this worktree");
+              if (file?.trim()) setCtx({ ...ctx, files: [...ctx.files, file.trim()] });
+            }}>
+              <Plus size={11} /> Add file
+            </span>
+          </div>
+
+          <div className="ctx-runtime">
+            <b>Worktree environment</b>
+            <span>{runtime.branch}</span>
+            <span>{runtime.dbName || "no database"}</span>
+            {runtime.ports.map((p) => <span key={p.name}>{p.name} :{p.port}</span>)}
           </div>
 
           <div className="ctx-foot">

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -18,6 +18,16 @@ export interface CustomCmd {
   command: string;
 }
 
+/** A coding-agent launcher available for one repository. The command is run
+ * inside the selected worktree; when enabled, Canopy appends its structured
+ * handoff as the command's first prompt argument. */
+export interface AgentCfg {
+  id: string;
+  name: string;
+  command: string;
+  promptOnLaunch: boolean;
+}
+
 export interface RepoCfg {
   id: string;
   name: string;
@@ -29,6 +39,8 @@ export interface RepoCfg {
   customCommands: CustomCmd[];
   /** agent-lane CLI (empty = built-in default) */
   agentCommand: string;
+  /** selectable coding-agent launchers; `agentCommand` remains as legacy data */
+  agents: AgentCfg[];
 }
 
 export interface Settings {
@@ -122,6 +134,7 @@ export const ipc = {
   resetDb: (wtKey: string) => invoke<void>("reset_db", { wtKey }),
 
   openInEditor: (wtKey: string) => invoke<void>("open_in_editor", { wtKey }),
+  openFileInEditor: (wtKey: string, path: string) => invoke<void>("open_file_in_editor", { wtKey, path }),
   revealInFinder: (wtKey: string) => invoke<void>("reveal_in_finder", { wtKey }),
   openTerminal: (wtKey: string) => invoke<void>("open_terminal", { wtKey }),
   openPort: (port: number) => invoke<void>("open_port", { port }),

--- a/src/store.ts
+++ b/src/store.ts
@@ -309,6 +309,17 @@ export const useStore = create<State>((set, get) => {
     },
     restartSession: (id) => {
       sessionStartedAt[id] = Date.now();
+      // A detached tab renders a placeholder inline and its window won't remount
+      // on a `gen` bump, so nothing would actually create the PTY — the tab would
+      // just claim to be running. Re-dock first; the pane then mounts and starts it.
+      if (get().detachedTerms.has(id)) {
+        closeDetachedWindow(id);
+        set((st) => {
+          const detachedTerms = new Set(st.detachedTerms);
+          detachedTerms.delete(id);
+          return { detachedTerms };
+        });
+      }
       set((st) => ({
         sessions: {
           ...st.sessions,

--- a/src/store.ts
+++ b/src/store.ts
@@ -17,6 +17,40 @@ export interface OpLog {
   running: boolean;
 }
 
+/* ── agent-lane sessions ──────────────────────────────────────────────────────
+   A worktree can hold any number of concurrent agent and shell tabs. Each one
+   is a PTY in Rust keyed by `id`; this list is the UI's view of them. It lives
+   in the store (not the lane) so it survives the lane remounting on worktree
+   switch — the PTYs keep running either way. */
+export type LaneKind = "agent" | "shell";
+
+export interface LaneSession {
+  /** backend PTY id — `${wtKey}::agent#3`, `${wtKey}::shell#1` */
+  id: string;
+  wtKey: string;
+  kind: LaneKind;
+  /** tab label: the agent profile's name, or "Shell" / "Shell 2" */
+  title: string;
+  /** repo agent-profile id this was launched from (agent tabs only) */
+  agentId?: string;
+  /** command the PTY was created with; undefined = interactive login shell */
+  command?: string;
+  /** false once the PTY exits — the tab stays so its output can be read/restarted */
+  running: boolean;
+  /** bumped on restart so the pane remounts and creates a fresh PTY */
+  gen: number;
+}
+
+/** Per-worktree id counter. Ids are never reused, so a closed tab's in-flight
+    backend events can't be mistaken for a new session under the same id. */
+const termSeq: Record<string, number> = {};
+export function nextTermId(wtKey: string, kind: LaneKind): string {
+  const n = (termSeq[wtKey] = (termSeq[wtKey] ?? 0) + 1);
+  return `${wtKey}::${kind}#${n}`;
+}
+/** wtKey of a session id (a wtKey is a filesystem path — it has no `::`). */
+const wtOf = (termId: string) => termId.slice(0, termId.lastIndexOf("::"));
+
 interface State {
   tree: RepoNode[];
   logs: Record<string, LogLine[]>;
@@ -30,13 +64,24 @@ interface State {
   query: string;
   tabSvcKey: string | null;
   collapsed: boolean;
-  /** agent-lane run state per worktree (wtKey → state); survives worktree switch */
-  agents: Record<string, "off" | "running">;
-  setAgent: (wtKey: string, state: "off" | "running") => void;
+  /** agent-lane tabs per worktree (wtKey → sessions); survives worktree switch */
+  sessions: Record<string, LaneSession[]>;
+  /** focused tab per worktree (wtKey → session id) */
+  activeTerm: Record<string, string | null>;
+  openSession: (s: Omit<LaneSession, "running" | "gen">) => void;
+  closeSession: (id: string) => void;
+  /** kill the process but keep the tab (its output stays readable) */
+  stopSession: (id: string) => void;
+  restartSession: (id: string) => void;
+  setActiveTerm: (wtKey: string, id: string) => void;
   /** terminal ids currently shown in a detached window — in the store so the
       placeholder survives a lane remount (worktree switch) */
   detachedTerms: Set<string>;
   setTermDetached: (id: string, v: boolean) => void;
+  /** bumped whenever settings are saved, so views holding a cached copy (the
+      agent lane's launcher list) know to re-read them */
+  settingsRev: number;
+  bumpSettings: () => void;
   /** focus mode: the middle pane drops to a rail so the terminal takes the window */
   mainRailed: boolean;
   setMainRailed: (v: boolean) => void;
@@ -90,7 +135,7 @@ export function wtLabel(tree: RepoNode[], wtKey: string): string {
 const timers: Record<string, ReturnType<typeof setTimeout>> = {};
 let toastTimer: ReturnType<typeof setTimeout> | undefined;
 const startedAt: Record<string, number> = {}; // svcKey -> ms epoch
-const agentStartedAt: Record<string, number> = {}; // wtKey -> ms epoch (agent start)
+const sessionStartedAt: Record<string, number> = {}; // term id -> ms epoch (session start)
 const QUICK_EXIT_MS = 2500; // agent gone this fast after start = it never really ran
 
 function appendLogs(svcKey: string, lines: LogLine[]) {
@@ -192,11 +237,54 @@ export const useStore = create<State>((set, get) => {
     query: "",
     tabSvcKey: mock[0]?.worktrees[0]?.services[0]?.svcKey ?? null,
     collapsed: false,
-    agents: {},
-    setAgent: (wtKey, state) => {
-      if (state === "running") agentStartedAt[wtKey] = Date.now();
-      set((st) => ({ agents: { ...st.agents, [wtKey]: state } }));
+    sessions: {},
+    activeTerm: {},
+    openSession: (s) => {
+      sessionStartedAt[s.id] = Date.now();
+      set((st) => ({
+        sessions: { ...st.sessions, [s.wtKey]: [...(st.sessions[s.wtKey] ?? []), { ...s, running: true, gen: 0 }] },
+        activeTerm: { ...st.activeTerm, [s.wtKey]: s.id },
+      }));
     },
+    closeSession: (id) => {
+      const wtKey = wtOf(id);
+      // kill the PTY unconditionally: an "exited" tab may only *look* dead (the
+      // command finished but a re-opened session could still hold the id).
+      if (hasBackend()) ipc.terminalClose(id).catch(() => {});
+      delete sessionStartedAt[id];
+      set((st) => {
+        const prev = st.sessions[wtKey] ?? [];
+        const at = prev.findIndex((s) => s.id === id);
+        const next = prev.filter((s) => s.id !== id);
+        const active = st.activeTerm[wtKey];
+        // focus the neighbour that visually takes the closed tab's place
+        const refocus = active !== id ? active : (next[at] ?? next[at - 1])?.id ?? null;
+        return {
+          sessions: { ...st.sessions, [wtKey]: next },
+          activeTerm: { ...st.activeTerm, [wtKey]: refocus },
+        };
+      });
+    },
+    stopSession: (id) => {
+      // mark first: terminal:exit then knows this was deliberate and stays quiet
+      set((st) => ({
+        sessions: {
+          ...st.sessions,
+          [wtOf(id)]: (st.sessions[wtOf(id)] ?? []).map((s) => (s.id === id ? { ...s, running: false } : s)),
+        },
+      }));
+      if (hasBackend()) ipc.terminalClose(id).catch(() => {});
+    },
+    restartSession: (id) => {
+      sessionStartedAt[id] = Date.now();
+      set((st) => ({
+        sessions: {
+          ...st.sessions,
+          [wtOf(id)]: (st.sessions[wtOf(id)] ?? []).map((s) => (s.id === id ? { ...s, running: true, gen: s.gen + 1 } : s)),
+        },
+      }));
+    },
+    setActiveTerm: (wtKey, id) => set((st) => ({ activeTerm: { ...st.activeTerm, [wtKey]: id } })),
     detachedTerms: new Set(),
     setTermDetached: (id, v) =>
       set((st) => {
@@ -205,6 +293,8 @@ export const useStore = create<State>((set, get) => {
         else next.delete(id);
         return { detachedTerms: next };
       }),
+    settingsRev: 0,
+    bumpSettings: () => set((st) => ({ settingsRev: st.settingsRev + 1 })),
     mainRailed: false,
     setMainRailed: (mainRailed) => set({ mainRailed }),
 
@@ -425,25 +515,28 @@ export function initSync(): () => void {
 
   track(on.worktreeOp((e) => appendOpLine(e.wtKey, e.state, e.detail)));
 
-  // agent lifecycle: the agent runs as its own PTY session (`${wtKey}::agent`),
-  // so its exit is the authoritative "agent stopped" signal.
+  // session lifecycle: every lane tab is its own PTY, so its exit is the
+  // authoritative "this tab stopped" signal. The tab is kept (marked not
+  // running) so its output stays readable and it can be restarted in place.
   track(
     on.terminalExit((e) => {
       // NB: don't clear the detached flag here — terminal:exit means the PTY
       // process ended, not that its window closed (that's the tauri://destroyed
       // handler). Clearing it would re-dock and spawn a new inline shell while
       // the detached window is still open.
-      const suffix = "::agent";
-      if (!e.id.endsWith(suffix)) return;
-      const wtKey = e.id.slice(0, -suffix.length);
-      // "running" here means it wasn't a user-initiated stop (stop sets off first)
-      const wasRunning = useStore.getState().agents[wtKey] === "running";
-      useStore.getState().setAgent(wtKey, "off");
-      if (wasRunning) {
-        const started = agentStartedAt[wtKey];
+      const wtKey = wtOf(e.id);
+      const sess = useStore.getState().sessions[wtKey]?.find((s) => s.id === e.id);
+      if (!sess) return;
+      // still "running" here means it wasn't a user-initiated stop (which marks
+      // the tab first), so a near-instant exit is worth surfacing.
+      if (sess.running && sess.kind === "agent") {
+        const started = sessionStartedAt[e.id];
         if (started && Date.now() - started < QUICK_EXIT_MS)
-          useStore.getState().showToast("Agent exited immediately — check the agent command");
+          useStore.getState().showToast(`${sess.title} exited immediately — check the agent command`);
       }
+      useStore.setState((st) => ({
+        sessions: { ...st.sessions, [wtKey]: (st.sessions[wtKey] ?? []).map((s) => (s.id === e.id ? { ...s, running: false } : s)) },
+      }));
     }),
   );
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -42,14 +42,38 @@ export interface LaneSession {
 }
 
 /** Per-worktree id counter. Ids are never reused, so a closed tab's in-flight
-    backend events can't be mistaken for a new session under the same id. */
+    backend events can't be mistaken for a new session under the same id.
+    The counter is module state, so it restarts at 1 if the webview reloads —
+    but the PTYs it already named live in Rust and survive that. `terminal_open`
+    is idempotent, so without the per-launch nonce a "new" tab could silently
+    attach to a previous run's process instead of launching its own command. */
+const LAUNCH = Date.now().toString(36);
 const termSeq: Record<string, number> = {};
 export function nextTermId(wtKey: string, kind: LaneKind): string {
   const n = (termSeq[wtKey] = (termSeq[wtKey] ?? 0) + 1);
-  return `${wtKey}::${kind}#${n}`;
+  return `${wtKey}::${kind}#${LAUNCH}-${n}`;
 }
 /** wtKey of a session id (a wtKey is a filesystem path — it has no `::`). */
 const wtOf = (termId: string) => termId.slice(0, termId.lastIndexOf("::"));
+
+/** Deterministic, injective window label for a detached terminal (hex of the id's
+    UTF-8 bytes) — a lossy replace could collide two worktrees onto one window. */
+export const laneLabel = (id: string) =>
+  "term-" +
+  Array.from(new TextEncoder().encode(id))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+
+/** Close the detached window showing `id`, if one is open. */
+async function closeDetachedWindow(id: string) {
+  if (!hasBackend()) return;
+  try {
+    const { WebviewWindow } = await import("@tauri-apps/api/webviewWindow");
+    await (await WebviewWindow.getByLabel(laneLabel(id)))?.close();
+  } catch {
+    /* the window is already gone — nothing to close */
+  }
+}
 
 interface State {
   tree: RepoNode[];
@@ -251,6 +275,11 @@ export const useStore = create<State>((set, get) => {
       // kill the PTY unconditionally: an "exited" tab may only *look* dead (the
       // command finished but a re-opened session could still hold the id).
       if (hasBackend()) ipc.terminalClose(id).catch(() => {});
+      // A popped-out tab has to take its window with it. Leaving it open strands
+      // a window attached to a PTY that no longer exists, and the stale
+      // detachedTerms entry would make a later session under this id render as
+      // detached from the moment it starts.
+      if (get().detachedTerms.has(id)) closeDetachedWindow(id);
       delete sessionStartedAt[id];
       set((st) => {
         const prev = st.sessions[wtKey] ?? [];
@@ -259,9 +288,12 @@ export const useStore = create<State>((set, get) => {
         const active = st.activeTerm[wtKey];
         // focus the neighbour that visually takes the closed tab's place
         const refocus = active !== id ? active : (next[at] ?? next[at - 1])?.id ?? null;
+        const detachedTerms = new Set(st.detachedTerms);
+        detachedTerms.delete(id);
         return {
           sessions: { ...st.sessions, [wtKey]: next },
           activeTerm: { ...st.activeTerm, [wtKey]: refocus },
+          detachedTerms,
         };
       });
     },

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2762,3 +2762,47 @@ select.set-input {
 .j-bool {
   color: var(--warn);
 }
+
+/* Agent profiles (Settings → repo → Agents) and the optional handoff on the
+   create-worktree modal. */
+.agent-row {
+  display: grid;
+  grid-template-columns: 26px minmax(90px, 0.8fr) minmax(170px, 2fr) auto 26px;
+  gap: 8px;
+  align-items: center;
+  padding: 7px 9px;
+  border-bottom: 1px solid var(--border-soft);
+}
+.agent-row:last-child {
+  border-bottom: 0;
+}
+.agent-row .ag-ic {
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 7px;
+  background: var(--accent-dim);
+  color: var(--accent);
+}
+.agent-row .input {
+  height: 30px;
+}
+.set-check.compact {
+  font-size: 11px;
+  white-space: nowrap;
+}
+/* a general-tab summary that hands off to the tab which actually owns the data */
+.cfg-xref {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  color: var(--faint);
+  font-size: 11.5px;
+}
+.handoff-fields { border-top: 1px solid var(--border-soft); margin-top: 15px; padding-top: 11px; }
+.handoff-fields summary { cursor: pointer; color: var(--dim); font-size: 12px; font-weight: 600; margin-bottom: 10px; }
+.handoff-fields summary span { color: var(--faint); font-weight: 400; margin-left: 5px; }
+.handoff-fields .set-label { display: block; margin: 9px 0 5px; }
+.handoff-desc { min-height: 54px; height: auto; padding: 8px 9px; resize: vertical; }

--- a/src/styles/terminal.css
+++ b/src/styles/terminal.css
@@ -66,7 +66,12 @@
 
 /* ── the lane ── */
 .lane {
-  flex: 0 1 auto;
+  /* The dragged width is authoritative — hence `flex: none`, not `0 1 auto`.
+     With flex-shrink enabled, `.main`'s intrinsic content width shrinks the lane
+     below the width state says it has, and the grip stops tracking the pointer.
+     `.main` (flex:1, min-width) absorbs the slack instead; the max-width rules
+     below are the real ceiling. */
+  flex: none;
   width: 372px;
   border-left: 1px solid var(--border-soft);
   background: var(--sidebar);
@@ -192,19 +197,37 @@
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
-.lane-seg {
+/* ── session tab strip ──────────────────────────────────────────────────────
+   One tab per live PTY (agents and shells side by side). The strip scrolls
+   horizontally rather than wrapping, so the terminal below never shifts height
+   as tabs are opened. */
+.lane-tabs {
   flex: none;
   display: flex;
-  gap: 3px;
-  padding: 9px 11px;
+  align-items: center;
+  gap: 4px;
+  padding: 7px 8px 7px 11px;
   border-bottom: 1px solid var(--border-soft);
+  min-width: 0;
 }
-.lane-seg button {
+.lt-scroll {
   flex: 1;
+  min-width: 0;
+  display: flex;
+  gap: 3px;
+  overflow-x: auto;
+  scrollbar-width: none;
+  padding-bottom: 1px;
+}
+.lt-scroll::-webkit-scrollbar {
+  display: none;
+}
+.lt {
+  flex: 0 0 auto;
+  max-width: 150px;
   height: 28px;
+  padding: 0 5px 0 9px;
   border-radius: 8px;
-  border: 0;
-  background: none;
   color: var(--faint);
   font-family: var(--sans);
   font-size: 12px;
@@ -212,17 +235,125 @@
   cursor: pointer;
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  gap: 7px;
+  gap: 6px;
   transition: background 0.1s, color 0.1s;
+  user-select: none;
 }
-.lane-seg button:hover {
+.lt:hover {
   background: rgba(255, 255, 255, 0.05);
   color: var(--dim);
 }
-.lane-seg button.on {
+.lt.on {
   background: var(--btn);
   color: var(--text);
+}
+.lt.ended {
+  opacity: 0.55;
+}
+.lt .lt-n {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.lt .lt-d {
+  flex: none;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--faint);
+}
+.lt .lt-d.live {
+  background: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-dim);
+}
+/* the close affordance replaces the status dot on hover — same footprint, so
+   tab widths never jump under the pointer */
+.lt .lt-x {
+  display: none;
+  flex: none;
+  width: 16px;
+  height: 16px;
+  margin-left: -3px;
+  border-radius: 5px;
+  align-items: center;
+  justify-content: center;
+  color: var(--faint);
+}
+.lt:hover .lt-x {
+  display: inline-flex;
+}
+.lt:hover .lt-d {
+  display: none;
+}
+.lt .lt-x:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text);
+}
+.lt-add {
+  position: relative;
+  flex: none;
+}
+.lt-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 40;
+  min-width: 168px;
+  padding: 5px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--panel);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.45);
+}
+.lt-menu-h {
+  padding: 5px 8px 4px;
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--faint);
+}
+.lt-menu button {
+  width: 100%;
+  height: 28px;
+  padding: 0 8px;
+  border: 0;
+  border-radius: 7px;
+  background: none;
+  color: var(--dim);
+  font: 600 12px var(--sans);
+  text-align: left;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.lt-menu button:hover {
+  background: var(--btn);
+  color: var(--text);
+}
+.lt-menu-sep {
+  height: 1px;
+  margin: 5px 4px;
+  background: var(--border-soft);
+}
+.lane-rail .ib {
+  position: relative;
+}
+.rail-n {
+  position: absolute;
+  top: -3px;
+  right: -3px;
+  min-width: 13px;
+  height: 13px;
+  padding: 0 3px;
+  border-radius: 7px;
+  background: var(--accent);
+  color: #0d1113;
+  font: 700 9px var(--sans);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 .lane-body {
   flex: 1;
@@ -263,6 +394,7 @@
 .xterm-host {
   width: 100%;
   height: 100%;
+  color-scheme: dark;
 }
 .term-body.hidden {
   visibility: hidden;
@@ -374,6 +506,16 @@
 .ag-pip.busy svg {
   animation: spin 1.5s linear infinite;
 }
+/* several agents in one worktree: the pip widens to carry the count */
+.ag-pip .ag-n {
+  font: 700 9px var(--sans);
+  margin-left: 2px;
+}
+.ag-pip:has(.ag-n) {
+  width: auto;
+  padding: 0 4px;
+  grid-auto-flow: column;
+}
 .ag-pip.wait {
   animation: pulse 1.6s ease-in-out infinite;
 }
@@ -451,6 +593,34 @@
 .ctx-title-in::placeholder {
   color: var(--faint);
 }
+.ctx-references {
+  display: grid;
+  grid-template-columns: 92px minmax(0, 1fr);
+  gap: 6px 8px;
+  padding: 5px 14px 11px;
+}
+.ctx-references label {
+  align-self: start;
+  padding-top: 7px;
+  color: var(--faint);
+  font-size: 11px;
+  font-weight: 600;
+}
+.ctx-references input,
+.ctx-references textarea {
+  width: 100%;
+  border: 1px solid var(--border-soft);
+  border-radius: 6px;
+  background: var(--panel-2);
+  color: var(--dim);
+  font: 11.5px var(--sans);
+  padding: 6px 8px;
+  outline: none;
+}
+.ctx-references textarea { min-height: 45px; resize: vertical; }
+.ctx-references textarea { grid-column: 2; }
+.ctx-references input:focus,
+.ctx-references textarea:focus { border-color: var(--accent); }
 .ctx-md {
   width: 100%;
   min-height: 104px;
@@ -540,6 +710,16 @@
   border-top: 1px solid var(--border-soft);
   background: rgba(0, 0, 0, 0.14);
 }
+.ctx-runtime {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  padding: 0 14px 11px;
+  color: var(--faint);
+  font: 10.5px var(--mono);
+}
+.ctx-runtime b { width: 100%; font: 700 9.5px var(--sans); letter-spacing: .08em; text-transform: uppercase; }
+.ctx-runtime span { padding: 3px 5px; border-radius: 4px; background: var(--panel-2); }
 .ctx-foot .hint {
   font-size: 11px;
   color: var(--faint);
@@ -607,6 +787,14 @@
 }
 .term-ph > * {
   flex: none;
+}
+/* the idle lane offers one launcher per configured agent — they wrap so a repo
+   with several agents doesn't push the shell button out of view */
+.term-ph .ph-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  justify-content: center;
 }
 .term-ph .ph-ic {
   width: 40px;

--- a/src/styles/terminal.css
+++ b/src/styles/terminal.css
@@ -349,7 +349,7 @@
   padding: 0 3px;
   border-radius: 7px;
   background: var(--accent);
-  color: #0d1113;
+  color: var(--on-accent);
   font: 700 9px var(--sans);
   display: inline-flex;
   align-items: center;

--- a/src/styles/terminal.css
+++ b/src/styles/terminal.css
@@ -222,20 +222,17 @@
 .lt-scroll::-webkit-scrollbar {
   display: none;
 }
+/* the chip is a wrapper: the tab itself and its close action are sibling
+   buttons, since a button can't legally nest inside another button */
 .lt {
   flex: 0 0 auto;
-  max-width: 150px;
+  max-width: 160px;
   height: 28px;
-  padding: 0 5px 0 9px;
+  padding: 0 5px 0 0;
   border-radius: 8px;
   color: var(--faint);
-  font-family: var(--sans);
-  font-size: 12px;
-  font-weight: 600;
-  cursor: pointer;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
   transition: background 0.1s, color 0.1s;
   user-select: none;
 }
@@ -249,6 +246,25 @@
 }
 .lt.ended {
   opacity: 0.55;
+}
+.lt .lt-main {
+  flex: 1;
+  min-width: 0;
+  height: 100%;
+  padding: 0 4px 0 9px;
+  border: 0;
+  border-radius: 8px;
+  background: none;
+  color: inherit;
+  font: 600 12px var(--sans);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.lt .lt-main:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
 }
 .lt .lt-n {
   overflow: hidden;
@@ -266,28 +282,38 @@
   background: var(--accent);
   box-shadow: 0 0 0 2px var(--accent-dim);
 }
-/* the close affordance replaces the status dot on hover — same footprint, so
-   tab widths never jump under the pointer */
 .lt .lt-x {
   display: none;
   flex: none;
-  width: 16px;
-  height: 16px;
-  margin-left: -3px;
+  width: 17px;
+  height: 17px;
+  padding: 0;
+  border: 0;
   border-radius: 5px;
+  background: none;
+  color: var(--faint);
+  cursor: pointer;
   align-items: center;
   justify-content: center;
-  color: var(--faint);
 }
-.lt:hover .lt-x {
+/* the close button replaces the status dot on hover — same footprint, so tab
+   widths never jump under the pointer. Keyboard focus reveals it too, or it
+   would be unreachable without a mouse. */
+.lt:hover .lt-x,
+.lt:focus-within .lt-x {
   display: inline-flex;
 }
-.lt:hover .lt-d {
+.lt:hover .lt-d,
+.lt:focus-within .lt-d {
   display: none;
 }
 .lt .lt-x:hover {
   background: rgba(255, 255, 255, 0.1);
   color: var(--text);
+}
+.lt .lt-x:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
 }
 .lt-add {
   position: relative;
@@ -400,6 +426,35 @@
   visibility: hidden;
   z-index: 0;
   pointer-events: none;
+}
+
+/* ── ended session: retained output, read-only, above a restart/close bar ── */
+.term-ended {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.term-ended .te-bar {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 4px 8px;
+  color: var(--faint);
+  font: 600 11.5px var(--sans);
+}
+.term-ended .te-bar .te-t {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.term-ended .te-body {
+  flex: 1;
+  min-height: 0;
+  position: relative;
+  opacity: 0.75; /* reads as history, not a live session */
 }
 
 /* ── agent output (structured transcript over the PTY) ── */

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -36,6 +36,8 @@
   --dim: var(--muted);
   --accent: var(--teal);
   --accent-dim: var(--teal-dim);
+  /* ink for text/icons sitting *on* an accent fill (badges, pills) */
+  --on-accent: #0d1113;
   --run: var(--green);
   --stop: var(--red);
   --warn: var(--amber);

--- a/src/terminal-window.tsx
+++ b/src/terminal-window.tsx
@@ -11,11 +11,13 @@ const params = new URLSearchParams(location.search);
 const termId = params.get("id") ?? "";
 const cwd = params.get("cwd") ?? "";
 const branch = params.get("branch") ?? "";
+const title = params.get("title") || "Terminal";
+const command = params.get("cmd") || undefined;
 
 document.body.style.background = "var(--panel-2)";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    <DetachedTerminal termId={termId} cwd={cwd} branch={branch} />
+    <DetachedTerminal termId={termId} cwd={cwd} branch={branch} title={title} command={command} />
   </React.StrictMode>,
 );


### PR DESCRIPTION
Fixes #32.

Grows the agent lane from one agent + one shell into any number of concurrent sessions, makes terminal output clickable, and fixes lane resizing.

## Multiple agents and terminals

Both tabs were previously backed by a single PTY under a fixed id (`${wtKey}::agent` / `::shell`), so a worktree could never run two agents at once. Sessions are now a list of `LaneSession`s in the store, each owning its own PTY under a numbered id (`::agent#3`), rendered as a scrollable tab strip with a `+` menu.

Ids are never reused, so a closed tab's in-flight backend events can't be attributed to a new session. `id.ends_with("::agent")` no longer identifies a kind now that ids carry an instance suffix — `kind_of()` parses the last `::` segment and still reads pre-existing unsuffixed ids.

An exited tab stays in the strip with its output intact and offers Restart/Close. One subtlety worth review: remounting a terminal for an exited session would silently **re-run its command**, so a session that exited outside the current lane instance's lifetime renders a placeholder rather than a live pane.

## Configurable agents

`RepoCfg.agents` replaces the single `agentCommand` string, with its own settings tab (name, command, "Send prompt" toggle for CLIs that don't take a positional prompt). The legacy field is folded into the list once at load — the previous approach synthesised a placeholder row during render whose index-based edits wrote to the wrong entry.

## Terminal links

`@xterm/addon-web-links` was never a dependency, so URLs were inert text. Added, routed through the Tauri opener. A second provider linkifies file paths (`src/app/Foo.tsx:12:3`) into the configured editor, resolved against the worktree root and refused if they escape it.

The pattern requires a slash and an extension, and skips anything inside a URL so the two providers don't fight. Checked against real output — matches paths at correct offsets, ignores `error[E0382]`, `2:30`, `v1.2`, and leaves `https://example.com/docs/guide.html` to the URL linkifier.

## Resizing

`.lane` was `flex: 0 1 auto`, so flex-shrink overrode the width the drag set — measured at 1800px wide, the inline style read `994px` while it rendered at `934.5px`. The drag computed the edge from that state and corrected against somewhere the edge wasn't: **a 200px drag moved it ~29px.**

- `flex: none` makes the width authoritative
- drag is delta-based, so the pointer stays glued to the grip through clamping
- the ceiling is applied at render time instead of written back into state — two writers were racing for it, and a narrow window permanently destroyed the chosen width
- focus-mode width restore moved out of the click handler into an effect on the `mainRailed` transition. The collapsed rail has its **own** exit buttons (`App.tsx:90`, `:100`) that bypassed the handler, so leaving focus mode that way left the lane blown up — and persisted it.
- added: `user-select: none` while dragging, double-click grip to reset

## Also

- `open_file_in_editor` escaped single quotes with `'\"'\"'` — the double-quote idiom misapplied; apostrophes in paths produced a broken shell command. `open_in_editor` didn't escape at all. Replaced with `sh_quote()` plus a test round-tripping through a real shell.
- Detached windows never received the tab's command, so one that created the PTY launched a bare login shell instead of the agent.
- Pinned the full ANSI palette; partial specification let coloured CLI output render monochrome.

## Testing

TypeScript and production build clean; 14 Rust tests pass (new: `sh_quote` round-trip, `kind_of` id parsing incl. legacy ids).

Driven in browser-mock mode: mixed tabs spawn and name correctly (`Claude`, `Claude 2`, `Shell`, `Shell 2`), closing a middle tab refocuses correctly, empty state hides the strip. Resize verified 1:1 in both directions, clamping exact at both limits, width surviving a window shrink/grow, and all three focus-exit paths restoring.

**Not verified:** link *activation* end-to-end — the browser mock has no PTY, so clicking a path is only checked at the regex and type level. Concurrent PTYs were checked by compile and unit test, not by running two agents side by side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGNzaUePP4SzBZxnBrE2CL