### PR TITLE
Modals: the dialog layer from Canopy Modals.html

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -204,6 +204,10 @@ export default function App() {
         e.preventDefault();
         setSideHidden((s) => !s);
       }
+      if (meta && e.key === "\\") {
+        e.preventDefault();
+        if (sel) setShowSwitchBranch(true);
+      }
       if (meta && e.key.toLowerCase() === "o") {
         e.preventDefault();
         setView((v) => (v === "overview" ? "wt" : "overview"));
@@ -290,6 +294,7 @@ export default function App() {
               onSetup={() => setShowSetup(true)}
               onOpenService={(s) => setSvcDetail(s)}
               onEditContext={() => setShowCtx(true)}
+              onSwitchBranch={() => setShowSwitchBranch(true)}
             />
           )
         )}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -7,8 +7,8 @@
 import { useEffect, useMemo, useState } from "react";
 import { hasBackend, ipc } from "../ipc";
 import { initSync, useStore } from "../store";
-import type { RepoNode, WorktreeNode } from "../types";
-import { Plus, X } from "../icons";
+import type { RepoNode, ServiceNode, WorktreeNode } from "../types";
+import { Plus } from "../icons";
 import { attentionItems, nextAction, type AttnItem, type NextAction } from "./nextAction";
 import { TopBar, AttentionPop } from "./canopy/TopBar";
 import SidebarNav from "./canopy/SidebarNav";
@@ -18,7 +18,10 @@ import Palette from "./canopy/Palette";
 import StatusBar from "./canopy/StatusBar";
 import { LAYOUT_ORDER, LAYOUTS, panesOf, type LayoutId, type PaneKind } from "./canopy/WorkSurface";
 import { useLaneLaunch } from "./canopy/laneLaunch";
-import DatabaseControl from "./DatabaseControl";
+import DatabaseModal from "./canopy/DatabaseModal";
+import SetupRunnerModal from "./canopy/SetupRunnerModal";
+import ServiceDetailModal from "./canopy/ServiceDetailModal";
+import ContextModal from "./canopy/ContextModal";
 import SettingsView from "./SettingsView";
 import NewWorktreeModal from "./NewWorktreeModal";
 import RemoveWorktreeModal from "./RemoveWorktreeModal";
@@ -53,6 +56,9 @@ export default function App() {
   const [showNewWt, setShowNewWt] = useState(false);
   const [showSwitchBranch, setShowSwitchBranch] = useState(false);
   const [showDb, setShowDb] = useState(false);
+  const [showSetup, setShowSetup] = useState(false);
+  const [showCtx, setShowCtx] = useState(false);
+  const [svcDetail, setSvcDetail] = useState<ServiceNode | null>(null);
   const [removeWtFor, setRemoveWtFor] = useState<WorktreeNode | null>(null);
   const [showOnboarding, setShowOnboarding] = useState(false);
   const [obDismissed, setObDismissed] = useState(false);
@@ -113,9 +119,9 @@ export default function App() {
         if (a.sessionId) setActiveTerm(key, a.sessionId);
         break;
       case "setup":
-        if (!hasBackend()) return showToast("Setup runs in the desktop app");
-        showToast(`Running setup — ${target.branch}…`);
-        ipc.runWorktreeSetup(key).catch((e) => showToast(`Setup failed — ${String(e)}`));
+        select(key);
+        setView("wt");
+        setShowSetup(true);
         break;
       case "starting":
         break; // busy — acting again would double-start
@@ -281,6 +287,9 @@ export default function App() {
               onShowSide={() => setSideHidden(false)}
               onRemove={() => setRemoveWtFor(sel.wt)}
               onDatabase={() => setShowDb(true)}
+              onSetup={() => setShowSetup(true)}
+              onOpenService={(s) => setSvcDetail(s)}
+              onEditContext={() => setShowCtx(true)}
             />
           )
         )}
@@ -336,25 +345,27 @@ export default function App() {
         />
       )}
 
-      {showDb && sel && (
-        <div className="cx-scrim" onMouseDown={() => setShowDb(false)}>
-          <div className="cx-modal" onMouseDown={(e) => e.stopPropagation()}>
-            <div className="cx-modal__head">
-              <div className="cx-modal__title">
-                <b>Database</b>
-                <span>{sel.wt.dbName ?? "not configured"}</span>
-              </div>
-              <button className="cx-ib" onClick={() => setShowDb(false)} title="Close">
-                <X size={13} />
-              </button>
-            </div>
-            <div className="cx-modal__body">
-              <DatabaseControl wt={sel.wt} />
-            </div>
-          </div>
-        </div>
+      {showDb && sel && <DatabaseModal wt={sel.wt} onClose={() => setShowDb(false)} />}
+      {showSetup && sel && (
+        <SetupRunnerModal
+          wt={sel.wt}
+          onClose={() => setShowSetup(false)}
+          onStartServices={() => startAll(sel.wt.wtKey)}
+        />
       )}
-
+      {svcDetail && sel && <ServiceDetailModal wt={sel.wt} svc={svcDetail} onClose={() => setSvcDetail(null)} />}
+      {showCtx && sel && (
+        <ContextModal
+          repo={sel.repo}
+          wt={sel.wt}
+          onClose={() => setShowCtx(false)}
+          onStartAgent={() => {
+            setView("wt");
+            setLayout("agent");
+            launch.startAgent();
+          }}
+        />
+      )}
       {showNewWt && <NewWorktreeModal repoId={sel?.repo.repoId ?? ""} onClose={() => setShowNewWt(false)} />}
       {removeWtFor && <RemoveWorktreeModal wt={removeWtFor} onClose={() => setRemoveWtFor(null)} />}
       {showSwitchBranch && sel && (

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -98,6 +98,14 @@ export default function App() {
 
   const launch = useLaneLaunch(sel?.repo ?? EMPTY_REPO, sel?.wt ?? EMPTY_WT);
 
+  /** Resolve a launch target by key. `select()` does not update this render's
+      closure, so anything launching for a worktree other than the currently
+      selected one has to say which one explicitly. */
+  const targetFor = (wtKey: string) => {
+    for (const r of tree) for (const w of r.worktrees) if (w.wtKey === wtKey) return { repo: r, wt: w };
+    return undefined;
+  };
+
   /* ── the one action ───────────────────────────────────────────────
      Every surface that offers "the next thing" calls this. */
   const runNext = (action?: NextAction | null, forKey?: string) => {
@@ -145,7 +153,7 @@ export default function App() {
         select(key);
         setView("wt");
         setLayout("agent");
-        launch.startAgent();
+        launch.startAgent(targetFor(key));
         break;
     }
   };
@@ -155,22 +163,17 @@ export default function App() {
     setView("wt");
     if (want === "terminal") {
       setLayout("shell");
-      launch.startShell();
+      launch.startShell(targetFor(wtKey));
     }
   };
 
   const openTerminalFor = (wtKey: string) => {
-    if (wtKey === sel?.wt.wtKey) {
-      setView("wt");
-      setLayout("shell");
-      if ((sessions[wtKey] ?? []).every((s) => s.kind !== "shell")) launch.startShell();
-      return;
-    }
-    // a different worktree: select it first — its launcher belongs to that
-    // worktree's context, so the shell opens on the next render
     select(wtKey);
     setView("wt");
     setLayout("shell");
+    // open one only if that worktree has none — naming the target means this
+    // works for any worktree, not just the one already selected
+    if ((sessions[wtKey] ?? []).every((s) => s.kind !== "shell")) launch.startShell(targetFor(wtKey));
   };
 
   const refresh = () => {
@@ -345,7 +348,7 @@ export default function App() {
           onStartAgent={() => {
             setView("wt");
             setLayout("agent");
-            launch.startAgent();
+            launch.startAgent(sel ? { repo: sel.repo, wt: sel.wt } : undefined);
           }}
         />
       )}
@@ -367,7 +370,7 @@ export default function App() {
           onStartAgent={() => {
             setView("wt");
             setLayout("agent");
-            launch.startAgent();
+            launch.startAgent(sel ? { repo: sel.repo, wt: sel.wt } : undefined);
           }}
         />
       )}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -4,7 +4,7 @@
    the one runner that turns a NextAction into work. Everything that offers
    "the next thing" routes through `runNext`, so the worktree bar's button,
    ⌘K's Suggested row, ⏎, and the overview's row action stay in lockstep. */
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { hasBackend, ipc } from "../ipc";
 import { initSync, useStore } from "../store";
 import type { RepoNode, WorktreeNode } from "../types";
@@ -63,6 +63,7 @@ export default function App() {
   const [showOnboarding, setShowOnboarding] = useState(false);
   const [obDismissed, setObDismissed] = useState(false);
   const [, setTick] = useState(0);
+  const attnRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => initSync(), []);
   // uptime / relative-time re-render
@@ -241,6 +242,7 @@ export default function App() {
         onOverview={() => setView("overview")}
         onRefresh={refresh}
         onSettings={() => setShowSettings(true)}
+        attnRef={attnRef}
       />
 
       <div className="cxs-body">
@@ -320,6 +322,7 @@ export default function App() {
 
       {attnOpen && (
         <AttentionPop
+          anchor={attnRef}
           items={attn}
           onClose={() => setAttnOpen(false)}
           onPick={(a) => {
@@ -338,6 +341,7 @@ export default function App() {
           onSelect={(k) => goto(k)}
           onOverview={() => setView("overview")}
           onAction={(a) => runNext(a)}
+          onRunFor={(k) => runNext(null, k)}
           onLayout={(l) => {
             setLayout(l);
             setView("wt");

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -7,7 +7,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { hasBackend, ipc } from "../ipc";
 import { initSync, useStore } from "../store";
-import type { RepoNode, ServiceNode, WorktreeNode } from "../types";
+import type { RepoNode, WorktreeNode } from "../types";
 import { Plus } from "../icons";
 import { attentionItems, nextAction, type AttnItem, type NextAction } from "./nextAction";
 import { TopBar, AttentionPop } from "./canopy/TopBar";
@@ -58,7 +58,7 @@ export default function App() {
   const [showDb, setShowDb] = useState(false);
   const [showSetup, setShowSetup] = useState(false);
   const [showCtx, setShowCtx] = useState(false);
-  const [svcDetail, setSvcDetail] = useState<ServiceNode | null>(null);
+  const [svcDetail, setSvcDetail] = useState<string | null>(null);
   const [removeWtFor, setRemoveWtFor] = useState<WorktreeNode | null>(null);
   const [showOnboarding, setShowOnboarding] = useState(false);
   const [obDismissed, setObDismissed] = useState(false);
@@ -292,7 +292,7 @@ export default function App() {
               onRemove={() => setRemoveWtFor(sel.wt)}
               onDatabase={() => setShowDb(true)}
               onSetup={() => setShowSetup(true)}
-              onOpenService={(s) => setSvcDetail(s)}
+              onOpenService={(s) => setSvcDetail(s.svcKey)}
               onEditContext={() => setShowCtx(true)}
               onSwitchBranch={() => setShowSwitchBranch(true)}
             />
@@ -358,7 +358,7 @@ export default function App() {
           onStartServices={() => startAll(sel.wt.wtKey)}
         />
       )}
-      {svcDetail && sel && <ServiceDetailModal wt={sel.wt} svc={svcDetail} onClose={() => setSvcDetail(null)} />}
+      {svcDetail && sel && <ServiceDetailModal wt={sel.wt} svcKey={svcDetail} onClose={() => setSvcDetail(null)} />}
       {showCtx && sel && (
         <ContextModal
           repo={sel.repo}

--- a/src/app/NewWorktreeModal.tsx
+++ b/src/app/NewWorktreeModal.tsx
@@ -1,98 +1,22 @@
-// New worktree flow — new branch from base, or check out an existing branch.
-// Branch pickers are searchable; a Fetch button runs `git fetch --all --prune`.
-// Streams create progress (incl. submodule clones) via worktree:op events.
-import { useEffect, useRef, useState } from "react";
+/* New worktree — the creation dialog.
+
+   Two modes: a new branch off a base, or checking out one that exists. The
+   "You'll get" panel is the reassurance — it answers "where will this land?"
+   while the name is still editable. The agent handoff is optional and
+   collapsed, because most worktrees don't need one, but when it's filled in
+   it seeds .canopy/context.md and later becomes the PR body. */
+import { useEffect, useMemo, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
-import { hasBackend, ipc } from "../ipc";
+import { hasBackend, ipc, type Branches, type OpEvent } from "../ipc";
 import { useStore } from "../store";
+import { Alert, ChevRight, Fork, Info, Plus, Refresh, Spinner } from "../icons";
+import Modal, { Hint, Spacer } from "./canopy/Modal";
+import RefPick from "./canopy/RefPick";
 import { seedWtContext } from "./WorktreeContext";
-import { Fork, Refresh, Search, Spinner } from "../icons";
 
-interface OpEvent {
-  wtKey: string;
-  op: string;
-  state: "progress" | "done" | "error";
-  detail: string;
-}
-
-type RefKind = "local" | "remote" | "tag";
-
-interface BranchItem {
-  name: string;
-  kind: RefKind;
-}
-
-/** Searchable ref dropdown — filters local + remote branches and tags as you type. */
-function BranchPicker({
-  value,
-  items,
-  onPick,
-  disabled,
-  placeholder,
-}: {
-  value: string;
-  items: BranchItem[];
-  onPick: (name: string, kind: RefKind) => void;
-  disabled?: boolean;
-  placeholder: string;
-}) {
-  const [q, setQ] = useState("");
-  const [open, setOpen] = useState(false);
-  const boxRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    function onDoc(e: MouseEvent) {
-      if (boxRef.current && !boxRef.current.contains(e.target as Node)) setOpen(false);
-    }
-    document.addEventListener("mousedown", onDoc);
-    return () => document.removeEventListener("mousedown", onDoc);
-  }, []);
-
-  const needle = q.toLowerCase();
-  const filtered = items.filter((b) => b.name.toLowerCase().includes(needle)).slice(0, 60);
-
-  return (
-    <div className="bp" ref={boxRef}>
-      <div className="bp-field" onClick={() => !disabled && setOpen(true)}>
-        <Search size={13} />
-        <input
-          className="bp-input"
-          value={open ? q : value || ""}
-          placeholder={value || placeholder}
-          disabled={disabled}
-          onFocusCapture={() => setOpen(true)}
-          onChange={(e) => {
-            setQ(e.target.value);
-            setOpen(true);
-          }}
-        />
-        {value && !open && <span className="bp-current">selected</span>}
-      </div>
-      {open && (
-        <div className="bp-list">
-          {filtered.length === 0 ? (
-            <div className="bp-empty">no matching branches</div>
-          ) : (
-            filtered.map((b) => (
-              <button
-                key={b.kind + ":" + b.name}
-                className={"bp-item" + (b.name === value ? " sel" : "")}
-                onClick={() => {
-                  onPick(b.name, b.kind);
-                  setQ("");
-                  setOpen(false);
-                }}
-              >
-                <span className="bp-name">{b.name}</span>
-                {b.kind !== "local" && <span className="bp-tag">{b.kind}</span>}
-              </button>
-            ))
-          )}
-        </div>
-      )}
-    </div>
-  );
-}
+/** A branch name becomes a directory name; git and the filesystem disagree
+    about what's legal, so the slug is the safe intersection. */
+const slugify = (b: string) => b.replace(/[^a-z0-9._-]+/gi, "-").toLowerCase();
 
 export default function NewWorktreeModal({ repoId, onClose }: { repoId: string; onClose: () => void }) {
   const tree = useStore((s) => s.tree);
@@ -102,15 +26,11 @@ export default function NewWorktreeModal({ repoId, onClose }: { repoId: string; 
   const repos = tree.map((r) => ({ id: r.repoId, name: r.name }));
   const [repo, setRepo] = useState(repoId || repos[0]?.id || "");
   const [mode, setMode] = useState<"new" | "existing">("new");
-  const [branch, setBranch] = useState(""); // new-branch name
-  const [base, setBase] = useState(""); // base for new branch
-  const [baseIsTag, setBaseIsTag] = useState(false);
-  const [existing, setExisting] = useState<{ name: string; kind: RefKind } | null>(null);
-  const [branches, setBranches] = useState<{ local: string[]; remote: string[]; tags: string[] }>({
-    local: [],
-    remote: [],
-    tags: [],
-  });
+  const [name, setName] = useState("");
+  const [base, setBase] = useState("");
+  const [existing, setExisting] = useState("");
+  const [existingKind, setExistingKind] = useState<"local" | "remote" | "tags" | "new">("local");
+  const [branches, setBranches] = useState<Branches | null>(null);
   const [busy, setBusy] = useState(false);
   const [fetching, setFetching] = useState(false);
   const [progress, setProgress] = useState<string[]>([]);
@@ -120,20 +40,24 @@ export default function NewWorktreeModal({ repoId, onClose }: { repoId: string; 
   const [issue, setIssue] = useState("");
   const [issueDescription, setIssueDescription] = useState("");
 
-  const localItems: BranchItem[] = branches.local.map((b) => ({ name: b, kind: "local" as const }));
-  const remoteItems: BranchItem[] = branches.remote.map((b) => ({ name: b, kind: "remote" as const }));
-  const tagItems: BranchItem[] = (branches.tags ?? []).map((t) => ({ name: t, kind: "tag" as const }));
-  const allItems = [...localItems, ...remoteItems, ...tagItems];
+  const activeRepo = tree.find((r) => r.repoId === repo);
+  // git refuses to check the same branch out twice; show them, disabled
+  const inUse = useMemo(() => new Set((activeRepo?.worktrees ?? []).map((w) => w.branch)), [activeRepo]);
 
   useEffect(() => {
-    if (!hasBackend() || !repo) return;
+    if (!hasBackend() || !repo) {
+      setBranches({ local: [], remote: [], tags: [] });
+      return;
+    }
+    setBranches(null);
     ipc
       .listBranches(repo)
       .then((b) => {
         setBranches(b);
-        if (!base) setBase(b.local.includes("main") ? "main" : b.local[0] ?? "");
+        if (!base) setBase(b.local.includes("main") ? "main" : (b.local[0] ?? ""));
       })
-      .catch(() => {});
+      .catch(() => setBranches({ local: [], remote: [], tags: [] }));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [repo]);
 
   useEffect(() => {
@@ -153,7 +77,7 @@ export default function NewWorktreeModal({ repoId, onClose }: { repoId: string; 
     try {
       const b = await ipc.fetchBranches(repo);
       setBranches(b);
-      showToast(`Fetched — ${b.local.length} local, ${b.remote.length} remote, ${b.tags?.length ?? 0} tags`);
+      showToast(`Fetched — ${b.local.length} local, ${b.remote.length} remote, ${b.tags.length} tags`);
     } catch (e) {
       setError(`Fetch failed — ${String(e)}`);
     } finally {
@@ -161,41 +85,33 @@ export default function NewWorktreeModal({ repoId, onClose }: { repoId: string; 
     }
   }
 
-  async function create() {
-    setError(null);
-    // resolve to {branch, base, createBranch} from the active mode
-    let payload: { branch: string; base?: string; createBranch: boolean };
-    if (mode === "new") {
-      if (!branch.trim()) return setError("Branch name required");
-      // refs/tags/ keeps a tag base unambiguous vs a branch of the same name
-      payload = { branch: branch.trim(), base: baseIsTag ? `refs/tags/${base}` : base, createBranch: true };
-    } else {
-      if (!existing) return setError("Pick a branch or tag");
-      if (existing.kind === "remote") {
-        // checking out a remote branch → create a local tracking branch.
-        // strip the remote name (first path segment): origin/feature/x → feature/x
-        const local = existing.name.split("/").slice(1).join("/");
-        payload = { branch: local, base: existing.name, createBranch: true };
-      } else if (existing.kind === "tag") {
-        // checking out a tag → create a local branch named after it
-        payload = { branch: existing.name, base: `refs/tags/${existing.name}`, createBranch: true };
-      } else {
-        payload = { branch: existing.name, createBranch: false };
-      }
-    }
+  const branch = mode === "new" ? name.trim() : existing;
+  const slug = slugify(branch || "new-branch");
+  const ok = !!branch;
 
+  async function create() {
+    if (!ok) return;
     setBusy(true);
     setProgress([]);
+    setError(null);
     try {
       if (!hasBackend()) {
         showToast("New worktree needs the desktop app");
         return;
       }
+      const payload =
+        mode === "new"
+          ? { branch, base: base || undefined, createBranch: true }
+          : existingKind === "tags"
+            ? // checking out a tag → create a local branch named after it
+              { branch: existing, base: `refs/tags/${existing}`, createBranch: true }
+            : { branch: existing, createBranch: false };
+
       const wtPath = await ipc.createWorktree({ repoId: repo, ...payload });
-      // The runtime details (ports/database) are derived from the authoritative
-      // tree after creation; seed the human handoff now, keyed by the new path.
-      seedWtContext(wtPath, { title: payload.branch, pr, prDescription, issue, issueDescription });
-      showToast(`Worktree ready — ${payload.branch}`);
+      // seed the human handoff now, keyed by the new path — the runtime
+      // details are read back from the authoritative tree afterwards
+      seedWtContext(wtPath, { title: branch, pr, prDescription, issue, issueDescription });
+      showToast(`Worktree ready — ${branch}`);
       select(wtPath);
       onClose();
     } catch (e) {
@@ -205,115 +121,197 @@ export default function NewWorktreeModal({ repoId, onClose }: { repoId: string; 
     }
   }
 
-  const canCreate = mode === "new" ? !!branch.trim() : !!existing;
-
   return (
-    <div className="modal-backdrop" onMouseDown={(e) => e.target === e.currentTarget && !busy && onClose()}>
-      <div className="modal">
-        <div className="modal-head">
-          <span className="fork" style={{ color: "var(--accent)", display: "inline-flex" }}>
-            <Fork size={15} />
-          </span>
-          New worktree
+    <Modal
+      icon={Fork}
+      title="New worktree"
+      sub={activeRepo?.name}
+      busy={busy}
+      onClose={onClose}
+      foot={
+        <>
+          <Hint icon={Info}>Ports and database are derived automatically</Hint>
+          <Spacer />
+          <button className="cx-btn cx-btn--ghost" onClick={onClose} disabled={busy}>
+            Cancel
+          </button>
+          <button className="cx-btn cx-btn--primary" onClick={create} disabled={busy || !ok}>
+            {busy ? (
+              <>
+                <Spinner size={12} />
+                Creating…
+              </>
+            ) : (
+              <>
+                <Plus size={12} />
+                Create worktree
+                <span className="cx-k">⌘⏎</span>
+              </>
+            )}
+          </button>
+        </>
+      }
+    >
+      <div className="cxm-fld">
+        <div className="cxm-flab">
+          <Fork size={11} />
+          Repository &amp; branch
+          <button
+            className="cx-btn cx-btn--ghost cxm-opt"
+            style={{ height: "var(--h-session)", padding: "0 var(--sp-3)", fontSize: "var(--fs-micro)" }}
+            onClick={fetchAll}
+            disabled={busy || fetching}
+          >
+            {fetching ? <Spinner size={10} /> : <Refresh size={10} />}
+            Fetch all
+          </button>
         </div>
 
-        <div className="modal-body">
-          <label className="set-label">Repository</label>
-          <select className="set-input" value={repo} onChange={(e) => setRepo(e.target.value)} disabled={busy}>
+        <div className="cxm-grid2" style={{ marginBottom: "var(--sp-row)" }}>
+          <select className="cx-input" value={repo} onChange={(e) => setRepo(e.target.value)} disabled={busy}>
             {repos.map((r) => (
               <option key={r.id} value={r.id}>
                 {r.name}
               </option>
             ))}
           </select>
-
-          <div className="bp-head">
-            <label className="set-label" style={{ flex: 1 }}>
-              Branch
-            </label>
-            <button className="bp-fetch" onClick={fetchAll} disabled={busy || fetching} title="git fetch --all --prune">
-              {fetching ? <Spinner size={13} /> : <Refresh size={13} />}
-              {fetching ? "Fetching…" : "Fetch all"}
-            </button>
-          </div>
-
-          <div className="modal-mode">
-            <button className={"console-tab" + (mode === "new" ? " sel" : "")} onClick={() => setMode("new")} disabled={busy}>
+          <div className="cx-seg">
+            <button className={mode === "new" ? "is-on" : ""} onClick={() => setMode("new")} disabled={busy}>
               New branch
             </button>
-            <button
-              className={"console-tab" + (mode === "existing" ? " sel" : "")}
-              onClick={() => setMode("existing")}
-              disabled={busy}
-            >
-              Existing branch / tag
+            <button className={mode === "existing" ? "is-on" : ""} onClick={() => setMode("existing")} disabled={busy}>
+              Existing
             </button>
           </div>
+        </div>
 
-          {mode === "new" ? (
-            <>
+        {mode === "new" ? (
+          <>
+            <div className="cxm-sfld">
+              <div className="cxm-flab cxm-flab--f">Branch name</div>
               <input
-                className="set-input"
-                placeholder="feature/my-branch"
-                value={branch}
-                onChange={(e) => setBranch(e.target.value)}
+                className="cx-input cx-input--mono"
+                placeholder="feat/my-branch"
+                value={name}
+                spellCheck={false}
+                onChange={(e) => setName(e.target.value)}
                 disabled={busy}
-                autoFocus
               />
-              <label className="set-label">From base</label>
-              <BranchPicker
-                value={baseIsTag ? `${base} (tag)` : base}
-                items={allItems}
-                onPick={(name, kind) => {
-                  setBase(name);
-                  setBaseIsTag(kind === "tag");
-                }}
-                disabled={busy}
-                placeholder="search base branch or tag…"
-              />
-            </>
-          ) : (
-            <BranchPicker
-              value={existing?.name ?? ""}
-              items={allItems}
-              onPick={(name, kind) => setExisting({ name, kind })}
-              disabled={busy}
-              placeholder="search branches and tags…"
-            />
-          )}
-
-          <details className="handoff-fields">
-            <summary>Agent handoff <span>optional PR / issue context</span></summary>
-            <label className="set-label">Pull request</label>
-            <input className="set-input" value={pr} placeholder="https://github.com/org/repo/pull/123" onChange={(e) => setPr(e.target.value)} disabled={busy} />
-            <textarea className="set-input handoff-desc" value={prDescription} placeholder="What the PR changes or needs reviewed" onChange={(e) => setPrDescription(e.target.value)} disabled={busy} />
-            <label className="set-label">Issue</label>
-            <input className="set-input" value={issue} placeholder="https://github.com/org/repo/issues/123" onChange={(e) => setIssue(e.target.value)} disabled={busy} />
-            <textarea className="set-input handoff-desc" value={issueDescription} placeholder="Problem, acceptance criteria, and constraints" onChange={(e) => setIssueDescription(e.target.value)} disabled={busy} />
-          </details>
-
-          {busy && (
-            <div className="modal-progress">
-              <span style={{ color: "var(--accent)", display: "inline-flex" }}>
-                <Spinner size={14} />
-              </span>
-              <div className="modal-progress-lines">
-                {progress.length ? progress.slice(-4).map((l, i) => <div key={i}>{l}</div>) : <div>creating…</div>}
-              </div>
             </div>
-          )}
-          {error && <div className="modal-error">{error}</div>}
-        </div>
-
-        <div className="modal-foot">
-          <button className="iconbtn" onClick={onClose} disabled={busy}>
-            Cancel
-          </button>
-          <button className="iconbtn primary" onClick={create} disabled={busy || !canCreate}>
-            {busy ? "Creating…" : "Create worktree"}
-          </button>
-        </div>
+            <div className="cxm-sfld">
+              <div className="cxm-flab cxm-flab--f">Created from</div>
+              <RefPick
+                value={base}
+                branches={branches}
+                placeholder="search a base branch or tag…"
+                onPick={(n) => setBase(n)}
+              />
+            </div>
+          </>
+        ) : (
+          <div className="cxm-sfld">
+            <div className="cxm-flab cxm-flab--f">Branch to check out</div>
+            <RefPick
+              value={existing}
+              branches={branches}
+              placeholder="search branches and tags…"
+              inUse={inUse}
+              onPick={(n, k) => {
+                setExisting(n);
+                setExistingKind(k);
+              }}
+            />
+          </div>
+        )}
       </div>
-    </div>
+
+      <div className="cxm-fld">
+        <div className="cxm-flab">You'll get</div>
+        <dl className="cx-kv">
+          <dt>Path</dt>
+          <dd>
+            .worktrees/<em>{ok ? slug : "…"}</em>
+          </dd>
+          {/* TODO(#58): ports and the database name are assigned inside
+              create_worktree. Deriving them here would duplicate backend logic
+              that can drift, and a wrong port is worse than a blank one. */}
+          <dt>Ports</dt>
+          <dd title="Assigned at creation">—</dd>
+          <dt>Database</dt>
+          <dd title="Assigned at creation">—</dd>
+        </dl>
+      </div>
+
+      <details className="cxm-disc">
+        <summary>
+          <span className="cv">
+            <ChevRight size={11} />
+          </span>
+          Agent handoff
+          <span className="sub">optional PR / issue context</span>
+        </summary>
+        <div className="cxm-disc__body">
+          <div className="cxm-fld">
+            <div className="cxm-flab cxm-flab--f">Pull request</div>
+            <input
+              className="cx-input"
+              placeholder="https://github.com/org/repo/pull/123"
+              value={pr}
+              onChange={(e) => setPr(e.target.value)}
+              disabled={busy}
+            />
+          </div>
+          <div className="cxm-fld">
+            <div className="cxm-flab cxm-flab--f">What it changes</div>
+            <textarea
+              className="cx-input"
+              placeholder="Seeds the agent, and later becomes the PR body"
+              value={prDescription}
+              onChange={(e) => setPrDescription(e.target.value)}
+              disabled={busy}
+            />
+          </div>
+          <div className="cxm-fld">
+            <div className="cxm-flab cxm-flab--f">Issue</div>
+            <input
+              className="cx-input"
+              placeholder="https://github.com/org/repo/issues/42"
+              value={issue}
+              onChange={(e) => setIssue(e.target.value)}
+              disabled={busy}
+            />
+          </div>
+          <div className="cxm-fld">
+            <div className="cxm-flab cxm-flab--f">Problem</div>
+            <textarea
+              className="cx-input"
+              value={issueDescription}
+              onChange={(e) => setIssueDescription(e.target.value)}
+              disabled={busy}
+            />
+          </div>
+        </div>
+      </details>
+
+      {busy && (
+        <div className="cxm-prog">
+          <span className="cxm-prog__ic">
+            <Spinner size={13} />
+          </span>
+          <div className="cxm-prog__lines">
+            {progress.length ? progress.slice(-4).map((l, i) => <div key={i}>{l}</div>) : <div>creating…</div>}
+          </div>
+        </div>
+      )}
+
+      {error && (
+        <div className="cx-alert cx-alert--error" style={{ marginTop: "var(--sp-modal-head)" }}>
+          <span className="cx-alert__ic">
+            <Alert size={13} />
+          </span>
+          <div>{error}</div>
+        </div>
+      )}
+    </Modal>
   );
 }

--- a/src/app/NewWorktreeModal.tsx
+++ b/src/app/NewWorktreeModal.tsx
@@ -14,9 +14,12 @@ import Modal, { Hint, Spacer } from "./canopy/Modal";
 import RefPick from "./canopy/RefPick";
 import { seedWtContext } from "./WorktreeContext";
 
-/** A branch name becomes a directory name; git and the filesystem disagree
-    about what's legal, so the slug is the safe intersection. */
-const slugify = (b: string) => b.replace(/[^a-z0-9._-]+/gi, "-").toLowerCase();
+/** Mirrors `sanitize_branch` in commands.rs:605 exactly — alphanumerics, `-`
+    and `.` survive, everything else becomes `_`, and CASE IS PRESERVED. An
+    approximation here is worse than nothing: the panel exists to tell you
+    where the worktree lands, so `Feature/foo` must read `Feature_foo`, not
+    `feature-foo`. Rust's is_alphanumeric is Unicode-aware, hence \p{L}\p{N}. */
+const sanitizeBranch = (b: string) => b.replace(/[^\p{L}\p{N}.-]/gu, "_");
 
 export default function NewWorktreeModal({ repoId, onClose }: { repoId: string; onClose: () => void }) {
   const tree = useStore((s) => s.tree);
@@ -39,6 +42,8 @@ export default function NewWorktreeModal({ repoId, onClose }: { repoId: string; 
   const [prDescription, setPrDescription] = useState("");
   const [issue, setIssue] = useState("");
   const [issueDescription, setIssueDescription] = useState("");
+  /** the repo's configured worktree dir; blank means `${repo.path}-worktrees` */
+  const [worktreeDir, setWorktreeDir] = useState<string | null>(null);
 
   const activeRepo = tree.find((r) => r.repoId === repo);
   // git refuses to check the same branch out twice; show them, disabled
@@ -49,15 +54,33 @@ export default function NewWorktreeModal({ repoId, onClose }: { repoId: string; 
       setBranches({ local: [], remote: [], tags: [] });
       return;
     }
+    // refs are repo-scoped: carrying a base/branch across a repo switch lets
+    // Create submit something that doesn't exist in the selected repository
     setBranches(null);
+    setBase("");
+    setExisting("");
+    setExistingKind("local");
     ipc
       .listBranches(repo)
       .then((b) => {
         setBranches(b);
-        if (!base) setBase(b.local.includes("main") ? "main" : (b.local[0] ?? ""));
+        setBase(b.local.includes("main") ? "main" : (b.local[0] ?? ""));
       })
       .catch(() => setBranches({ local: [], remote: [], tags: [] }));
     // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [repo]);
+
+  // read the repo's worktreeDir so the destination shown is the real one
+  useEffect(() => {
+    if (!hasBackend() || !repo) return;
+    let alive = true;
+    ipc
+      .getSettings()
+      .then((st) => alive && setWorktreeDir(st.repos.find((r) => r.id === repo)?.worktreeDir ?? ""))
+      .catch(() => alive && setWorktreeDir(null));
+    return () => {
+      alive = false;
+    };
   }, [repo]);
 
   useEffect(() => {
@@ -86,8 +109,12 @@ export default function NewWorktreeModal({ repoId, onClose }: { repoId: string; 
   }
 
   const branch = mode === "new" ? name.trim() : existing;
-  const slug = slugify(branch || "new-branch");
   const ok = !!branch;
+  // create_worktree: `${worktree_dir || repo.path + "-worktrees"}/${sanitize_branch(branch)}`
+  const destination =
+    ok && worktreeDir !== null && activeRepo
+      ? `${worktreeDir.trim() || `${activeRepo.path}-worktrees`}/${sanitizeBranch(branch)}`
+      : null;
 
   async function create() {
     if (!ok) return;
@@ -99,13 +126,19 @@ export default function NewWorktreeModal({ repoId, onClose }: { repoId: string; 
         showToast("New worktree needs the desktop app");
         return;
       }
+      // `git worktree add <path> origin/foo` checks out the remote-tracking ref
+      // DETACHED. A remote pick has to become a real local branch tracking it —
+      // reuse the local one if it already exists, otherwise create it.
+      const localOf = (ref: string) => ref.replace(/^[^/]+\//, "");
       const payload =
         mode === "new"
           ? { branch, base: base || undefined, createBranch: true }
           : existingKind === "tags"
             ? // checking out a tag → create a local branch named after it
               { branch: existing, base: `refs/tags/${existing}`, createBranch: true }
-            : { branch: existing, createBranch: false };
+            : existingKind === "remote"
+              ? { branch: localOf(existing), base: existing, createBranch: !branches?.local.includes(localOf(existing)) }
+              : { branch: existing, createBranch: false };
 
       const wtPath = await ipc.createWorktree({ repoId: repo, ...payload });
       // seed the human handoff now, keyed by the new path — the runtime
@@ -229,9 +262,7 @@ export default function NewWorktreeModal({ repoId, onClose }: { repoId: string; 
         <div className="cxm-flab">You'll get</div>
         <dl className="cx-kv">
           <dt>Path</dt>
-          <dd>
-            .worktrees/<em>{ok ? slug : "…"}</em>
-          </dd>
+          <dd title={destination ?? undefined}>{destination ?? "—"}</dd>
           {/* TODO(#58): ports and the database name are assigned inside
               create_worktree. Deriving them here would duplicate backend logic
               that can drift, and a wrong port is worse than a blank one. */}

--- a/src/app/RemoveWorktreeModal.tsx
+++ b/src/app/RemoveWorktreeModal.tsx
@@ -11,9 +11,14 @@ import type { WorktreeNode } from "../types";
 import { Alert, Info, Spinner, Trash } from "../icons";
 import Modal, { Hint, Spacer } from "./canopy/Modal";
 
+/** git::dirty_report truncates `status --porcelain` with .take(10), so a
+    result of exactly this length is a floor rather than a total. */
+const DIRTY_CAP = 10;
+
 export default function RemoveWorktreeModal({ wt, onClose }: { wt: WorktreeNode; onClose: () => void }) {
   const showToast = useStore((s) => s.showToast);
   const [report, setReport] = useState<{ dirty: boolean; details: string[] } | null>(null);
+  const [probeError, setProbeError] = useState<string | null>(null);
   const [deleteBranch, setDeleteBranch] = useState(false);
   const [dropDb, setDropDb] = useState(true);
   const [busy, setBusy] = useState(false);
@@ -25,10 +30,19 @@ export default function RemoveWorktreeModal({ wt, onClose }: { wt: WorktreeNode;
       setReport({ dirty: false, details: [] });
       return;
     }
+    // Fail CLOSED. Treating a failed probe as "clean" would let the dialog
+    // assert nothing is uncommitted and arm a destructive delete on the
+    // strength of an error.
     ipc
       .worktreeDirtyReport(wt.wtKey)
-      .then(setReport)
-      .catch(() => setReport({ dirty: false, details: [] }));
+      .then((r) => {
+        setReport(r);
+        setProbeError(null);
+      })
+      .catch((e) => {
+        setReport(null);
+        setProbeError(String(e));
+      });
   }, [wt.wtKey]);
 
   const armed = confirm.trim() === wt.branch;
@@ -67,7 +81,7 @@ export default function RemoveWorktreeModal({ wt, onClose }: { wt: WorktreeNode;
           <button className="cx-btn cx-btn--ghost" onClick={onClose} disabled={busy}>
             Cancel
           </button>
-          <button className="cx-btn cx-btn--danger" onClick={remove} disabled={busy || !armed || !report}>
+          <button className="cx-btn cx-btn--danger" onClick={remove} disabled={busy || !armed || !report || !!probeError}>
             {busy ? (
               <>
                 <Spinner size={12} />
@@ -83,7 +97,18 @@ export default function RemoveWorktreeModal({ wt, onClose }: { wt: WorktreeNode;
         </>
       }
     >
-      {!report ? (
+      {probeError ? (
+        <div className="cx-alert cx-alert--error">
+          <span className="cx-alert__ic">
+            <Alert size={13} />
+          </span>
+          <div>
+            <b>Could not check for uncommitted changes.</b>
+            <pre>{probeError}</pre>
+            Removal is disabled until this succeeds — deleting without knowing what is here could lose work.
+          </div>
+        </div>
+      ) : !report ? (
         <div className="cxm-prog" style={{ borderTop: 0, marginTop: 0, paddingTop: 0 }}>
           <span className="cxm-prog__ic">
             <Spinner size={13} />
@@ -97,9 +122,14 @@ export default function RemoveWorktreeModal({ wt, onClose }: { wt: WorktreeNode;
           </span>
           <div>
             <b>
-              {report.details.length} uncommitted change{report.details.length === 1 ? "" : "s"} will be lost.
+              {report.details.length >= DIRTY_CAP
+                ? `At least ${DIRTY_CAP} uncommitted changes will be lost.`
+                : `${report.details.length} uncommitted change${report.details.length === 1 ? "" : "s"} will be lost.`}
             </b>
             <pre>{report.details.join("\n")}</pre>
+            {report.details.length >= DIRTY_CAP && (
+              <span style={{ color: "var(--red-text-soft)" }}>Showing the first {DIRTY_CAP}; there may be more.</span>
+            )}
           </div>
         </div>
       ) : (

--- a/src/app/RemoveWorktreeModal.tsx
+++ b/src/app/RemoveWorktreeModal.tsx
@@ -1,17 +1,23 @@
-// Remove-worktree confirm: shows dirty state (incl. submodules) and warns that
-// the worktree's private submodule clones die with it.
+/* Remove worktree — the destructive dialog.
+
+   Warnings say what is lost, concretely: the count, then the actual file list.
+   Never "This action cannot be undone." The primary is armed only once the
+   branch name is typed back, because the cost here is unrecoverable work in
+   private submodule clones, not just a directory. */
 import { useEffect, useState } from "react";
 import { hasBackend, ipc } from "../ipc";
 import { useStore } from "../store";
 import type { WorktreeNode } from "../types";
-import { Spinner } from "../icons";
+import { Alert, Info, Spinner, Trash } from "../icons";
+import Modal, { Hint, Spacer } from "./canopy/Modal";
 
 export default function RemoveWorktreeModal({ wt, onClose }: { wt: WorktreeNode; onClose: () => void }) {
   const showToast = useStore((s) => s.showToast);
   const [report, setReport] = useState<{ dirty: boolean; details: string[] } | null>(null);
   const [deleteBranch, setDeleteBranch] = useState(false);
-  const [dropDb, setDropDb] = useState(true); // default on
+  const [dropDb, setDropDb] = useState(true);
   const [busy, setBusy] = useState(false);
+  const [confirm, setConfirm] = useState("");
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -19,8 +25,14 @@ export default function RemoveWorktreeModal({ wt, onClose }: { wt: WorktreeNode;
       setReport({ dirty: false, details: [] });
       return;
     }
-    ipc.worktreeDirtyReport(wt.wtKey).then(setReport);
+    ipc
+      .worktreeDirtyReport(wt.wtKey)
+      .then(setReport)
+      .catch(() => setReport({ dirty: false, details: [] }));
   }, [wt.wtKey]);
+
+  const armed = confirm.trim() === wt.branch;
+  const ahead = wt.git?.ahead ?? 0;
 
   async function remove() {
     setBusy(true);
@@ -41,53 +53,129 @@ export default function RemoveWorktreeModal({ wt, onClose }: { wt: WorktreeNode;
   }
 
   return (
-    <div className="modal-backdrop" onMouseDown={(e) => e.target === e.currentTarget && !busy && onClose()}>
-      <div className="modal">
-        <div className="modal-head">Remove worktree — {wt.branch}</div>
-        <div className="modal-body">
-          <div style={{ fontSize: 12.5, color: "var(--dim)", lineHeight: 1.55 }}>
-            Deletes <span className="gitnum">{wt.path}</span> including its private submodule checkouts. Unpushed
-            commits inside submodules are lost.
-          </div>
-          {!report ? (
-            <div className="modal-progress">
-              <Spinner size={14} />
-              <div className="modal-progress-lines">checking for uncommitted changes…</div>
-            </div>
-          ) : report.dirty ? (
-            <div className="modal-dirty">
-              ● uncommitted changes:{"\n"}
-              {report.details.join("\n")}
-            </div>
-          ) : (
-            <div style={{ fontSize: 12, color: "var(--run)" }}>○ clean — no uncommitted changes</div>
-          )}
-          {wt.dbName && (
-            <label style={{ display: "flex", alignItems: "center", gap: 7, fontSize: 12.5, color: "var(--dim)", cursor: "pointer" }}>
-              <input type="checkbox" checked={dropDb} onChange={(e) => setDropDb(e.target.checked)} />
-              Drop database <span className="gitnum">{wt.dbName}</span>
-            </label>
-          )}
-          <label style={{ display: "flex", alignItems: "center", gap: 7, fontSize: 12.5, color: "var(--dim)", cursor: "pointer" }}>
-            <input type="checkbox" checked={deleteBranch} onChange={(e) => setDeleteBranch(e.target.checked)} />
-            Also delete branch <span className="gitnum">{wt.branch}</span>
-          </label>
-          {error && <div className="modal-error">{error}</div>}
-        </div>
-        <div className="modal-foot">
-          <button className="iconbtn" onClick={onClose} disabled={busy}>
+    <Modal
+      icon={Trash}
+      danger
+      title="Remove worktree"
+      sub={wt.branch}
+      busy={busy}
+      onClose={onClose}
+      foot={
+        <>
+          <Hint icon={Info}>The branch itself is kept unless you tick it</Hint>
+          <Spacer />
+          <button className="cx-btn cx-btn--ghost" onClick={onClose} disabled={busy}>
             Cancel
           </button>
-          <button
-            className="iconbtn"
-            style={{ background: "var(--stop)", color: "#fff", fontWeight: 600 }}
-            onClick={remove}
-            disabled={busy || !report}
-          >
-            {busy ? "Removing…" : "Remove worktree"}
+          <button className="cx-btn cx-btn--danger" onClick={remove} disabled={busy || !armed || !report}>
+            {busy ? (
+              <>
+                <Spinner size={12} />
+                Removing…
+              </>
+            ) : (
+              <>
+                <Trash size={12} />
+                Remove worktree
+              </>
+            )}
           </button>
+        </>
+      }
+    >
+      {!report ? (
+        <div className="cxm-prog" style={{ borderTop: 0, marginTop: 0, paddingTop: 0 }}>
+          <span className="cxm-prog__ic">
+            <Spinner size={13} />
+          </span>
+          <div className="cxm-prog__lines">checking for uncommitted changes…</div>
         </div>
+      ) : report.dirty ? (
+        <div className="cx-alert cx-alert--error">
+          <span className="cx-alert__ic">
+            <Alert size={13} />
+          </span>
+          <div>
+            <b>
+              {report.details.length} uncommitted change{report.details.length === 1 ? "" : "s"} will be lost.
+            </b>
+            <pre>{report.details.join("\n")}</pre>
+          </div>
+        </div>
+      ) : (
+        <div className="cx-alert cx-alert--ok">
+          <span className="cx-alert__ic">
+            <Info size={13} />
+          </span>
+          <div>Clean — nothing uncommitted in the worktree or its submodules.</div>
+        </div>
+      )}
+
+      <p
+        style={{
+          fontSize: "var(--fs-body)",
+          color: "var(--text-secondary)",
+          lineHeight: "var(--lh-body)",
+          margin: "0 0 var(--sp-modal-head)",
+        }}
+      >
+        Deletes <span style={{ fontFamily: "var(--mono)", fontSize: "var(--fs-small)" }}>{wt.path}</span> and its private
+        submodule checkouts. Unpushed commits inside submodules cannot be recovered.
+      </p>
+
+      {wt.dbName && (
+        <label className="cxm-chk">
+          <input type="checkbox" checked={dropDb} onChange={(e) => setDropDb(e.target.checked)} disabled={busy} />
+          <span className="cxm-chk__tx">
+            <b>Drop database</b>
+            <span className="mono">{wt.dbName}</span>
+          </span>
+        </label>
+      )}
+
+      <label className="cxm-chk">
+        <input
+          type="checkbox"
+          checked={deleteBranch}
+          onChange={(e) => setDeleteBranch(e.target.checked)}
+          disabled={busy}
+        />
+        <span className="cxm-chk__tx">
+          <b>Also delete the branch</b>
+          <span>
+            {ahead > 0
+              ? `${ahead} commit${ahead === 1 ? "" : "s"} not on origin — they would be lost too.`
+              : `${wt.branch} is kept unless you tick this.`}
+          </span>
+        </span>
+      </label>
+
+      <div className="cxm-fld" style={{ marginTop: "var(--sp-modal-head)" }}>
+        <div className="cxm-flab cxm-flab--f">
+          Type{" "}
+          <span style={{ fontFamily: "var(--mono)", textTransform: "none", letterSpacing: 0, color: "var(--red-text)" }}>
+            {wt.branch}
+          </span>{" "}
+          to confirm
+        </div>
+        <input
+          className="cx-input cx-input--mono"
+          value={confirm}
+          spellCheck={false}
+          placeholder={wt.branch}
+          onChange={(e) => setConfirm(e.target.value)}
+          disabled={busy}
+        />
       </div>
-    </div>
+
+      {error && (
+        <div className="cx-alert cx-alert--error" style={{ marginTop: "var(--sp-modal-head)" }}>
+          <span className="cx-alert__ic">
+            <Alert size={13} />
+          </span>
+          <div>{error}</div>
+        </div>
+      )}
+    </Modal>
   );
 }

--- a/src/app/SwitchBranchModal.tsx
+++ b/src/app/SwitchBranchModal.tsx
@@ -62,7 +62,17 @@ export default function SwitchBranchModal({
   );
   const canCreate = !!t && !known.has(t) && !t.startsWith("origin/");
 
-  async function go(name: string, create: boolean) {
+  /** `git checkout origin/foo` detaches HEAD. Switching to a remote row means
+      the local short name: reuse it if present, else create it from the remote. */
+  async function goRef(ref: string, kind: "local" | "remote" | "new") {
+    if (kind === "remote") {
+      const local = ref.replace(/^[^/]+\//, "");
+      return go(local, !(branches?.local ?? []).includes(local), ref);
+    }
+    return go(ref, kind === "new");
+  }
+
+  async function go(name: string, create: boolean, from?: string) {
     setBusy(true);
     setError(null);
     try {
@@ -70,7 +80,7 @@ export default function SwitchBranchModal({
         showToast("Switching branch needs the desktop app");
         return;
       }
-      await ipc.switchWorktreeBranch(wt.wtKey, name, create, create ? current : undefined);
+      await ipc.switchWorktreeBranch(wt.wtKey, name, create, create ? (from ?? current) : undefined);
       showToast(`Switched to ${name} — dependencies reused`);
       onClose();
     } catch (e) {
@@ -116,7 +126,7 @@ export default function SwitchBranchModal({
         {!branches && <div className="cxm-pick-e">Loading branches…</div>}
 
         {canCreate && (
-          <button className="cxm-pick-i cxm-pick-i--new" onClick={() => go(t, true)} disabled={busy}>
+          <button className="cxm-pick-i cxm-pick-i--new" onClick={() => goRef(t, "new")} disabled={busy}>
             <span className="ic">
               <Plus size={12} />
             </span>
@@ -131,15 +141,16 @@ export default function SwitchBranchModal({
           <div key={g.k}>
             <div className="cxm-pick-g">{g.label}</div>
             {g.items.map((n) => {
-              const isCur = n === current;
-              const taken = g.k === "local" && inUse.has(n) && !isCur;
+              const short = g.k === "remote" ? n.replace(/^[^/]+\//, "") : n;
+              const isCur = short === current;
+              const taken = inUse.has(short) && !isCur;
               return (
                 <button
                   key={g.k + n}
                   className={"cxm-pick-i" + (isCur ? " is-on" : "")}
                   disabled={isCur || taken || busy}
                   title={taken ? `${n} is checked out in another worktree` : undefined}
-                  onClick={() => go(n, false)}
+                  onClick={() => goRef(n, g.k)}
                 >
                   <span className="ic">
                     <Fork size={12} />

--- a/src/app/SwitchBranchModal.tsx
+++ b/src/app/SwitchBranchModal.tsx
@@ -1,95 +1,16 @@
-// Switch branch in place — check out a different branch in THIS worktree folder,
-// so node_modules / build output are reused (no reinstall/setup). Two modes:
-// switch to an existing branch, or create a new branch from a base.
-import { useEffect, useRef, useState } from "react";
-import { hasBackend, ipc } from "../ipc";
+/* Switch branch, in place — the cheap alternative to a new worktree.
+
+   The point of this dialog is the subtitle: switching reuses the dependencies
+   already installed here, so it costs ~0s where a new worktree costs a full
+   provision. The warning is equally specific — uncommitted work carries over
+   rather than being stashed, which is occasionally what you want and
+   occasionally a nasty surprise. */
+import { useEffect, useMemo, useState } from "react";
+import { hasBackend, ipc, type Branches } from "../ipc";
 import { useStore } from "../store";
 import type { RepoNode, WorktreeNode } from "../types";
-import { Fork, Refresh, Search, Spinner } from "../icons";
-
-type RefKind = "local" | "remote" | "tag";
-interface BranchItem {
-  name: string;
-  kind: RefKind;
-  inUse?: boolean; // checked out in another worktree → can't check out here
-  current?: boolean;
-}
-
-/** Searchable ref picker (reuses the .bp-* styles), with in-use disabling. */
-function Picker({
-  value,
-  items,
-  onPick,
-  placeholder,
-  disabled,
-}: {
-  value: string;
-  items: BranchItem[];
-  onPick: (name: string, kind: RefKind) => void;
-  placeholder: string;
-  disabled?: boolean;
-}) {
-  const [q, setQ] = useState("");
-  const [open, setOpen] = useState(false);
-  const boxRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    function onDoc(e: MouseEvent) {
-      if (boxRef.current && !boxRef.current.contains(e.target as Node)) setOpen(false);
-    }
-    document.addEventListener("mousedown", onDoc);
-    return () => document.removeEventListener("mousedown", onDoc);
-  }, []);
-
-  const needle = q.toLowerCase();
-  const filtered = items.filter((b) => b.name.toLowerCase().includes(needle)).slice(0, 60);
-
-  return (
-    <div className="bp" ref={boxRef}>
-      <div className="bp-field" onClick={() => !disabled && setOpen(true)}>
-        <Search size={13} />
-        <input
-          className="bp-input"
-          value={open ? q : value || ""}
-          placeholder={value || placeholder}
-          disabled={disabled}
-          onFocusCapture={() => setOpen(true)}
-          onChange={(e) => {
-            setQ(e.target.value);
-            setOpen(true);
-          }}
-        />
-      </div>
-      {open && (
-        <div className="bp-list">
-          {filtered.length === 0 ? (
-            <div className="bp-empty">no matching branches</div>
-          ) : (
-            filtered.map((b) => (
-              <button
-                key={b.kind + ":" + b.name}
-                className={"bp-item" + (b.name === value ? " sel" : "") + (b.inUse ? " dis" : "")}
-                disabled={b.inUse}
-                title={b.inUse ? "Checked out in another worktree" : undefined}
-                onClick={() => {
-                  if (b.inUse) return;
-                  onPick(b.name, b.kind);
-                  setQ("");
-                  setOpen(false);
-                }}
-              >
-                <span className="bp-name">{b.name}</span>
-                {b.current && <span className="bp-tag cur">current</span>}
-                {b.inUse && <span className="bp-tag warn">in worktree</span>}
-                {b.kind !== "local" && !b.inUse && <span className="bp-tag">{b.kind}</span>}
-              </button>
-            ))
-          )}
-        </div>
-      )}
-    </div>
-  );
-}
+import { Alert, Fork, Plus, Search, Spinner, Swap } from "../icons";
+import Modal, { Hint, Spacer } from "./canopy/Modal";
 
 export default function SwitchBranchModal({
   repo,
@@ -103,78 +24,54 @@ export default function SwitchBranchModal({
   const showToast = useStore((s) => s.showToast);
   const current = wt.branch;
 
-  const [branches, setBranches] = useState<{ local: string[]; remote: string[]; tags: string[] }>({
-    local: [],
-    remote: [],
-    tags: [],
-  });
-  const [mode, setMode] = useState<"existing" | "new">("existing");
-  const [target, setTarget] = useState<{ name: string; kind: RefKind } | null>(null);
-  const [name, setName] = useState("");
-  const [base, setBase] = useState<{ name: string; kind: RefKind }>({ name: current, kind: "local" });
+  const [branches, setBranches] = useState<Branches | null>(null);
+  const [q, setQ] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   // branches checked out in OTHER worktrees of this repo (git blocks re-checkout)
-  const inUse = new Set(repo.worktrees.filter((w) => w.wtKey !== wt.wtKey).map((w) => w.branch));
+  const inUse = useMemo(
+    () => new Set(repo.worktrees.filter((w) => w.wtKey !== wt.wtKey).map((w) => w.branch)),
+    [repo.worktrees, wt.wtKey],
+  );
 
   useEffect(() => {
-    if (!hasBackend()) return;
-    ipc.listBranches(repo.repoId).then(setBranches).catch(() => {});
+    if (!hasBackend()) {
+      setBranches({ local: [], remote: [], tags: [] });
+      return;
+    }
+    ipc
+      .listBranches(repo.repoId)
+      .then(setBranches)
+      .catch(() => setBranches({ local: [], remote: [], tags: [] }));
   }, [repo.repoId]);
 
-  const localItems: BranchItem[] = branches.local.map((b) => ({
-    name: b,
-    kind: "local" as const,
-    inUse: inUse.has(b) && b !== current,
-    current: b === current,
-  }));
-  // a remote pick materializes as its short local name — so origin/foo is
-  // blocked when local foo is checked out in another worktree
-  const shortName = (r: string) => r.split("/").slice(1).join("/");
-  const remoteItems: BranchItem[] = branches.remote.map((b) => ({
-    name: b,
-    kind: "remote" as const,
-    inUse: inUse.has(shortName(b)) && shortName(b) !== current,
-  }));
-  const tagItems: BranchItem[] = (branches.tags ?? []).map((t) => ({ name: t, kind: "tag" as const }));
-  const allItems = [...localItems, ...remoteItems, ...tagItems];
+  const t = q.trim();
+  const groups = useMemo(() => {
+    if (!branches) return [];
+    const match = (n: string) => !t || n.toLowerCase().includes(t.toLowerCase());
+    return [
+      { k: "local" as const, label: "Local", items: branches.local.filter(match) },
+      { k: "remote" as const, label: "Remote", items: branches.remote.filter(match) },
+    ].filter((g) => g.items.length);
+  }, [branches, t]);
 
-  const nextBranch = mode === "existing" ? target?.name ?? "" : name.trim();
-  const canGo = mode === "existing" ? !!target && target.name !== current : !!name.trim();
+  const known = useMemo(
+    () => new Set([...(branches?.local ?? []), ...(branches?.remote ?? []), ...(branches?.tags ?? [])]),
+    [branches],
+  );
+  const canCreate = !!t && !known.has(t) && !t.startsWith("origin/");
 
-  async function go() {
-    setError(null);
-    // resolve {branch, create, base} from the active mode + ref kind
-    let payload: { branch: string; create: boolean; base?: string };
-    if (mode === "existing") {
-      if (!target) return setError("Pick a branch");
-      if (target.kind === "remote") {
-        // if the local branch already exists, check it out instead of `-b`
-        // (which would fail with "branch already exists")
-        const local = target.name.split("/").slice(1).join("/");
-        payload = branches.local.includes(local)
-          ? { branch: local, create: false }
-          : { branch: local, create: true, base: target.name };
-      } else if (target.kind === "tag") {
-        payload = { branch: target.name, create: true, base: `refs/tags/${target.name}` };
-      } else {
-        payload = { branch: target.name, create: false };
-      }
-    } else {
-      if (!name.trim()) return setError("Branch name required");
-      const b = base.kind === "tag" ? `refs/tags/${base.name}` : base.name;
-      payload = { branch: name.trim(), create: true, base: b };
-    }
-
+  async function go(name: string, create: boolean) {
     setBusy(true);
+    setError(null);
     try {
       if (!hasBackend()) {
-        showToast("Switch branch needs the desktop app");
+        showToast("Switching branch needs the desktop app");
         return;
       }
-      await ipc.switchWorktreeBranch(wt.wtKey, payload.branch, payload.create, payload.base);
-      showToast(`Switched to ${payload.branch} — deps reused`);
+      await ipc.switchWorktreeBranch(wt.wtKey, name, create, create ? current : undefined);
+      showToast(`Switched to ${name} — dependencies reused`);
       onClose();
     } catch (e) {
       setError(String(e));
@@ -184,95 +81,98 @@ export default function SwitchBranchModal({
   }
 
   return (
-    <div className="modal-backdrop" onMouseDown={(e) => e.target === e.currentTarget && !busy && onClose()}>
-      <div className="modal">
-        <div className="modal-head">
-          <span className="fork" style={{ color: "var(--accent)", display: "inline-flex" }}>
-            <Fork size={15} />
-          </span>
-          Switch branch
-        </div>
-
-        <div className="modal-body">
-          <div className="switch-reuse">
-            <span className="sr-ic">
-              <Refresh size={14} />
-            </span>
-            <span>
-              In-place switch — same folder, so <code>node_modules</code> and build output are reused. Submodules are re-pinned to the target branch, which can take a moment on big repos.
-            </span>
-          </div>
-
-          <div className="switch-line">
-            <span className="sl-cur">
-              <Fork size={12} /> {current}
-            </span>
-            <span className="sl-arrow">→</span>
-            <span className={"sl-next" + (canGo ? "" : " empty")}>{nextBranch || "choose a branch"}</span>
-          </div>
-
-          <div className="modal-mode">
-            <button className={"console-tab" + (mode === "existing" ? " sel" : "")} onClick={() => setMode("existing")} disabled={busy}>
-              Switch to existing
-            </button>
-            <button className={"console-tab" + (mode === "new" ? " sel" : "")} onClick={() => setMode("new")} disabled={busy}>
-              New branch
-            </button>
-          </div>
-
-          {mode === "new" && (
-            <>
-              <label className="set-label">New branch name</label>
-              <input
-                className="set-input"
-                placeholder="feat/my-thing"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                disabled={busy}
-                autoFocus
-                spellCheck={false}
-              />
-            </>
-          )}
-
-          <label className="set-label">{mode === "existing" ? "Branch to check out" : "Base branch"}</label>
-          {mode === "existing" ? (
-            <Picker
-              value={target?.name ?? ""}
-              items={allItems}
-              onPick={(name, kind) => setTarget({ name, kind })}
-              placeholder="search branches, remotes, tags…"
-              disabled={busy}
-            />
-          ) : (
-            <Picker
-              value={base.name}
-              items={allItems}
-              onPick={(name, kind) => setBase({ name, kind })}
-              placeholder="search base…"
-              disabled={busy}
-            />
-          )}
-
-          {wt.git?.dirty && (
-            <div className="switch-warn">
-              This worktree has <b>uncommitted changes</b> — they'll be carried onto <code>{nextBranch || "the new branch"}</code>. Commit or
-              stash first for a clean switch.
-            </div>
-          )}
-          {error && <div className="modal-error">{error}</div>}
-        </div>
-
-        <div className="modal-foot">
-          <button className="iconbtn" onClick={onClose} disabled={busy}>
+    <Modal
+      icon={Swap}
+      title="Switch branch"
+      sub={`on ${current} · reuses dependencies, ~0s setup`}
+      narrow
+      busy={busy}
+      onClose={onClose}
+      foot={
+        <>
+          <Hint icon={Alert} tone="warn">
+            Uncommitted changes carry over
+          </Hint>
+          <Spacer />
+          <button className="cx-btn cx-btn--ghost" onClick={onClose} disabled={busy}>
             Cancel
           </button>
-          <button className="iconbtn primary" onClick={go} disabled={busy || !canGo}>
-            {busy ? <Spinner size={13} /> : null}
-            {busy ? "Switching…" : "Switch branch"}
-          </button>
-        </div>
+        </>
+      }
+    >
+      <div className="cxm-pick-f" style={{ marginBottom: "var(--sp-row)" }}>
+        <Search size={12} />
+        <input
+          autoFocus
+          value={q}
+          spellCheck={false}
+          placeholder="Switch to a branch, or type a new name…"
+          onChange={(e) => setQ(e.target.value)}
+          disabled={busy}
+        />
       </div>
-    </div>
+
+      <div style={{ maxHeight: 260, overflowY: "auto", margin: "0 calc(var(--sp-xs) * -1)" }}>
+        {!branches && <div className="cxm-pick-e">Loading branches…</div>}
+
+        {canCreate && (
+          <button className="cxm-pick-i cxm-pick-i--new" onClick={() => go(t, true)} disabled={busy}>
+            <span className="ic">
+              <Plus size={12} />
+            </span>
+            <span className="nm">
+              Create branch <b style={{ fontWeight: 600 }}>{t}</b>
+            </span>
+            <span className="cx-tag">off {current}</span>
+          </button>
+        )}
+
+        {groups.map((g) => (
+          <div key={g.k}>
+            <div className="cxm-pick-g">{g.label}</div>
+            {g.items.map((n) => {
+              const isCur = n === current;
+              const taken = g.k === "local" && inUse.has(n) && !isCur;
+              return (
+                <button
+                  key={g.k + n}
+                  className={"cxm-pick-i" + (isCur ? " is-on" : "")}
+                  disabled={isCur || taken || busy}
+                  title={taken ? `${n} is checked out in another worktree` : undefined}
+                  onClick={() => go(n, false)}
+                >
+                  <span className="ic">
+                    <Fork size={12} />
+                  </span>
+                  <span className="nm">{n}</span>
+                  {isCur && <span className="cx-tag">current</span>}
+                  {taken && <span className="cx-tag cx-tag--warn">in use</span>}
+                </button>
+              );
+            })}
+          </div>
+        ))}
+
+        {branches && !groups.length && !canCreate && <div className="cxm-pick-e">No branches match “{q}”.</div>}
+      </div>
+
+      {busy && (
+        <div className="cxm-prog">
+          <span className="cxm-prog__ic">
+            <Spinner size={13} />
+          </span>
+          <div className="cxm-prog__lines">switching…</div>
+        </div>
+      )}
+
+      {error && (
+        <div className="cx-alert cx-alert--error" style={{ marginTop: "var(--sp-modal-head)" }}>
+          <span className="cx-alert__ic">
+            <Alert size={13} />
+          </span>
+          <div>{error}</div>
+        </div>
+      )}
+    </Modal>
   );
 }

--- a/src/app/WorktreeContext.tsx
+++ b/src/app/WorktreeContext.tsx
@@ -72,6 +72,13 @@ function load(key: string): WtContext {
   return EMPTY;
 }
 
+/** Read a worktree's context outside React. Launches use this rather than a
+    hook snapshot: `useWtContext` is per-caller state, so an edit in the
+    context editor would not be visible to a launcher holding its own copy. */
+export function readWtContext(wtKey: string): WtContext {
+  return load(`canopy.ctx.${wtKey}`);
+}
+
 /** Load/save a worktree's context, reloading when the selected worktree changes. */
 export function useWtContext(wtKey: string): [WtContext, (c: WtContext) => void] {
   const key = `canopy.ctx.${wtKey}`;

--- a/src/app/canopy/AnchoredMenu.tsx
+++ b/src/app/canopy/AnchoredMenu.tsx
@@ -1,0 +1,88 @@
+/* A menu that floats free of its trigger's layout.
+
+   Anchored popovers cannot live inside the chrome that opens them. Two
+   separate things trap them:
+
+     · `.cxs-wtbar` sets `overflow: hidden` so a long branch name ellipses —
+       and an ancestor's clip beats any z-index a descendant can set.
+     · `.cxs-main` sets `container-type: inline-size` for the pane queries,
+       which applies layout containment. That makes it both a stacking
+       context and the containing block for absolutely positioned children,
+       so a popover inside it can never paint above the status bar.
+
+   So the menu is portalled to <body> and positioned from the trigger's
+   viewport rect. Fixed rather than absolute, because the reference is a
+   viewport rect and the app itself never scrolls. */
+import { useEffect, useLayoutEffect, useRef, useState, type ReactNode, type RefObject } from "react";
+import { createPortal } from "react-dom";
+
+export default function AnchoredMenu({
+  anchor,
+  onClose,
+  align = "right",
+  width,
+  children,
+}: {
+  anchor: RefObject<HTMLElement | null>;
+  onClose: () => void;
+  /** which edge of the menu lines up with the trigger */
+  align?: "left" | "right";
+  width?: number;
+  children: ReactNode;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState<{ top: number; left?: number; right?: number } | null>(null);
+
+  // measure before paint so the menu never shows at 0,0 for a frame
+  useLayoutEffect(() => {
+    const place = () => {
+      const a = anchor.current?.getBoundingClientRect();
+      if (!a) return;
+      const gap = 4;
+      setPos(
+        align === "right"
+          ? { top: a.bottom + gap, right: Math.max(gap, window.innerWidth - a.right) }
+          : { top: a.bottom + gap, left: Math.min(a.left, window.innerWidth - (width ?? 216) - gap) },
+      );
+    };
+    place();
+    window.addEventListener("resize", place);
+    return () => window.removeEventListener("resize", place);
+  }, [anchor, align, width]);
+
+  useEffect(() => {
+    // the trigger is outside this element, so a click on it would otherwise
+    // close-then-reopen; ignore anything inside the anchor too
+    const down = (e: MouseEvent) => {
+      const t = e.target as Node;
+      if (ref.current?.contains(t) || anchor.current?.contains(t)) return;
+      onClose();
+    };
+    const key = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onClose();
+      }
+    };
+    document.addEventListener("mousedown", down);
+    document.addEventListener("keydown", key, true);
+    return () => {
+      document.removeEventListener("mousedown", down);
+      document.removeEventListener("keydown", key, true);
+    };
+  }, [anchor, onClose]);
+
+  if (!pos) return null;
+
+  return createPortal(
+    <div
+      className="cx-pop"
+      role="menu"
+      ref={ref}
+      style={{ position: "fixed", top: pos.top, left: pos.left, right: pos.right, minWidth: width }}
+    >
+      {children}
+    </div>,
+    document.body,
+  );
+}

--- a/src/app/canopy/ContextModal.tsx
+++ b/src/app/canopy/ContextModal.tsx
@@ -3,7 +3,7 @@
    issue text into it; the runtime strip below is what the agent inherits
    whether or not anything is typed here. */
 import { useState } from "react";
-import { Copy, Doc, Info, Link, Plus, Sparkle } from "../../icons";
+import { Copy, Doc, Info, Link, Plus, Sparkle, X } from "../../icons";
 import { useStore } from "../../store";
 import type { RepoNode, WorktreeNode } from "../../types";
 import { composeContextMd, mdRender, runtimeFor, useWtContext } from "../WorktreeContext";
@@ -23,6 +23,8 @@ export default function ContextModal({
   const showToast = useStore((s) => s.showToast);
   const [ctx, setCtx] = useWtContext(wt.wtKey);
   const [tab, setTab] = useState<"write" | "preview">("write");
+  /** the inline add-a-link field; null when the affordance is at rest */
+  const [draftLink, setDraftLink] = useState<string | null>(null);
   const runtime = runtimeFor(repo, wt);
 
   return (
@@ -149,29 +151,68 @@ export default function ContextModal({
         </div>
       </div>
 
-      {ctx.links.length > 0 && (
-        <div className="cxm-fld">
-          <div className="cxm-flab">
-            <Link size={11} />
-            Links
-          </div>
-          <div className="cxm-links">
-            {ctx.links.map((l) => (
-              <span key={l.label} className="cxm-brc">
-                <Link size={10} />
-                <span className="n">{l.label}</span>
+      {/* Always rendered. Gating this on a non-empty list meant a fresh
+          context could never gain its first link — the add affordance was
+          hidden behind the thing it exists to create. */}
+      <div className="cxm-fld">
+        <div className="cxm-flab">
+          <Link size={11} />
+          Links
+        </div>
+        <div className="cxm-links">
+          {ctx.links.map((l) => (
+            <span key={l.label} className="cxm-brc" title={l.label}>
+              <Link size={10} />
+              <span className="n">{l.label}</span>
+              <span
+                className="x"
+                role="button"
+                tabIndex={0}
+                title={`Remove ${l.label}`}
+                onClick={() => setCtx({ ...ctx, links: ctx.links.filter((x) => x.label !== l.label) })}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    setCtx({ ...ctx, links: ctx.links.filter((x) => x.label !== l.label) });
+                  }
+                }}
+              >
+                <X size={9} />
               </span>
-            ))}
-            <span
-              className="cxm-brc cxm-brc--add"
-              onClick={() => showToast("Paste an issue or PR link into References above")}
-            >
+            </span>
+          ))}
+
+          {draftLink === null ? (
+            <button className="cxm-brc cxm-brc--add" onClick={() => setDraftLink("")}>
               <Plus size={10} />
               <span className="n">Add link</span>
-            </span>
-          </div>
+            </button>
+          ) : (
+            <input
+              className="cx-input cxm-linkin"
+              autoFocus
+              value={draftLink}
+              spellCheck={false}
+              placeholder="Paste an issue or PR link, then ⏎"
+              onChange={(e) => setDraftLink(e.target.value)}
+              onBlur={() => setDraftLink(null)}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") {
+                  e.stopPropagation();
+                  setDraftLink(null);
+                }
+                if (e.key === "Enter") {
+                  const v = draftLink.trim();
+                  if (!v) return setDraftLink(null);
+                  if (!ctx.links.some((l) => l.label === v))
+                    setCtx({ ...ctx, links: [...ctx.links, { label: v, kind: "link" }] });
+                  setDraftLink(null);
+                }
+              }}
+            />
+          )}
         </div>
-      )}
+      </div>
     </Modal>
   );
 }

--- a/src/app/canopy/ContextModal.tsx
+++ b/src/app/canopy/ContextModal.tsx
@@ -1,0 +1,177 @@
+/* The context editor — what the agent is seeded with, and what later becomes
+   the PR body. Write/Preview because the body is markdown and people paste
+   issue text into it; the runtime strip below is what the agent inherits
+   whether or not anything is typed here. */
+import { useState } from "react";
+import { Copy, Doc, Info, Link, Plus, Sparkle } from "../../icons";
+import { useStore } from "../../store";
+import type { RepoNode, WorktreeNode } from "../../types";
+import { composeContextMd, mdRender, runtimeFor, useWtContext } from "../WorktreeContext";
+import Modal, { Hint, Spacer } from "./Modal";
+
+export default function ContextModal({
+  repo,
+  wt,
+  onClose,
+  onStartAgent,
+}: {
+  repo: RepoNode;
+  wt: WorktreeNode;
+  onClose: () => void;
+  onStartAgent: () => void;
+}) {
+  const showToast = useStore((s) => s.showToast);
+  const [ctx, setCtx] = useWtContext(wt.wtKey);
+  const [tab, setTab] = useState<"write" | "preview">("write");
+  const runtime = runtimeFor(repo, wt);
+
+  return (
+    <Modal
+      icon={Doc}
+      title="Context"
+      sub={wt.branch}
+      wide
+      onClose={onClose}
+      foot={
+        <>
+          <Hint icon={Info}>Seeds the agent · becomes the PR body</Hint>
+          <Spacer />
+          <button
+            className="cx-btn cx-btn--ghost"
+            onClick={() => {
+              navigator.clipboard?.writeText(composeContextMd(ctx, runtime)).then(
+                () => showToast("Copied as PR body"),
+                () => showToast("Could not copy to the clipboard"),
+              );
+            }}
+          >
+            <Copy size={11} />
+            Copy as PR body
+          </button>
+          <button
+            className="cx-btn cx-btn--primary"
+            onClick={() => {
+              onStartAgent();
+              onClose();
+            }}
+          >
+            <Sparkle size={12} />
+            Start agent
+            <span className="cx-k">⌘⏎</span>
+          </button>
+        </>
+      }
+    >
+      <div className="cxm-fld">
+        <div className="cxm-flab">
+          Task
+          <div className="cx-seg cxm-opt" style={{ padding: "var(--sp-1)" }}>
+            <button className={tab === "write" ? "is-on" : ""} onClick={() => setTab("write")}>
+              Write
+            </button>
+            <button className={tab === "preview" ? "is-on" : ""} onClick={() => setTab("preview")}>
+              Preview
+            </button>
+          </div>
+        </div>
+        <input
+          className="cx-input"
+          style={{ fontSize: "var(--fs-md)", fontWeight: "var(--fw-semi)", marginBottom: "var(--sp-row)" }}
+          value={ctx.title}
+          onChange={(e) => setCtx({ ...ctx, title: e.target.value })}
+          placeholder="What is this worktree for?"
+        />
+        {tab === "write" ? (
+          <textarea
+            className="cx-input cx-input--mono"
+            style={{ minHeight: 150, lineHeight: 1.7 }}
+            value={ctx.body}
+            spellCheck={false}
+            onChange={(e) => setCtx({ ...ctx, body: e.target.value })}
+          />
+        ) : (
+          <div className="cxm-preview">{mdRender(ctx.body)}</div>
+        )}
+      </div>
+
+      <div className="cxm-fld">
+        <div className="cxm-flab">
+          <Link size={11} />
+          References
+          <span className="cxm-opt">handed over from New worktree</span>
+        </div>
+        <div className="cxm-ctxref">
+          <label>Pull request</label>
+          <input
+            className="cx-input"
+            value={ctx.pr}
+            spellCheck={false}
+            placeholder="https://github.com/org/repo/pull/123"
+            onChange={(e) => setCtx({ ...ctx, pr: e.target.value })}
+          />
+          <label>What it changes</label>
+          <textarea
+            className="cx-input"
+            value={ctx.prDescription}
+            onChange={(e) => setCtx({ ...ctx, prDescription: e.target.value })}
+          />
+          <label>Issue</label>
+          <input
+            className="cx-input"
+            value={ctx.issue}
+            spellCheck={false}
+            placeholder="https://github.com/org/repo/issues/42"
+            onChange={(e) => setCtx({ ...ctx, issue: e.target.value })}
+          />
+          <label>Problem</label>
+          <textarea
+            className="cx-input"
+            value={ctx.issueDescription}
+            onChange={(e) => setCtx({ ...ctx, issueDescription: e.target.value })}
+          />
+        </div>
+      </div>
+
+      <div className="cxm-fld">
+        <div className="cxm-flab">Runtime the agent inherits</div>
+        <div className="cxm-ctxrt">
+          <span>
+            branch <em>{runtime.branch}</em>
+          </span>
+          {runtime.ports.map((p) => (
+            <span key={p.name}>
+              {p.name.toLowerCase()} <em>:{p.port}</em>
+            </span>
+          ))}
+          <span>
+            db <em>{runtime.dbName ?? "none"}</em>
+          </span>
+        </div>
+      </div>
+
+      {ctx.links.length > 0 && (
+        <div className="cxm-fld">
+          <div className="cxm-flab">
+            <Link size={11} />
+            Links
+          </div>
+          <div className="cxm-links">
+            {ctx.links.map((l) => (
+              <span key={l.label} className="cxm-brc">
+                <Link size={10} />
+                <span className="n">{l.label}</span>
+              </span>
+            ))}
+            <span
+              className="cxm-brc cxm-brc--add"
+              onClick={() => showToast("Paste an issue or PR link into References above")}
+            >
+              <Plus size={10} />
+              <span className="n">Add link</span>
+            </span>
+          </div>
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/src/app/canopy/DatabaseModal.tsx
+++ b/src/app/canopy/DatabaseModal.tsx
@@ -56,13 +56,14 @@ export default function DatabaseModal({ wt, onClose }: { wt: WorktreeNode; onClo
         title="Save snapshot"
         sub={current ?? undefined}
         narrow
-        busy={busy}
         onClose={() => setSnap(null)}
         foot={
           <>
             <Spacer />
-            <button className="cx-btn cx-btn--ghost" onClick={() => setSnap(null)} disabled={busy}>
-              Cancel
+            {/* the snapshot is backend-owned and can take a while; dismissing
+                lets it finish rather than holding the dialog hostage */}
+            <button className="cx-btn cx-btn--ghost" onClick={() => setSnap(null)}>
+              {busy ? "Run in background" : "Cancel"}
             </button>
             <button
               className="cx-btn cx-btn--primary"

--- a/src/app/canopy/DatabaseModal.tsx
+++ b/src/app/canopy/DatabaseModal.tsx
@@ -1,0 +1,231 @@
+/* Database tools — the searchable switcher plus the real action set.
+
+   Snapshots are a NAME prompt defaulting to {db}_snap_<timestamp>, not a
+   managed list, and restore reads a dump from disk — that is what the backend
+   actually does, so that is what the dialog offers. Confirmations are past
+   tense and unremarkable: "Snapshot … created", "Now using tj_main". */
+import { useEffect, useState } from "react";
+import { Database, Download, Info, Refresh, Restart, Pull } from "../../icons";
+import { hasBackend, ipc } from "../../ipc";
+import { useStore } from "../../store";
+import type { WorktreeNode } from "../../types";
+import Modal, { Hint, Spacer } from "./Modal";
+
+const snapDefault = (db: string) => {
+  const d = new Date();
+  const p = (n: number) => String(n).padStart(2, "0");
+  return `${db}_snap_${d.getFullYear()}${p(d.getMonth() + 1)}${p(d.getDate())}_${p(d.getHours())}${p(d.getMinutes())}`;
+};
+
+export default function DatabaseModal({ wt, onClose }: { wt: WorktreeNode; onClose: () => void }) {
+  const showToast = useStore((s) => s.showToast);
+  const resetDb = useStore((s) => s.resetDb);
+  const [dbs, setDbs] = useState<string[]>([]);
+  const [current, setCurrent] = useState<string | null>(wt.dbName);
+  const [q, setQ] = useState("");
+  const [snap, setSnap] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    if (!hasBackend()) return;
+    ipc.listDatabases(wt.wtKey).then(setDbs).catch(() => {});
+    ipc.currentDatabase(wt.wtKey).then(setCurrent).catch(() => {});
+  }, [wt.wtKey]);
+
+  const list = dbs.filter((d) => d.toLowerCase().includes(q.toLowerCase()));
+
+  const switchTo = async (name: string) => {
+    if (name === current || !hasBackend()) return;
+    setBusy(true);
+    try {
+      await ipc.switchDatabase(wt.wtKey, name);
+      setCurrent(name);
+      showToast(`Now using ${name}`);
+    } catch (e) {
+      showToast(String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  /* ── the snapshot name prompt is its own step, not a separate dialog ── */
+  if (snap !== null) {
+    return (
+      <Modal
+        icon={Database}
+        title="Save snapshot"
+        sub={current ?? undefined}
+        narrow
+        busy={busy}
+        onClose={() => setSnap(null)}
+        foot={
+          <>
+            <Spacer />
+            <button className="cx-btn cx-btn--ghost" onClick={() => setSnap(null)} disabled={busy}>
+              Cancel
+            </button>
+            <button
+              className="cx-btn cx-btn--primary"
+              disabled={!snap.trim() || busy}
+              onClick={async () => {
+                setBusy(true);
+                try {
+                  if (hasBackend()) await ipc.snapshotDatabase(wt.wtKey, snap.trim());
+                  showToast(`Snapshot ${snap.trim()} created`);
+                  setSnap(null);
+                } catch (e) {
+                  showToast(String(e));
+                } finally {
+                  setBusy(false);
+                }
+              }}
+            >
+              Create
+              <span className="cx-k">⏎</span>
+            </button>
+          </>
+        }
+      >
+        <div className="cxm-fld">
+          <div className="cxm-flab cxm-flab--f">Snapshot name</div>
+          <input
+            className="cx-input cx-input--mono"
+            value={snap}
+            autoFocus
+            spellCheck={false}
+            onChange={(e) => setSnap(e.target.value)}
+          />
+          <div className="cxm-fhint">Copies {current} as it is right now. Restore it later from the actions list.</div>
+        </div>
+      </Modal>
+    );
+  }
+
+  return (
+    <Modal
+      icon={Database}
+      title="Database"
+      sub={current ? `${current} · isolated to this worktree` : "not configured"}
+      busy={busy}
+      onClose={onClose}
+      foot={
+        <>
+          <Hint icon={Info}>Each worktree gets its own database</Hint>
+          <Spacer />
+          <button className="cx-btn cx-btn--ghost" onClick={onClose}>
+            Close
+          </button>
+          <button
+            className="cx-btn cx-btn--primary"
+            onClick={async () => {
+              try {
+                if (hasBackend()) await ipc.runMigration(wt.wtKey);
+                showToast("Running migration…");
+                onClose();
+              } catch (e) {
+                showToast(String(e));
+              }
+            }}
+          >
+            <Restart size={12} />
+            Run migration
+            <span className="cx-k">⏎</span>
+          </button>
+        </>
+      }
+    >
+      <div className="cxm-fld">
+        <div className="cxm-flab">
+          <Database size={11} />
+          Switch database
+        </div>
+        <div className="cxm-pick-f" style={{ marginBottom: "var(--sp-tight)" }}>
+          <input placeholder="Search databases…" value={q} spellCheck={false} onChange={(e) => setQ(e.target.value)} />
+        </div>
+        <div className="cxm-dbl">
+          {list.length === 0 ? (
+            <div className="cxm-pick-e">{dbs.length ? `No databases match “${q}”.` : "No databases found."}</div>
+          ) : (
+            list.map((d) => (
+              <button key={d} className={"cxm-dbo" + (d === current ? " is-on" : "")} onClick={() => switchTo(d)}>
+                <span className="ic">
+                  <Database size={11} />
+                </span>
+                {d}
+                {d === current && <span className="cx-tag" style={{ marginLeft: "auto" }}>current</span>}
+              </button>
+            ))
+          )}
+        </div>
+      </div>
+
+      <div className="cxm-fld">
+        <div className="cxm-flab">Actions</div>
+        <button className="cxm-act" onClick={() => setSnap(snapDefault(current ?? "db"))}>
+          <span className="ic">
+            <Pull size={13} />
+          </span>
+          Save snapshot…
+          <span className="sub">{current}_snap_…</span>
+        </button>
+        <button
+          className="cxm-act"
+          onClick={async () => {
+            if (!hasBackend()) return showToast("Export needs the desktop app");
+            const { save } = await import("@tauri-apps/plugin-dialog");
+            const path = await save({ defaultPath: `${current}.dump`, title: "Export database" });
+            if (!path) return;
+            try {
+              await ipc.exportDatabase(wt.wtKey, path);
+              showToast(`Exported ${current}`);
+              onClose();
+            } catch (e) {
+              showToast(String(e));
+            }
+          }}
+        >
+          <span className="ic">
+            <Download size={12} />
+          </span>
+          Export to file…
+          <span className="sub">{current}.dump</span>
+        </button>
+        <button
+          className="cxm-act"
+          onClick={async () => {
+            if (!hasBackend()) return showToast("Restore needs the desktop app");
+            const { open } = await import("@tauri-apps/plugin-dialog");
+            const path = await open({ title: "Restore database", multiple: false });
+            if (!path || typeof path !== "string") return;
+            try {
+              await ipc.restoreDatabase(wt.wtKey, path);
+              showToast(`Restoring ${current} from file…`);
+              onClose();
+            } catch (e) {
+              showToast(String(e));
+            }
+          }}
+        >
+          <span className="ic">
+            <Refresh size={12} />
+          </span>
+          Restore from file…
+          <span className="sub">.dump · .backup · .sql</span>
+        </button>
+        <button
+          className="cxm-act cxm-act--danger"
+          onClick={() => {
+            resetDb(wt.wtKey);
+            onClose();
+          }}
+        >
+          <span className="ic">
+            <Restart size={12} />
+          </span>
+          Reset database
+          <span className="sub">drops and re-seeds</span>
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/src/app/canopy/Modal.tsx
+++ b/src/app/canopy/Modal.tsx
@@ -1,0 +1,100 @@
+/* The modal shell every dialog is built on.
+
+   Every modal ends the same way: a ghost dismiss plus ONE primary that names
+   its action — the same "next action" contract as the main window. If a
+   button could sensibly say "OK", the dialog hasn't decided what it's for.
+
+   The card floats, so it carries radius and shadow. Its interior is flat. */
+import { useEffect, useRef, type ComponentType, type ReactNode } from "react";
+import { Cube, X } from "../../icons";
+
+export default function Modal({
+  icon: Icon = Cube,
+  danger,
+  title,
+  sub,
+  wide,
+  narrow,
+  busy,
+  onClose,
+  children,
+  foot,
+}: {
+  icon?: ComponentType<{ size?: number }>;
+  danger?: boolean;
+  title: string;
+  sub?: string;
+  wide?: boolean;
+  narrow?: boolean;
+  /** while busy the dialog refuses Escape and scrim-dismiss — a half-finished
+      worktree create should not be dismissable by a stray click */
+  busy?: boolean;
+  onClose: () => void;
+  children: ReactNode;
+  foot?: ReactNode;
+}) {
+  const card = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const k = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !busy) {
+        // capture phase + stopPropagation: the app-level Escape handler would
+        // otherwise also close the palette or attention queue behind us
+        e.stopPropagation();
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", k, true);
+    const first = card.current?.querySelector<HTMLElement>("input,textarea,select,button.cx-btn--primary");
+    const t = setTimeout(() => first?.focus(), 40);
+    return () => {
+      document.removeEventListener("keydown", k, true);
+      clearTimeout(t);
+    };
+  }, [busy, onClose]);
+
+  return (
+    <div
+      className="cx-scrim"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget && !busy) onClose();
+      }}
+    >
+      <div
+        className={"cx-modal" + (wide ? " cx-modal--wide" : "") + (narrow ? " cx-modal--narrow" : "")}
+        ref={card}
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+      >
+        <div className="cx-modal__head">
+          <span className={"cx-modal__ic" + (danger ? " cx-modal__ic--danger" : "")}>
+            <Icon size={14} />
+          </span>
+          <span className="cx-modal__title">
+            <b>{title}</b>
+            {sub && <span>{sub}</span>}
+          </span>
+          <button className="cx-ib" onClick={onClose} disabled={busy} title="Close">
+            <X size={13} />
+          </button>
+        </div>
+        <div className="cx-modal__body">{children}</div>
+        {foot && <div className="cx-modal__foot">{foot}</div>}
+      </div>
+    </div>
+  );
+}
+
+/** The footer's supporting line — always the elastic item, so the actions
+    beside it never shrink or wrap. */
+export function Hint({ icon: Icon, children, tone }: { icon?: ComponentType<{ size?: number }>; children: ReactNode; tone?: "warn" }) {
+  return (
+    <span className="cx-modal__hint" style={tone === "warn" ? { color: "var(--state-attention)" } : undefined}>
+      {Icon && <Icon size={11} />}
+      <span>{children}</span>
+    </span>
+  );
+}
+
+export const Spacer = () => <span className="cxs-spacer" />;

--- a/src/app/canopy/Modal.tsx
+++ b/src/app/canopy/Modal.tsx
@@ -36,6 +36,29 @@ export default function Modal({
   const card = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
+    // aria-modal="true" promises focus cannot leave the dialog. Without a trap
+    // Tab walks straight into the app behind the scrim, so the promise was
+    // false for assistive tech and keyboard users alike.
+    const opener = document.activeElement as HTMLElement | null;
+    const FOCUSABLE =
+      'a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),summary,[tabindex]:not([tabindex="-1"])';
+    const trap = (e: KeyboardEvent) => {
+      if (e.key !== "Tab" || !card.current) return;
+      const items = [...card.current.querySelectorAll<HTMLElement>(FOCUSABLE)].filter((el) => el.offsetParent !== null);
+      if (!items.length) return;
+      const first = items[0];
+      const last = items[items.length - 1];
+      const active = document.activeElement;
+      if (e.shiftKey && (active === first || !card.current.contains(active))) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+    document.addEventListener("keydown", trap, true);
+
     const k = (e: KeyboardEvent) => {
       if (e.key === "Escape" && !busy) {
         // capture phase + stopPropagation: the app-level Escape handler would
@@ -49,7 +72,11 @@ export default function Modal({
     const t = setTimeout(() => first?.focus(), 40);
     return () => {
       document.removeEventListener("keydown", k, true);
+      document.removeEventListener("keydown", trap, true);
       clearTimeout(t);
+      // hand focus back to whatever opened us, so the keyboard doesn't reset
+      // to the top of the document
+      opener?.focus?.();
     };
   }, [busy, onClose]);
 

--- a/src/app/canopy/Overview.tsx
+++ b/src/app/canopy/Overview.tsx
@@ -59,8 +59,11 @@ export default function Overview({
     const agent = ss.find((s) => s.kind === "agent" && s.running);
     const state = agent ? agentState(agent) : null;
     const live = wt.services.filter((s) => isLive(s.status)).length;
-    const cpu = wt.services.reduce((n, s) => n + (stats[s.svcKey]?.cpu ?? 0), 0);
-    const mem = wt.services.reduce((n, s) => n + (stats[s.svcKey]?.memMb ?? 0), 0);
+    // the store retains a service's last sample after it stops, so totalling
+    // every service would keep counting processes that are gone
+    const running = wt.services.filter((s) => isLive(s.status));
+    const cpu = running.reduce((n, s) => n + (stats[s.svcKey]?.cpu ?? 0), 0);
+    const mem = running.reduce((n, s) => n + (stats[s.svcKey]?.memMb ?? 0), 0);
     const na = nextAction(wt, ss);
     const g = wt.git;
 

--- a/src/app/canopy/Palette.tsx
+++ b/src/app/canopy/Palette.tsx
@@ -30,6 +30,7 @@ export default function Palette({
   onSelect,
   onOverview,
   onAction,
+  onRunFor,
   onLayout,
   onNewWorktree,
   onSettings,
@@ -42,6 +43,8 @@ export default function Palette({
   onSelect: (wtKey: string) => void;
   onOverview: () => void;
   onAction: (a: NextAction) => void;
+  /** run the ranked next action for another worktree, the way the overview does */
+  onRunFor: (wtKey: string) => void;
   onLayout: (l: LayoutId) => void;
   onNewWorktree: () => void;
   onSettings: () => void;
@@ -76,9 +79,12 @@ export default function Palette({
           g: "Suggested",
           icon: a.kind === "crash" ? Alert : a.kind === "wait" ? Sparkle : Cube,
           tone: a.kind === "crash" ? "crash" : "urgent",
+          // The row is labelled with an imperative ("Restart — API crashed"),
+          // so it has to perform it. Selecting and leaving the crash in place
+          // would make ⌘K the one surface that disagrees with the others.
           nm: `${a.act} — ${a.title}`,
           why: a.wt,
-          run: () => onSelect(a.wtKey),
+          run: () => onRunFor(a.wtKey),
         }),
       );
     }
@@ -131,7 +137,7 @@ export default function Palette({
     });
     return out;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ql, sel, attn, flat, sessions]);
+  }, [ql, sel, attn, flat, sessions, onRunFor]);
 
   useEffect(() => setI(0), [ql]);
 

--- a/src/app/canopy/RefPick.tsx
+++ b/src/app/canopy/RefPick.tsx
@@ -107,7 +107,10 @@ export default function RefPick({
             <div key={g.k}>
               <div className="cxm-pick-g">{g.label}</div>
               {g.items.map((n) => {
-                const taken = g.k === "local" && inUse?.has(n) && n !== value;
+                // selecting `origin/foo` creates or reuses local `foo`, so the
+                // in-use test has to compare the name it will actually resolve to
+                const short = g.k === "remote" ? n.replace(/^[^/]+\//, "") : n;
+                const taken = g.k !== "tags" && inUse?.has(short) && short !== value;
                 return (
                   <button
                     key={g.k + n}

--- a/src/app/canopy/RefPick.tsx
+++ b/src/app/canopy/RefPick.tsx
@@ -1,0 +1,140 @@
+/* The searchable ref picker, shared by New worktree and Switch branch.
+
+   Groups are Local / Remote / Tags. A branch already checked out in another
+   worktree is shown but disabled and tagged "in use" — hiding it would leave
+   you wondering where it went; git simply won't check it out twice. */
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Chevron, Fork, Plus, Search } from "../../icons";
+import type { Branches } from "../../ipc";
+
+export interface RefPickProps {
+  value: string;
+  onPick: (name: string, kind: "local" | "remote" | "tags" | "new") => void;
+  branches: Branches | null;
+  placeholder?: string;
+  /** offer "Create <name>" when the typed text matches no known ref */
+  allowCreate?: boolean;
+  /** branch names already checked out elsewhere — shown, disabled, tagged */
+  inUse?: Set<string>;
+  /** a ref to omit entirely (the worktree's current branch, usually) */
+  exclude?: string;
+  autoFocus?: boolean;
+}
+
+export default function RefPick({
+  value,
+  onPick,
+  branches,
+  placeholder,
+  allowCreate,
+  inUse,
+  exclude,
+  autoFocus,
+}: RefPickProps) {
+  const [q, setQ] = useState("");
+  const [open, setOpen] = useState(false);
+  const box = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const d = (e: MouseEvent) => {
+      if (box.current && !box.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", d);
+    return () => document.removeEventListener("mousedown", d);
+  }, []);
+
+  const t = q.trim();
+  const groups = useMemo(() => {
+    if (!branches) return [];
+    const match = (n: string) => n !== exclude && (!t || n.toLowerCase().includes(t.toLowerCase()));
+    return (
+      [
+        { k: "local" as const, label: "Local", items: branches.local.filter(match) },
+        { k: "remote" as const, label: "Remote", items: branches.remote.filter(match) },
+        { k: "tags" as const, label: "Tags", items: branches.tags.filter(match) },
+      ] satisfies { k: "local" | "remote" | "tags"; label: string; items: string[] }[]
+    ).filter((g) => g.items.length);
+  }, [branches, t, exclude]);
+
+  const known = useMemo(
+    () => new Set([...(branches?.local ?? []), ...(branches?.remote ?? []), ...(branches?.tags ?? [])]),
+    [branches],
+  );
+  // a name carrying a remote prefix isn't a branch you can create locally
+  const canCreate = !!allowCreate && !!t && !known.has(t) && !t.startsWith("origin/");
+
+  return (
+    <div className="cxm-pick" ref={box}>
+      <div className="cxm-pick-f" onClick={() => setOpen(true)}>
+        <Search size={12} />
+        <input
+          value={open ? q : value}
+          placeholder={value || placeholder}
+          spellCheck={false}
+          autoFocus={autoFocus}
+          onFocus={() => setOpen(true)}
+          onChange={(e) => {
+            setQ(e.target.value);
+            setOpen(true);
+          }}
+        />
+        <Chevron size={12} />
+      </div>
+
+      {open && (
+        <div className="cxm-pick-l">
+          {!branches && <div className="cxm-pick-e">Loading refs…</div>}
+
+          {canCreate && (
+            <button
+              className="cxm-pick-i cxm-pick-i--new"
+              onClick={() => {
+                onPick(t, "new");
+                setQ("");
+                setOpen(false);
+              }}
+            >
+              <span className="ic">
+                <Plus size={12} />
+              </span>
+              <span className="nm">
+                Create <b style={{ fontWeight: 600 }}>{t}</b>
+              </span>
+            </button>
+          )}
+
+          {groups.map((g) => (
+            <div key={g.k}>
+              <div className="cxm-pick-g">{g.label}</div>
+              {g.items.map((n) => {
+                const taken = g.k === "local" && inUse?.has(n) && n !== value;
+                return (
+                  <button
+                    key={g.k + n}
+                    className={"cxm-pick-i" + (n === value ? " is-on" : "")}
+                    disabled={taken}
+                    title={taken ? `${n} is checked out in another worktree` : undefined}
+                    onClick={() => {
+                      onPick(n, g.k);
+                      setQ("");
+                      setOpen(false);
+                    }}
+                  >
+                    <span className="ic">
+                      <Fork size={12} />
+                    </span>
+                    <span className="nm">{n}</span>
+                    {taken && <span className="cx-tag cx-tag--warn">in use</span>}
+                    {!taken && g.k !== "local" && <span className="cx-tag">{g.k === "tags" ? "tag" : "remote"}</span>}
+                  </button>
+                );
+              })}
+            </div>
+          ))}
+
+          {branches && !groups.length && !canCreate && <div className="cxm-pick-e">No refs match “{q}”.</div>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/canopy/ServiceDetailModal.tsx
+++ b/src/app/canopy/ServiceDetailModal.tsx
@@ -13,23 +13,30 @@ import Modal, { Hint, Spacer } from "./Modal";
 
 export default function ServiceDetailModal({
   wt,
-  svc,
+  svcKey,
   onClose,
 }: {
   wt: WorktreeNode;
-  svc: ServiceNode;
+  /** the KEY, not the node: a captured node would freeze at the status it had
+      when the chip was clicked, so a process dying while this is open would
+      never surface its failure or exit code */
+  svcKey: string;
   onClose: () => void;
 }) {
-  const stats = useStore((s) => s.stats[svc.svcKey]);
-  const history = useStore((s) => s.cpuHistory[svc.svcKey]);
-  const exitCode = useStore((s) => s.exitCodes[svc.svcKey]);
-  const logs = useStore((s) => s.logs[svc.svcKey]);
+  const stats = useStore((s) => s.stats[svcKey]);
+  const history = useStore((s) => s.cpuHistory[svcKey]);
+  const exitCode = useStore((s) => s.exitCodes[svcKey]);
+  const logs = useStore((s) => s.logs[svcKey]);
   const tree = useStore((s) => s.tree);
+  const svc = useMemo<ServiceNode | null>(() => {
+    for (const r of tree) for (const w of r.worktrees) for (const s of w.services) if (s.svcKey === svcKey) return s;
+    return null;
+  }, [tree, svcKey]);
   const restartService = useStore((s) => s.restartService);
   const stopService = useStore((s) => s.stopService);
   const showToast = useStore((s) => s.showToast);
 
-  const opened = String(svc.port ?? "");
+  const opened = String(svc?.port ?? "");
   const [port, setPort] = useState(opened);
   const changed = port !== opened;
 
@@ -41,12 +48,16 @@ export default function ServiceDetailModal({
     for (const r of tree)
       for (const w of r.worktrees)
         for (const s of w.services)
-          if (s.svcKey !== svc.svcKey && s.port === n) return `${w.branch} · ${s.name}`;
+          if (s.svcKey !== svcKey && s.port === n) return `${w.branch} · ${s.name}`;
     return null;
-  }, [port, tree, svc.svcKey]);
+  }, [port, tree, svcKey]);
 
-  const valid = /^\d{2,5}$/.test(port) && !clash;
-  const crashed = svc.status === "error";
+  // set_service_port rejects anything outside 1024–65535 (commands.rs:861).
+  // Only gate on the port when it actually changed — a portless service
+  // (ServiceNode.port === null) must still be restartable.
+  const portOk = /^\d+$/.test(port) && Number(port) >= 1024 && Number(port) <= 65535 && !clash;
+  const valid = changed ? portOk : true;
+  const crashed = svc?.status === "error";
   const tail = (logs ?? []).filter((l) => l.lv === "err").slice(-2);
 
   const max = Math.max(12, ...(history ?? [0]));
@@ -58,14 +69,14 @@ export default function ServiceDetailModal({
         return;
       }
       try {
-        await ipc.setServicePort(svc.svcKey, Number(port));
-        showToast(`${svc.name} port → ${port}`);
+        await ipc.setServicePort(svcKey, Number(port));
+        showToast(`${svc?.name} port → ${port}`);
       } catch (e) {
         showToast(String(e));
         return;
       }
     } else {
-      restartService(svc.svcKey);
+      restartService(svcKey);
     }
     onClose();
   };
@@ -73,8 +84,8 @@ export default function ServiceDetailModal({
   return (
     <Modal
       icon={Server}
-      title={svc.name}
-      sub={crashed ? `${wt.branch} · exited${exitCode != null ? ` with code ${exitCode}` : ""}` : `${wt.branch} · ${svc.status}`}
+      title={svc?.name ?? "Service"}
+      sub={crashed ? `${wt.branch} · exited${exitCode != null ? ` with code ${exitCode}` : ""}` : `${wt.branch} · ${svc?.status ?? "gone"}`}
       onClose={onClose}
       foot={
         <>
@@ -126,11 +137,11 @@ export default function ServiceDetailModal({
             <span className="k">uptime</span>
           </div>
           <Spacer />
-          {svc.status === "running" && (
+          {svc?.status === "running" && (
             <button
               className="cx-btn cx-btn--sm"
               onClick={() => {
-                stopService(svc.svcKey);
+                stopService(svcKey);
                 onClose();
               }}
             >
@@ -160,6 +171,8 @@ export default function ServiceDetailModal({
         />
         {clash ? (
           <div className="cxm-fhint cxm-fhint--bad">Port {port} is already used by {clash}.</div>
+        ) : changed && !portOk ? (
+          <div className="cxm-fhint cxm-fhint--bad">Port must be between 1024 and 65535.</div>
         ) : changed ? (
           <div className="cxm-fhint cxm-fhint--warn">Overrides the assigned port. Esc reverts to {opened}.</div>
         ) : (

--- a/src/app/canopy/ServiceDetailModal.tsx
+++ b/src/app/canopy/ServiceDetailModal.tsx
@@ -1,0 +1,177 @@
+/* Service detail — opened from a chip in the service rail.
+
+   Carries what ServiceCard used to: the cpu/mem/uptime trio with a CPU
+   sparkline, the port override (Esc reverts), and Restart / Stop. When the
+   process died, the failure leads — red marks the problem, and the button
+   that fixes it stays teal, because restarting is constructive. */
+import { useMemo, useState } from "react";
+import { Alert, Info, Restart, Server, Stop } from "../../icons";
+import { hasBackend, ipc } from "../../ipc";
+import { useStore } from "../../store";
+import { fmtUptime, type ServiceNode, type WorktreeNode } from "../../types";
+import Modal, { Hint, Spacer } from "./Modal";
+
+export default function ServiceDetailModal({
+  wt,
+  svc,
+  onClose,
+}: {
+  wt: WorktreeNode;
+  svc: ServiceNode;
+  onClose: () => void;
+}) {
+  const stats = useStore((s) => s.stats[svc.svcKey]);
+  const history = useStore((s) => s.cpuHistory[svc.svcKey]);
+  const exitCode = useStore((s) => s.exitCodes[svc.svcKey]);
+  const logs = useStore((s) => s.logs[svc.svcKey]);
+  const tree = useStore((s) => s.tree);
+  const restartService = useStore((s) => s.restartService);
+  const stopService = useStore((s) => s.stopService);
+  const showToast = useStore((s) => s.showToast);
+
+  const opened = String(svc.port ?? "");
+  const [port, setPort] = useState(opened);
+  const changed = port !== opened;
+
+  /* Clash detection needs only the tree — every other worktree's ports are
+     already known here, so this is real rather than a backend gap. */
+  const clash = useMemo(() => {
+    const n = Number(port);
+    if (!n) return null;
+    for (const r of tree)
+      for (const w of r.worktrees)
+        for (const s of w.services)
+          if (s.svcKey !== svc.svcKey && s.port === n) return `${w.branch} · ${s.name}`;
+    return null;
+  }, [port, tree, svc.svcKey]);
+
+  const valid = /^\d{2,5}$/.test(port) && !clash;
+  const crashed = svc.status === "error";
+  const tail = (logs ?? []).filter((l) => l.lv === "err").slice(-2);
+
+  const max = Math.max(12, ...(history ?? [0]));
+
+  const save = async () => {
+    if (changed) {
+      if (!hasBackend()) {
+        showToast("Port changes need the desktop app");
+        return;
+      }
+      try {
+        await ipc.setServicePort(svc.svcKey, Number(port));
+        showToast(`${svc.name} port → ${port}`);
+      } catch (e) {
+        showToast(String(e));
+        return;
+      }
+    } else {
+      restartService(svc.svcKey);
+    }
+    onClose();
+  };
+
+  return (
+    <Modal
+      icon={Server}
+      title={svc.name}
+      sub={crashed ? `${wt.branch} · exited${exitCode != null ? ` with code ${exitCode}` : ""}` : `${wt.branch} · ${svc.status}`}
+      onClose={onClose}
+      foot={
+        <>
+          <Hint icon={Info}>{changed ? "Saves the port, then restarts" : "Port is derived from the worktree index"}</Hint>
+          <Spacer />
+          <button className="cx-btn cx-btn--ghost" onClick={onClose}>
+            Close
+          </button>
+          <button className="cx-btn cx-btn--primary" onClick={save} disabled={!valid}>
+            <Restart size={12} />
+            {changed ? "Save & restart" : "Restart"}
+            <span className="cx-k">⏎</span>
+          </button>
+        </>
+      }
+    >
+      {crashed && (
+        <div className="cx-alert cx-alert--error">
+          <span className="cx-alert__ic">
+            <Alert size={13} />
+          </span>
+          <div>
+            <b>Exited{exitCode != null ? ` with code ${exitCode}` : ""}.</b>
+            {tail.length > 0 && <pre>{tail.map((l) => l.text).join("\n")}</pre>}
+          </div>
+        </div>
+      )}
+
+      <div className="cxm-fld">
+        <div className="cxm-flab">{crashed ? "Last samples before exit" : "Now"}</div>
+        <div className="cxm-mrow">
+          {history && history.length > 0 && (
+            <div className="cx-spark" title="recent CPU">
+              {history.map((v, i) => (
+                <i key={i} style={{ height: Math.max(2, Math.round((v / max) * 14)) }} />
+              ))}
+            </div>
+          )}
+          <div className="cxm-met">
+            <span className="v">{stats ? `${stats.cpu.toFixed(1)}%` : "—"}</span>
+            <span className="k">cpu</span>
+          </div>
+          <div className="cxm-met">
+            <span className="v">{stats ? `${Math.round(stats.memMb)} MB` : "—"}</span>
+            <span className="k">mem</span>
+          </div>
+          <div className="cxm-met">
+            <span className="v">{fmtUptime(stats?.uptimeSec)}</span>
+            <span className="k">uptime</span>
+          </div>
+          <Spacer />
+          {svc.status === "running" && (
+            <button
+              className="cx-btn cx-btn--sm"
+              onClick={() => {
+                stopService(svc.svcKey);
+                onClose();
+              }}
+            >
+              <Stop size={10} />
+              Stop
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="cxm-fld">
+        <div className="cxm-flab cxm-flab--f">
+          <Server size={11} />
+          Port
+        </div>
+        <input
+          className="cx-input cx-input--mono"
+          value={port}
+          spellCheck={false}
+          onChange={(e) => setPort(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") {
+              e.stopPropagation();
+              setPort(opened);
+            }
+          }}
+        />
+        {clash ? (
+          <div className="cxm-fhint cxm-fhint--bad">Port {port} is already used by {clash}.</div>
+        ) : changed ? (
+          <div className="cxm-fhint cxm-fhint--warn">Overrides the assigned port. Esc reverts to {opened}.</div>
+        ) : (
+          <div className="cxm-fhint">Assigned from the worktree index. Change it only if something else holds the port.</div>
+        )}
+      </div>
+
+      {/* TODO(#59): the design shows the resolved environment (PORT,
+          DATABASE_URL, TOOLJET_HOST) here. No IPC exposes it, and guessing
+          the values would defeat the panel's entire purpose — it exists to
+          answer "why is this talking to the wrong database?". Omitted until
+          service_env lands. */}
+    </Modal>
+  );
+}

--- a/src/app/canopy/ServiceRail.tsx
+++ b/src/app/canopy/ServiceRail.tsx
@@ -1,8 +1,9 @@
 /* The service rail — everything the old service cards said, in one 34px row.
 
-   Running services read as filled tokens; idle ones recede to text. Selecting
-   a chip filters the log stream below it, so the rail and the log toolbar are
-   two views of one selection rather than two competing controls. */
+   Running services read as filled tokens; idle ones recede to text. A chip
+   opens Service detail — the port override, metrics and failure live there.
+   Log filtering is the log toolbar's own chip row, so one click never has to
+   mean two things. */
 import { Database, Play, Restart, Spinner, Stop } from "../../icons";
 import { useStore } from "../../store";
 import type { ServiceNode, WorktreeNode } from "../../types";
@@ -11,14 +12,11 @@ import { svcDotClass } from "../nextAction";
 
 export default function ServiceRail({
   wt,
-  filter,
-  onFilter,
+  onOpenService,
   onDatabase,
 }: {
   wt: WorktreeNode;
-  /** svcKey of the service the logs are filtered to, or "all" */
-  filter: string;
-  onFilter: (svcKey: string) => void;
+  onOpenService: (s: ServiceNode) => void;
   onDatabase: () => void;
 }) {
   const stats = useStore((s) => s.stats);
@@ -54,17 +52,16 @@ export default function ServiceRail({
             className={
               "cxs-svc" +
               (live ? "" : " cxs-svc--off") +
-              (s.status === "error" ? " cxs-svc--error" : "") +
-              (filter === s.svcKey ? " is-on" : "")
+              (s.status === "error" ? " cxs-svc--error" : "")
             }
-            onClick={() => onFilter(filter === s.svcKey ? "all" : s.svcKey)}
+            onClick={() => onOpenService(s)}
             role="button"
             tabIndex={0}
             title={`${s.name} — ${s.status}`}
             onKeyDown={(e) => {
               if (e.key === "Enter" || e.key === " ") {
                 e.preventDefault();
-                onFilter(filter === s.svcKey ? "all" : s.svcKey);
+                onOpenService(s);
               }
             }}
           >

--- a/src/app/canopy/ServiceRail.tsx
+++ b/src/app/canopy/ServiceRail.tsx
@@ -59,6 +59,10 @@ export default function ServiceRail({
             tabIndex={0}
             title={`${s.name} — ${s.status}`}
             onKeyDown={(e) => {
+              // only when the CHIP itself has focus — this also receives keys
+              // bubbling from the nested start/stop button, and preventDefault
+              // there would suppress that button's own activation
+              if (e.target !== e.currentTarget) return;
               if (e.key === "Enter" || e.key === " ") {
                 e.preventDefault();
                 onOpenService(s);

--- a/src/app/canopy/SetupRunnerModal.tsx
+++ b/src/app/canopy/SetupRunnerModal.tsx
@@ -1,7 +1,7 @@
 /* Setup runner — the provisioning stream as a step list rather than a spinner.
 
    Steps come from the worktree:op buffer the store already folds; the backend
-   emits ordered "[k/n]: cmd" markers. "Run in background" simply closes the
+   emits ordered "{label} [k/n]: cmd" markers. "Run in background" simply closes the
    dialog: the run is backend-owned and keeps going either way, which is why
    the button says what it does rather than "Hide". */
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -11,8 +11,9 @@ import { useStore } from "../../store";
 import type { WorktreeNode } from "../../types";
 import Modal, { Hint, Spacer } from "./Modal";
 
-/** "[2/5]: pnpm install" → { n: 2, of: 5, cmd: "pnpm install" } */
-const STEP = /^\[(\d+)\/(\d+)\]:\s*(.*)$/;
+/** setup.rs emits `{label} [2/5]: pnpm install` — the operation label comes
+    first, so the marker is matched anywhere in the line rather than anchored. */
+const STEP = /\[(\d+)\/(\d+)\]:\s*(.*)$/;
 
 export default function SetupRunnerModal({
   wt,
@@ -27,17 +28,25 @@ export default function SetupRunnerModal({
   const showToast = useStore((s) => s.showToast);
   const startedAt = useRef(Date.now());
   const [failed, setFailed] = useState(false);
+  /** true when we joined a run already in progress rather than starting one */
+  const [attached, setAttached] = useState(false);
 
   useEffect(() => {
     if (!hasBackend()) {
       showToast("Setup runs in the desktop app");
       return;
     }
+    // Reopening after "Run in background" must ATTACH to the run in flight.
+    // The backend has no per-worktree guard, so invoking again would provision
+    // concurrently — two `pnpm install`s in one directory.
+    if (useStore.getState().ops[wt.wtKey]?.running) {
+      setAttached(true);
+      return;
+    }
     ipc.runWorktreeSetup(wt.wtKey).catch((e) => {
       setFailed(true);
       showToast(`Setup failed — ${String(e)}`);
     });
-    // launched once per open; the run is backend-owned from here
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [wt.wtKey]);
 
@@ -75,7 +84,7 @@ export default function SetupRunnerModal({
             {errored
               ? "The failing step is shown above"
               : done
-                ? `Took ${elapsed}s`
+                ? (attached ? "Finished" : `Took ${elapsed}s`)
                 : total
                   ? `Step ${Math.min(current, total)} of ${total}`
                   : "starting…"}

--- a/src/app/canopy/SetupRunnerModal.tsx
+++ b/src/app/canopy/SetupRunnerModal.tsx
@@ -1,0 +1,153 @@
+/* Setup runner — the provisioning stream as a step list rather than a spinner.
+
+   Steps come from the worktree:op buffer the store already folds; the backend
+   emits ordered "[k/n]: cmd" markers. "Run in background" simply closes the
+   dialog: the run is backend-owned and keeps going either way, which is why
+   the button says what it does rather than "Hide". */
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Check, Cube, Play, Spinner } from "../../icons";
+import { hasBackend, ipc } from "../../ipc";
+import { useStore } from "../../store";
+import type { WorktreeNode } from "../../types";
+import Modal, { Hint, Spacer } from "./Modal";
+
+/** "[2/5]: pnpm install" → { n: 2, of: 5, cmd: "pnpm install" } */
+const STEP = /^\[(\d+)\/(\d+)\]:\s*(.*)$/;
+
+export default function SetupRunnerModal({
+  wt,
+  onClose,
+  onStartServices,
+}: {
+  wt: WorktreeNode;
+  onClose: () => void;
+  onStartServices: () => void;
+}) {
+  const op = useStore((s) => s.ops[wt.wtKey]);
+  const showToast = useStore((s) => s.showToast);
+  const startedAt = useRef(Date.now());
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    if (!hasBackend()) {
+      showToast("Setup runs in the desktop app");
+      return;
+    }
+    ipc.runWorktreeSetup(wt.wtKey).catch((e) => {
+      setFailed(true);
+      showToast(`Setup failed — ${String(e)}`);
+    });
+    // launched once per open; the run is backend-owned from here
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [wt.wtKey]);
+
+  /* Rebuild the step list from the op buffer. Every marker seen is a step;
+     the highest marker is the one in flight, everything before it is done. */
+  const { steps, current, total } = useMemo(() => {
+    const seen: { n: number; cmd: string }[] = [];
+    let total = 0;
+    for (const l of op?.lines ?? []) {
+      const m = STEP.exec(l.text);
+      if (!m) continue;
+      total = Number(m[2]);
+      const n = Number(m[1]);
+      if (!seen.some((s) => s.n === n)) seen.push({ n, cmd: m[3] });
+    }
+    seen.sort((a, b) => a.n - b.n);
+    return { steps: seen, current: seen.length ? seen[seen.length - 1].n : 0, total };
+  }, [op]);
+
+  const running = op?.running ?? true;
+  const done = !running && !failed && steps.length > 0;
+  const errored = failed || (op?.lines ?? []).some((l) => l.lv === "err");
+  const elapsed = ((Date.now() - startedAt.current) / 1000).toFixed(1);
+
+  return (
+    <Modal
+      icon={Cube}
+      title={errored ? "Setup failed" : done ? "Setup complete" : "Running setup"}
+      sub={wt.branch}
+      busy={running && !errored}
+      onClose={onClose}
+      foot={
+        <>
+          <Hint icon={done ? Check : errored ? undefined : Spinner}>
+            {errored
+              ? "The failing step is shown above"
+              : done
+                ? `Took ${elapsed}s`
+                : total
+                  ? `Step ${Math.min(current, total)} of ${total}`
+                  : "starting…"}
+          </Hint>
+          <Spacer />
+          {running && !errored && (
+            <button className="cx-btn cx-btn--ghost" onClick={onClose}>
+              Run in background
+            </button>
+          )}
+          {done ? (
+            <button
+              className="cx-btn cx-btn--primary"
+              onClick={() => {
+                onStartServices();
+                onClose();
+              }}
+            >
+              <Play size={12} />
+              Start services
+              <span className="cx-k">⏎</span>
+            </button>
+          ) : (
+            <button className="cx-btn" onClick={onClose}>
+              {errored ? "Close" : "Cancel"}
+            </button>
+          )}
+        </>
+      }
+    >
+      {steps.length === 0 && !errored && (
+        <div className="cxm-prog" style={{ borderTop: 0, marginTop: 0, paddingTop: 0 }}>
+          <span className="cxm-prog__ic">
+            <Spinner size={13} />
+          </span>
+          <div className="cxm-prog__lines">preparing…</div>
+        </div>
+      )}
+
+      {steps.map((s) => {
+        const state = s.n < current ? "done" : s.n === current && running ? "active" : errored && s.n === current ? "failed" : "done";
+        return (
+          <div className={`cx-step cx-step--${state}`} key={s.n}>
+            <span className="cx-step__bullet">
+              {state === "done" ? "✓" : state === "failed" ? "✕" : <Spinner size={10} />}
+            </span>
+            <span className="cx-step__text">{s.cmd}</span>
+            {/* TODO(#60): the design shows a result per step ("1,842 packages",
+                "37 migrations"). worktree:op carries step identity but no
+                parsed result, so nothing is shown rather than invented. */}
+          </div>
+        );
+      })}
+
+      {/* the raw tail stays available — a failing step is read, not guessed at */}
+      {errored && (
+        <div className="cx-alert cx-alert--error" style={{ marginTop: "var(--sp-modal-head)" }}>
+          <div>
+            <b>Setup did not finish.</b>
+            <pre>{(op?.lines ?? []).slice(-4).map((l) => l.text).join("\n")}</pre>
+          </div>
+        </div>
+      )}
+
+      {done && (
+        <div className="cx-alert cx-alert--ok" style={{ marginTop: "var(--sp-modal-head)", marginBottom: 0 }}>
+          <span className="cx-alert__ic">
+            <Check size={13} />
+          </span>
+          <div>Provisioned and ready.</div>
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/src/app/canopy/SetupRunnerModal.tsx
+++ b/src/app/canopy/SetupRunnerModal.tsx
@@ -66,7 +66,14 @@ export default function SetupRunnerModal({
     return { steps: seen, current: seen.length ? seen[seen.length - 1].n : 0, total };
   }, [op]);
 
+  // Optimistic for DISPLAY: before the first worktree:op event there is
+  // nothing to show but "running".
   const running = op?.running ?? true;
+  // Authoritative for DISMISSAL. Defaulting `busy` to true refused Escape and
+  // scrim-dismiss before any event arrived — and if the run never started
+  // (no backend, or the backend never emitted), the dialog could not be
+  // closed by keyboard at all.
+  const inFlight = op?.running === true;
   const done = !running && !failed && steps.length > 0;
   const errored = failed || (op?.lines ?? []).some((l) => l.lv === "err");
   const elapsed = ((Date.now() - startedAt.current) / 1000).toFixed(1);
@@ -76,7 +83,7 @@ export default function SetupRunnerModal({
       icon={Cube}
       title={errored ? "Setup failed" : done ? "Setup complete" : "Running setup"}
       sub={wt.branch}
-      busy={running && !errored}
+      busy={inFlight && !errored}
       onClose={onClose}
       foot={
         <>

--- a/src/app/canopy/SidebarNav.tsx
+++ b/src/app/canopy/SidebarNav.tsx
@@ -67,7 +67,7 @@ export default function SidebarNav({
   }, [flat, q, attn, pins]);
 
   return (
-    <aside className={"cxs-side" + (hidden ? " is-hidden" : "")}>
+    <aside className={"cxs-side" + (hidden ? " is-hidden" : "")} inert={hidden || undefined} aria-hidden={hidden || undefined}>
       <div className="cxs-shead">
         <div className="cx-search cxs-sfilter">
           <Search size={12} />
@@ -148,6 +148,9 @@ function WorktreeRow({
   const agents = sessions.filter((s) => s.kind === "agent" && s.running);
   const waiting = agents.some((s) => agentState(s) === "waiting");
   const live = wt.services.some((s) => isLive(s.status));
+  // isLive() excludes `stopping`, so a worktree mid-shutdown reads as idle and
+  // the toggle would offer "Start services" — which then races the shutdown.
+  const settling = wt.services.some((s) => s.status === "starting" || s.status === "stopping");
   const pinned = isPinned(wt.wtKey);
 
   return (
@@ -181,9 +184,11 @@ function WorktreeRow({
       <span className="cxs-qa">
         <button
           className={"qb " + (live ? "st" : "go")}
-          title={live ? "Stop services" : "Start services"}
+          disabled={settling}
+          title={settling ? "Waiting for services to settle…" : live ? "Stop services" : "Start services"}
           onClick={(e) => {
             e.stopPropagation();
+            if (settling) return;
             onToggleServices();
           }}
         >

--- a/src/app/canopy/StatusBar.tsx
+++ b/src/app/canopy/StatusBar.tsx
@@ -38,6 +38,7 @@ export default function StatusBar({
   const sessions = useStore((s) => (wt ? (s.sessions[wt.wtKey] ?? EMPTY) : EMPTY));
   const gitPull = useStore((s) => s.gitPull);
   const [pullOpen, setPullOpen] = useState(false);
+  const caretRef = useRef<HTMLButtonElement>(null);
 
   if (view === "overview" || !wt) {
     return (
@@ -98,6 +99,7 @@ export default function StatusBar({
             Pull
           </button>
           <button
+            ref={caretRef}
             className={"cxs-sb cxs-pullcaret" + (pullOpen ? " is-on" : "")}
             title="Pull individual submodules"
             aria-haspopup="menu"
@@ -107,7 +109,7 @@ export default function StatusBar({
             <Chevron size={9} />
           </button>
         </span>
-        {pullOpen && <PullPop wt={wt} onClose={() => setPullOpen(false)} />}
+        {pullOpen && <PullPop wt={wt} anchor={caretRef} onClose={() => setPullOpen(false)} />}
       </span>
 
       {agents.length > 0 && (
@@ -132,7 +134,7 @@ export default function StatusBar({
 
 /* ── the welded pull popover ──────────────────────────────────────── */
 
-function PullPop({ wt, onClose }: { wt: WorktreeNode; onClose: () => void }) {
+function PullPop({ wt, onClose, anchor }: { wt: WorktreeNode; onClose: () => void; anchor?: React.RefObject<HTMLElement | null> }) {
   const showToast = useStore((s) => s.showToast);
   const [subs, setSubs] = useState<SubmoduleStatus[]>([]);
   const [loaded, setLoaded] = useState(false);
@@ -160,7 +162,11 @@ function PullPop({ wt, onClose }: { wt: WorktreeNode; onClose: () => void }) {
 
   useEffect(() => {
     const d = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+      const t = e.target as Node;
+      // the caret is outside this ref; without this the listener closes the
+      // popover and the caret's click reopens it, so it can never dismiss
+      if (anchor?.current?.contains(t)) return;
+      if (ref.current && !ref.current.contains(t)) onClose();
     };
     const k = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();

--- a/src/app/canopy/TopBar.tsx
+++ b/src/app/canopy/TopBar.tsx
@@ -3,7 +3,7 @@
    Left is identity (brand + which worktree you're in), centre is the one
    global entry point (⌘K), right is the cross-worktree signal — how much is
    running, how many agents, and what needs a human. */
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, type RefObject } from "react";
 import { Bell, Check, ChevRight, Chevron, Cube, Fork, Refresh, Settings, Sparkle, Alert } from "../../icons";
 import type { AttnItem } from "../nextAction";
 import type { RepoNode, WorktreeNode } from "../../types";
@@ -19,6 +19,7 @@ export function TopBar({
   onOverview,
   onRefresh,
   onSettings,
+  attnRef,
 }: {
   repo: RepoNode | null;
   wt: WorktreeNode | null;
@@ -30,6 +31,8 @@ export function TopBar({
   onOverview: () => void;
   onRefresh: () => void;
   onSettings: () => void;
+  /** shared with AttentionPop so the trigger can close its own popover */
+  attnRef?: RefObject<HTMLButtonElement | null>;
 }) {
   const crashes = attn.filter((a) => a.kind === "crash").length;
 
@@ -76,13 +79,13 @@ export function TopBar({
           </button>
         )}
         {attn.length > 0 ? (
-          <button className={"cxs-attn" + (crashes ? " cxs-attn--crash" : "")} onClick={onAttn}>
+          <button ref={attnRef} className={"cxs-attn" + (crashes ? " cxs-attn--crash" : "")} onClick={onAttn}>
             <span className="d" />
             <span>{attn.length}</span>
             <span className="lbl">{`need${attn.length === 1 ? "s" : ""} you`}</span>
           </button>
         ) : (
-          <button className="cxs-attn cxs-attn--clear" onClick={onAttn} title="Nothing needs you">
+          <button ref={attnRef} className="cxs-attn cxs-attn--clear" onClick={onAttn} title="Nothing needs you">
             <Check size={12} />
             <span className="lbl">All clear</span>
           </button>
@@ -100,15 +103,30 @@ export function TopBar({
 }
 
 /** The attention queue — everything needing a human, across worktrees, ranked. */
-export function AttentionPop({ items, onPick, onClose }: { items: AttnItem[]; onPick: (a: AttnItem) => void; onClose: () => void }) {
+export function AttentionPop({
+  items,
+  onPick,
+  onClose,
+  anchor,
+}: {
+  items: AttnItem[];
+  onPick: (a: AttnItem) => void;
+  onClose: () => void;
+  /** the trigger, so its own mousedown isn't treated as "outside" — otherwise
+      the listener closes the popover and the click immediately reopens it,
+      making the trigger unable to dismiss what it opened */
+  anchor?: React.RefObject<HTMLElement | null>;
+}) {
   const ref = useRef<HTMLDivElement>(null);
   useEffect(() => {
     const d = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+      const t = e.target as Node;
+      if (anchor?.current?.contains(t)) return;
+      if (ref.current && !ref.current.contains(t)) onClose();
     };
     document.addEventListener("mousedown", d);
     return () => document.removeEventListener("mousedown", d);
-  }, [onClose]);
+  }, [onClose, anchor]);
 
   return (
     <div className="cx-pop cxs-attnpop" ref={ref}>

--- a/src/app/canopy/WorkSurface.tsx
+++ b/src/app/canopy/WorkSurface.tsx
@@ -12,6 +12,8 @@ import type { ServiceNode, WorktreeNode } from "../../types";
 import TerminalPane from "../TerminalPane";
 import LogsPane from "./LogsPane";
 import { agentState, nextClass, type NextAction } from "../nextAction";
+import { useWtContext } from "../WorktreeContext";
+import { Chevron } from "../../icons";
 import type { LaneLaunch } from "./laneLaunch";
 
 export type PaneKind = "logs" | "shell" | "agent";
@@ -59,6 +61,7 @@ export default function WorkSurface({
   onNext,
   onRestart,
   launch,
+  onEditContext,
 }: {
   wt: WorktreeNode;
   panes: PaneKind[];
@@ -69,6 +72,7 @@ export default function WorkSurface({
   onNext: () => void;
   onRestart: (s: ServiceNode) => void;
   launch: LaneLaunch;
+  onEditContext: () => void;
 }) {
   const [split, setSplit] = useState(0.56);
   const [drag, setDrag] = useState(false);
@@ -121,6 +125,7 @@ export default function WorkSurface({
             onNext={onNext}
             onRestart={onRestart}
             launch={launch}
+            onEditContext={onEditContext}
           />
         </div>
       ))}
@@ -139,6 +144,7 @@ function Pane({
   onNext,
   onRestart,
   launch,
+  onEditContext,
 }: {
   kind: PaneKind;
   index: number;
@@ -150,7 +156,9 @@ function Pane({
   onNext: () => void;
   onRestart: (s: ServiceNode) => void;
   launch: LaneLaunch;
+  onEditContext: () => void;
 }) {
+  const [ctx] = useWtContext(wt.wtKey);
   const all = useStore((s) => s.sessions[wt.wtKey] ?? EMPTY);
   const activeTerm = useStore((s) => s.activeTerm[wt.wtKey]);
   const setActiveTerm = useStore((s) => s.setActiveTerm);
@@ -209,6 +217,16 @@ function Pane({
 
   return (
     <div className="cxs-pane">
+      {kind === "agent" && (
+        <button className="cxs-ctxbar" onClick={onEditContext} title="Edit the context this worktree's agents inherit">
+          <span className="lb">Context</span>
+          <span className={"ti" + (ctx.title.trim() ? "" : " is-empty")}>
+            {ctx.title.trim() || "No task set — the agent still inherits branch, ports and database"}
+          </span>
+          {ctx.links.length > 0 && <span className="lk">{ctx.links.length} links</span>}
+          <Chevron size={11} />
+        </button>
+      )}
       <div className="cx-tabs">
         <div className="cx-tabs__scroll">
           {(Object.keys(TAB_META) as PaneKind[]).map((t) => {

--- a/src/app/canopy/WorkSurface.tsx
+++ b/src/app/canopy/WorkSurface.tsx
@@ -249,28 +249,34 @@ function Pane({
                   <span
                     key={s.id}
                     className={"cxs-sc" + (active?.id === s.id ? " is-on" : "")}
-                    onClick={() => setActiveTerm(wt.wtKey, s.id)}
-                    role="button"
-                    tabIndex={0}
+                    onClick={(e) => {
+                      // the close button lives inside; don't re-select on its click
+                      if ((e.target as HTMLElement).closest(".x")) return;
+                      setActiveTerm(wt.wtKey, s.id);
+                    }}
                     onKeyDown={(e) => {
+                      if (e.target !== e.currentTarget) return;
                       if (e.key === "Enter" || e.key === " ") {
                         e.preventDefault();
                         setActiveTerm(wt.wtKey, s.id);
                       }
                     }}
+                    role="button"
+                    tabIndex={0}
                   >
                     <span className={"d " + (st === "waiting" ? "wait" : st === "busy" ? "run" : "")} />
                     {s.title}
-                    <span
+                    <button
                       className="x"
-                      title="Close session"
+                      aria-label={`Close ${s.title}`}
+                      title={`Close ${s.title}`}
                       onClick={(e) => {
                         e.stopPropagation();
                         closeSession(s.id);
                       }}
                     >
                       <X size={9} />
-                    </span>
+                    </button>
                   </span>
                 );
               })}

--- a/src/app/canopy/WorktreeView.tsx
+++ b/src/app/canopy/WorktreeView.tsx
@@ -8,6 +8,7 @@ import { Cube, Editor, Finder, Fork, More, SidebarIcon, Terminal, Trash } from "
 import { useStore } from "../../store";
 import type { ServiceNode, WorktreeNode } from "../../types";
 import { nextClass, type NextAction } from "../nextAction";
+import AnchoredMenu from "./AnchoredMenu";
 import ServiceRail from "./ServiceRail";
 import WorkSurface, { type PaneKind } from "./WorkSurface";
 import type { LaneLaunch } from "./laneLaunch";
@@ -45,21 +46,12 @@ export default function WorktreeView({
   const restartService = useStore((s) => s.restartService);
   const [filter, setFilter] = useState("all");
   const [menu, setMenu] = useState(false);
-  const menuRef = useRef<HTMLDivElement>(null);
+  const moreRef = useRef<HTMLButtonElement>(null);
   const NaIcon = na.icon;
 
   // a filter naming a service that no longer exists would silently hide
   // everything, so fall back to "all" when the worktree changes
   useEffect(() => setFilter("all"), [wt.wtKey]);
-
-  useEffect(() => {
-    if (!menu) return;
-    const d = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) setMenu(false);
-    };
-    document.addEventListener("mousedown", d);
-    return () => document.removeEventListener("mousedown", d);
-  }, [menu]);
 
   const runSetup = () => {
     setMenu(false);
@@ -98,50 +90,48 @@ export default function WorktreeView({
           <button className="cx-ib" title="Reveal in Finder" onClick={() => openWorktree(wt.wtKey, "finder")}>
             <Finder size={14} />
           </button>
-          <div style={{ position: "relative", display: "inline-flex" }} ref={menuRef}>
-            <button className="cx-ib" title="More" onClick={() => setMenu((m) => !m)}>
-              <More size={15} />
-            </button>
-            {menu && (
-              <div className="cx-pop cxs-moremenu">
-                <button className="cx-pop__item" onClick={runSetup}>
-                  <span className="cx-pop__ic">
-                    <Cube size={13} />
-                  </span>
-                  Run setup
-                </button>
-                <button
-                  className="cx-pop__item"
-                  onClick={() => {
-                    setMenu(false);
-                    openWorktree(wt.wtKey, "terminal");
-                  }}
-                >
-                  <span className="cx-pop__ic">
-                    <Terminal size={13} />
-                  </span>
-                  Open in Terminal
-                </button>
-                {!wt.isMain && (
-                  <>
-                    <div className="cx-pop__sep" />
-                    <button
-                      className="cx-pop__item cx-pop__item--danger"
-                      onClick={() => {
-                        setMenu(false);
-                        onRemove();
-                      }}
-                    >
-                      <span className="cx-pop__ic">
-                        <Trash size={13} />
-                      </span>
-                      Remove worktree…
-                    </button>
-                  </>
-                )}
-              </div>
-            )}
-          </div>
+          <button className="cx-ib" title="More" onClick={() => setMenu((m) => !m)} ref={moreRef} aria-haspopup="menu" aria-expanded={menu}>
+            <More size={15} />
+          </button>
+          {menu && (
+            <AnchoredMenu anchor={moreRef} onClose={() => setMenu(false)} width={216}>
+              <button className="cx-pop__item" onClick={runSetup}>
+                <span className="cx-pop__ic">
+                  <Cube size={13} />
+                </span>
+                Run setup
+              </button>
+              <button
+                className="cx-pop__item"
+                onClick={() => {
+                  setMenu(false);
+                  openWorktree(wt.wtKey, "terminal");
+                }}
+              >
+                <span className="cx-pop__ic">
+                  <Terminal size={13} />
+                </span>
+                Open in Terminal
+              </button>
+              {!wt.isMain && (
+                <>
+                  <div className="cx-pop__sep" />
+                  <button
+                    className="cx-pop__item cx-pop__item--danger"
+                    onClick={() => {
+                      setMenu(false);
+                      onRemove();
+                    }}
+                  >
+                    <span className="cx-pop__ic">
+                      <Trash size={13} />
+                    </span>
+                    Remove worktree…
+                  </button>
+                </>
+              )}
+            </AnchoredMenu>
+          )}
 
           <span className="cxs-actdiv" />
 

--- a/src/app/canopy/WorktreeView.tsx
+++ b/src/app/canopy/WorktreeView.tsx
@@ -3,8 +3,8 @@
    The bar is ONE line: the branch is the only elastic item, and the actions
    never shrink — a shrinking action group just clips its own button. The
    reason rides in front of the next action and is the first thing to yield. */
-import { useEffect, useRef, useState } from "react";
-import { Cube, Editor, Finder, Fork, More, SidebarIcon, Terminal, Trash } from "../../icons";
+import { useEffect, useRef, useState, type ComponentType } from "react";
+import { Copy, Cube, Database, Doc, Editor, Finder, Fork, More, Pull, SidebarIcon, Swap, Trash } from "../../icons";
 import { useStore } from "../../store";
 import type { ServiceNode, WorktreeNode } from "../../types";
 import { nextClass, type NextAction } from "../nextAction";
@@ -12,6 +12,30 @@ import AnchoredMenu from "./AnchoredMenu";
 import ServiceRail from "./ServiceRail";
 import WorkSurface, { type PaneKind } from "./WorkSurface";
 import type { LaneLaunch } from "./laneLaunch";
+
+function MenuItem({
+  icon: Icon,
+  label,
+  k,
+  danger,
+  onPick,
+}: {
+  icon: ComponentType<{ size?: number }>;
+  label: string;
+  k?: string;
+  danger?: boolean;
+  onPick: () => void;
+}) {
+  return (
+    <button className={"cx-pop__item" + (danger ? " cx-pop__item--danger" : "")} onClick={onPick} role="menuitem">
+      <span className="cx-pop__ic">
+        <Icon size={13} />
+      </span>
+      {label}
+      {k && <span className="cx-k">{k}</span>}
+    </button>
+  );
+}
 
 export default function WorktreeView({
   wt,
@@ -27,6 +51,7 @@ export default function WorktreeView({
   onSetup,
   onOpenService,
   onEditContext,
+  onSwitchBranch,
 }: {
   wt: WorktreeNode;
   na: NextAction;
@@ -41,8 +66,11 @@ export default function WorktreeView({
   onSetup: () => void;
   onOpenService: (s: ServiceNode) => void;
   onEditContext: () => void;
+  onSwitchBranch: () => void;
 }) {
   const openWorktree = useStore((s) => s.openWorktree);
+  const gitPull = useStore((s) => s.gitPull);
+  const showToast = useStore((s) => s.showToast);
   const restartService = useStore((s) => s.restartService);
   const [filter, setFilter] = useState("all");
   const [menu, setMenu] = useState(false);
@@ -94,40 +122,30 @@ export default function WorktreeView({
             <More size={15} />
           </button>
           {menu && (
-            <AnchoredMenu anchor={moreRef} onClose={() => setMenu(false)} width={216}>
-              <button className="cx-pop__item" onClick={runSetup}>
-                <span className="cx-pop__ic">
-                  <Cube size={13} />
-                </span>
-                Run setup
-              </button>
-              <button
-                className="cx-pop__item"
-                onClick={() => {
+            <AnchoredMenu anchor={moreRef} onClose={() => setMenu(false)} width={246}>
+              <MenuItem icon={Swap} label="Switch branch…" k="⌘\" onPick={() => { setMenu(false); onSwitchBranch(); }} />
+              <MenuItem icon={Pull} label="Pull" onPick={() => { setMenu(false); gitPull(wt.wtKey); }} />
+              <MenuItem icon={Cube} label="Run setup…" onPick={runSetup} />
+              <div className="cx-pop__sep" />
+              <MenuItem icon={Database} label="Database…" onPick={() => { setMenu(false); onDatabase(); }} />
+              <MenuItem icon={Doc} label="Context…" onPick={() => { setMenu(false); onEditContext(); }} />
+              <div className="cx-pop__sep" />
+              <MenuItem icon={Finder} label="Reveal in Finder" onPick={() => { setMenu(false); openWorktree(wt.wtKey, "finder"); }} />
+              <MenuItem
+                icon={Copy}
+                label="Copy path"
+                onPick={() => {
                   setMenu(false);
-                  openWorktree(wt.wtKey, "terminal");
+                  navigator.clipboard?.writeText(wt.path).then(
+                    () => showToast("Path copied"),
+                    () => showToast("Could not copy to the clipboard"),
+                  );
                 }}
-              >
-                <span className="cx-pop__ic">
-                  <Terminal size={13} />
-                </span>
-                Open in Terminal
-              </button>
+              />
               {!wt.isMain && (
                 <>
                   <div className="cx-pop__sep" />
-                  <button
-                    className="cx-pop__item cx-pop__item--danger"
-                    onClick={() => {
-                      setMenu(false);
-                      onRemove();
-                    }}
-                  >
-                    <span className="cx-pop__ic">
-                      <Trash size={13} />
-                    </span>
-                    Remove worktree…
-                  </button>
+                  <MenuItem icon={Trash} label="Remove worktree…" danger onPick={() => { setMenu(false); onRemove(); }} />
                 </>
               )}
             </AnchoredMenu>

--- a/src/app/canopy/WorktreeView.tsx
+++ b/src/app/canopy/WorktreeView.tsx
@@ -5,7 +5,6 @@
    reason rides in front of the next action and is the first thing to yield. */
 import { useEffect, useRef, useState } from "react";
 import { Cube, Editor, Finder, Fork, More, SidebarIcon, Terminal, Trash } from "../../icons";
-import { hasBackend, ipc } from "../../ipc";
 import { useStore } from "../../store";
 import type { ServiceNode, WorktreeNode } from "../../types";
 import { nextClass, type NextAction } from "../nextAction";
@@ -24,6 +23,9 @@ export default function WorktreeView({
   onShowSide,
   onRemove,
   onDatabase,
+  onSetup,
+  onOpenService,
+  onEditContext,
 }: {
   wt: WorktreeNode;
   na: NextAction;
@@ -35,10 +37,12 @@ export default function WorktreeView({
   onShowSide: () => void;
   onRemove: () => void;
   onDatabase: () => void;
+  onSetup: () => void;
+  onOpenService: (s: ServiceNode) => void;
+  onEditContext: () => void;
 }) {
   const openWorktree = useStore((s) => s.openWorktree);
   const restartService = useStore((s) => s.restartService);
-  const showToast = useStore((s) => s.showToast);
   const [filter, setFilter] = useState("all");
   const [menu, setMenu] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -59,12 +63,7 @@ export default function WorktreeView({
 
   const runSetup = () => {
     setMenu(false);
-    if (!hasBackend()) {
-      showToast("Setup runs in the desktop app");
-      return;
-    }
-    showToast(`Running setup — ${wt.branch}…`);
-    ipc.runWorktreeSetup(wt.wtKey).catch((e) => showToast(`Setup failed — ${String(e)}`));
+    onSetup();
   };
 
   return (
@@ -156,7 +155,7 @@ export default function WorktreeView({
         </div>
       </div>
 
-      <ServiceRail wt={wt} filter={filter} onFilter={setFilter} onDatabase={onDatabase} />
+      <ServiceRail wt={wt} onOpenService={onOpenService} onDatabase={onDatabase} />
 
       <WorkSurface
         wt={wt}
@@ -168,6 +167,7 @@ export default function WorktreeView({
         onNext={onNext}
         onRestart={(s: ServiceNode) => restartService(s.svcKey)}
         launch={launch}
+        onEditContext={onEditContext}
       />
     </div>
   );

--- a/src/app/canopy/WorktreeView.tsx
+++ b/src/app/canopy/WorktreeView.tsx
@@ -115,9 +115,7 @@ export default function WorktreeView({
           <button className="cx-ib" title="Open in editor" onClick={() => openWorktree(wt.wtKey, "editor")}>
             <Editor size={14} />
           </button>
-          <button className="cx-ib" title="Reveal in Finder" onClick={() => openWorktree(wt.wtKey, "finder")}>
-            <Finder size={14} />
-          </button>
+          {/* Reveal in Finder lives in the ⋯ menu — one route, not two. */}
           <button className="cx-ib" title="More" onClick={() => setMenu((m) => !m)} ref={moreRef} aria-haspopup="menu" aria-expanded={menu}>
             <More size={15} />
           </button>

--- a/src/app/canopy/laneLaunch.ts
+++ b/src/app/canopy/laneLaunch.ts
@@ -4,12 +4,19 @@
    identically: the handoff is written to .canopy/context.md first, then the
    agent runs as its OWN PTY with the prompt as its first argument. Running it
    as the session's command means the session ends — and the tab flips to
-   "ended" — exactly when the agent exits. */
+   "ended" — exactly when the agent exits.
+
+   Every launch takes an explicit TARGET. Closing over "whatever is selected"
+   was wrong in two ways: `select()` does not update this render's closure, so
+   launching from an overview row created the session in the previously
+   selected worktree; and a hook-held context snapshot went stale the moment
+   the context editor saved. Both are avoided by resolving the repo, worktree,
+   agent profile and context at call time. */
 import { useCallback, useEffect, useState } from "react";
 import { hasBackend, ipc, type AgentCfg } from "../../ipc";
 import { nextTermId, useStore } from "../../store";
 import type { RepoNode, WorktreeNode } from "../../types";
-import { composeAgentPrompt, composeContextMd, runtimeFor, useWtContext } from "../WorktreeContext";
+import { composeAgentPrompt, composeContextMd, readWtContext, runtimeFor } from "../WorktreeContext";
 
 const defaultAgent = (legacy: string): AgentCfg => ({
   id: "default",
@@ -19,83 +26,104 @@ const defaultAgent = (legacy: string): AgentCfg => ({
 });
 const shellQuote = (value: string) => `'${value.replace(/'/g, `'"'"'`)}'`;
 
-export interface LaneLaunch {
-  /** the repo's configured agent launchers (never empty — falls back to a default) */
-  agents: AgentCfg[];
-  startAgent: (profile?: AgentCfg) => Promise<void>;
-  startShell: () => void;
+/** Where a launch should happen. Omitted fields fall back to the hook's
+    defaults, which is what the work surface wants (it is always in-context). */
+export interface LaunchTarget {
+  repo?: RepoNode;
+  wt?: WorktreeNode;
+  profile?: AgentCfg;
 }
 
-export function useLaneLaunch(repo: RepoNode, wt: WorktreeNode): LaneLaunch {
+export interface LaneLaunch {
+  /** the default repo's configured launchers (never empty) */
+  agents: AgentCfg[];
+  startAgent: (target?: LaunchTarget) => Promise<void>;
+  startShell: (target?: LaunchTarget) => void;
+}
+
+export function useLaneLaunch(defaultRepo: RepoNode, defaultWt: WorktreeNode): LaneLaunch {
   const showToast = useStore((s) => s.showToast);
   const openSession = useStore((s) => s.openSession);
   const settingsRev = useStore((s) => s.settingsRev);
   const [agents, setAgents] = useState<AgentCfg[]>([defaultAgent("")]);
-  const [ctx] = useWtContext(wt.wtKey);
 
+  const profilesFor = useCallback(async (repoId: string): Promise<AgentCfg[]> => {
+    if (!hasBackend()) return [defaultAgent("")];
+    try {
+      const settings = await ipc.getSettings();
+      const configured = settings.repos.find((r) => r.id === repoId);
+      const next = (configured?.agents ?? []).filter((a) => a.id.trim() && a.command.trim());
+      return next.length ? next : [defaultAgent(configured?.agentCommand || "")];
+    } catch {
+      return [defaultAgent("")];
+    }
+  }, []);
+
+  // the default repo's list, for any UI that wants to render the choices
   useEffect(() => {
-    if (!hasBackend()) return;
     let alive = true;
-    ipc
-      .getSettings()
-      .then((settings) => {
-        if (!alive) return;
-        const configured = settings.repos.find((r) => r.id === repo.repoId);
-        const next = (configured?.agents ?? []).filter((a) => a.id.trim() && a.command.trim());
-        setAgents(next.length ? next : [defaultAgent(configured?.agentCommand || "")]);
-      })
-      .catch(() => {});
+    if (!defaultRepo.repoId) return;
+    profilesFor(defaultRepo.repoId).then((a) => alive && setAgents(a));
     return () => {
       alive = false;
     };
-  }, [repo.repoId, settingsRev]);
+  }, [defaultRepo.repoId, settingsRev, profilesFor]);
 
   /** "Claude", then "Claude 2", … — tab labels stay tellable apart at a glance.
       Reads live store state, not this render's snapshot, so two launches in the
       same tick can't both claim the unsuffixed name. */
-  const uniqueTitle = useCallback(
-    (base: string) => {
-      const live = useStore.getState().sessions[wt.wtKey] ?? [];
-      const taken = new Set(live.map((s) => s.title));
-      if (!taken.has(base)) return base;
-      for (let n = 2; ; n++) if (!taken.has(`${base} ${n}`)) return `${base} ${n}`;
-    },
-    [wt.wtKey],
-  );
+  const uniqueTitle = useCallback((wtKey: string, base: string) => {
+    const live = useStore.getState().sessions[wtKey] ?? [];
+    const taken = new Set(live.map((s) => s.title));
+    if (!taken.has(base)) return base;
+    for (let n = 2; ; n++) if (!taken.has(`${base} ${n}`)) return `${base} ${n}`;
+  }, []);
 
   const startAgent = useCallback(
-    async (profile?: AgentCfg) => {
-      const p = profile ?? agents[0];
-      if (!p) return;
+    async (target?: LaunchTarget) => {
+      const repo = target?.repo ?? defaultRepo;
+      const wt = target?.wt ?? defaultWt;
+      if (!wt.wtKey) return;
+
+      const profile = target?.profile ?? (repo.repoId === defaultRepo.repoId ? agents[0] : (await profilesFor(repo.repoId))[0]);
+      if (!profile) return;
+
       const id = nextTermId(wt.wtKey, "agent");
-      const title = uniqueTitle(p.name || "Agent");
+      const title = uniqueTitle(wt.wtKey, profile.name || "Agent");
       if (!hasBackend()) {
-        openSession({ id, wtKey: wt.wtKey, kind: "agent", title, agentId: p.id, command: "agent" });
+        openSession({ id, wtKey: wt.wtKey, kind: "agent", title, agentId: profile.id, command: "agent" });
         showToast(`${title} — ${repo.name} · ${wt.branch}`);
         return;
       }
       try {
         const runtime = runtimeFor(repo, wt);
+        // read the PERSISTED context, so an edit made moments ago is included
+        const ctx = readWtContext(wt.wtKey);
         // Always write the handoff: even a blank brief includes the branch,
         // database and resolved ports the agent needs to work safely.
         await ipc.writeWorktreeContext(wt.path, composeContextMd(ctx, runtime));
         const prompt = composeAgentPrompt(ctx, runtime);
         // A profile can opt out for CLIs that do not accept an initial
         // positional prompt; those still get CANOPY_CONTEXT_FILE.
-        const command = p.promptOnLaunch ? `${p.command} ${shellQuote(prompt)}` : p.command;
-        openSession({ id, wtKey: wt.wtKey, kind: "agent", title, agentId: p.id, command });
-        showToast(`${title} started with this worktree's context`);
+        const command = profile.promptOnLaunch ? `${profile.command} ${shellQuote(prompt)}` : profile.command;
+        openSession({ id, wtKey: wt.wtKey, kind: "agent", title, agentId: profile.id, command });
+        showToast(`${title} started — ${wt.branch}`);
       } catch (e) {
         showToast(`Agent start failed — ${String(e)}`);
       }
     },
-    [agents, ctx, openSession, repo, showToast, uniqueTitle, wt],
+    [agents, defaultRepo, defaultWt, openSession, profilesFor, showToast, uniqueTitle],
   );
 
-  const startShell = useCallback(() => {
-    const id = nextTermId(wt.wtKey, "shell");
-    openSession({ id, wtKey: wt.wtKey, kind: "shell", title: uniqueTitle("Shell") });
-  }, [openSession, uniqueTitle, wt.wtKey]);
+  const startShell = useCallback(
+    (target?: LaunchTarget) => {
+      const wt = target?.wt ?? defaultWt;
+      if (!wt.wtKey) return;
+      const id = nextTermId(wt.wtKey, "shell");
+      openSession({ id, wtKey: wt.wtKey, kind: "shell", title: uniqueTitle(wt.wtKey, "Shell") });
+    },
+    [defaultWt, openSession, uniqueTitle],
+  );
 
   return { agents, startAgent, startShell };
 }

--- a/src/app/nextAction.ts
+++ b/src/app/nextAction.ts
@@ -88,7 +88,9 @@ export function nextAction(wt: WorktreeNode, sessions: LaneSession[]): NextActio
   const crashed = wt.services.find((s) => s.status === "error");
   const waiting = agents.find((s) => agentState(s) === "waiting");
   const busy = agents.find((s) => agentState(s) === "busy");
-  const starting = wt.services.find((s) => s.status === "starting");
+  // `stopping` is equally in-flight: treating it as idle lets a worktree
+  // advertise "everything healthy" mid-shutdown, and lets ⏎ start it again
+  const starting = wt.services.find((s) => s.status === "starting" || s.status === "stopping");
   const stopped = wt.services.filter((s) => s.status === "stopped");
   const web = wt.services.find((s) => s.kind === "web" && s.status === "running" && s.port);
   const git = wt.git;
@@ -123,8 +125,8 @@ export function nextAction(wt: WorktreeNode, sessions: LaneSession[]): NextActio
       id: "starting",
       kind: "busy",
       icon: Spinner,
-      label: `Starting ${starting.name}…`,
-      why: starting.port ? "waiting for the port" : "waiting for the process",
+      label: starting.status === "stopping" ? `Stopping ${starting.name}…` : `Starting ${starting.name}…`,
+      why: starting.status === "stopping" ? "waiting for it to exit" : starting.port ? "waiting for the port" : "waiting for the process",
     };
 
   if (git && git.behind > 0)

--- a/src/icons.tsx
+++ b/src/icons.tsx
@@ -414,3 +414,11 @@ export const Sliders = ({ size = 14 }: P) => (
     <circle cx="19" cy="18" r="1.9" />
   </svg>
 );
+
+/** Two arrows trading places — branch switching, in place. */
+export const Swap = ({ size = 14 }: P) => (
+  <svg {...isvg(size, 1.8)}>
+    <path d="M4 8h13l-3 -3" />
+    <path d="M20 16h-13l3 3" />
+  </svg>
+);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,6 +10,7 @@ import "./styles/terminal.css";
 // app.css still owns.
 import "./styles/canopy-components.css";
 import "./styles/canopy-shell.css";
+import "./styles/canopy-modals.css";
 
 applyPlatformClass();
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -7,6 +7,7 @@ import { genLine, logTime, mockTree } from "./mock";
 import { hasBackend, ipc, on } from "./ipc";
 
 const LOG_CAP = 160;
+const CPU_SAMPLES = 7; // the service-detail sparkline shows seven slots
 const OP_LOG_CAP = 300;
 
 /** Buffered progress of a worktree-level operation (setup / create / custom cmd). */
@@ -80,6 +81,13 @@ interface State {
   logs: Record<string, LogLine[]>;
   ops: Record<string, OpLog>;
   stats: Record<string, SvcStats>;
+  /** rolling CPU samples per service — the service-detail sparkline. Kept
+      client-side because the backend streams point-in-time stats and has no
+      reason to retain history for a modal that may never open. */
+  cpuHistory: Record<string, number[]>;
+  /** last non-zero exit code per service. service:status already carries it;
+      it was previously dropped on the floor. */
+  exitCodes: Record<string, number>;
   resetting: Record<string, boolean>;
   toast: string | null;
   flash: "manager" | "quit" | null;
@@ -257,6 +265,8 @@ export const useStore = create<State>((set, get) => {
     logs: seedLogs(mock),
     ops: {},
     stats: seedStats(mock),
+    cpuHistory: {},
+    exitCodes: {},
     resetting: {},
     toast: null,
     flash: null,
@@ -566,6 +576,8 @@ export function initSync(): () => void {
       useStore.setState((st) => ({ tree: patchStatus(st.tree, e.svcKey, e.status) }));
       if (e.status === "running" && e.startedAt) startedAt[e.svcKey] = e.startedAt * 1000;
       if (e.status === "stopped" || e.status === "error") delete startedAt[e.svcKey];
+      if (e.exitCode != null)
+        useStore.setState((st) => ({ exitCodes: { ...st.exitCodes, [e.svcKey]: e.exitCode as number } }));
     }),
   );
 
@@ -602,8 +614,12 @@ export function initSync(): () => void {
     on.serviceStats((e) => {
       useStore.setState((st) => {
         const stats = { ...st.stats };
-        for (const s of e.entries) stats[s.svcKey] = { cpu: s.cpu, memMb: s.memMb, uptimeSec: s.uptimeSec };
-        return { stats };
+        const cpuHistory = { ...st.cpuHistory };
+        for (const s of e.entries) {
+          stats[s.svcKey] = { cpu: s.cpu, memMb: s.memMb, uptimeSec: s.uptimeSec };
+          cpuHistory[s.svcKey] = [...(cpuHistory[s.svcKey] ?? []), s.cpu].slice(-CPU_SAMPLES);
+        }
+        return { stats, cpuHistory };
       });
     }),
   );
@@ -652,7 +668,15 @@ export function startMockTick() {
         uptimeSec: getUptimeSec(s.svcKey) ?? 0,
       };
     });
-    useStore.setState({ stats });
+    // mirror the event path so the service-detail sparkline has samples in a
+    // plain browser too, not only under the Tauri backend
+    useStore.setState((st) => {
+      const cpuHistory = { ...st.cpuHistory };
+      running.forEach((s) => {
+        cpuHistory[s.svcKey] = [...(cpuHistory[s.svcKey] ?? []), stats[s.svcKey]?.cpu ?? 0].slice(-CPU_SAMPLES);
+      });
+      return { stats, cpuHistory };
+    });
 
     running.forEach((s) => {
       if (s.svcKey === st.tabSvcKey || Math.random() < 0.18) {

--- a/src/styles/canopy-components.css
+++ b/src/styles/canopy-components.css
@@ -6,7 +6,7 @@
 /* ── Button ───────────────────────────────────────────────────────
    Buttons NEVER shrink or wrap. In any toolbar the supporting text is the
    elastic item; an action label is not worth degrading. */
-.cx-btn{height:var(--h-control);padding:0 var(--sp-pop-lg);border-radius:var(--r-lg);border:var(--border-w) solid var(--divider);background:var(--btn);color:var(--text-secondary);font:var(--fw-medium) var(--fs-body) var(--sans);cursor:pointer;display:inline-flex;align-items:center;gap:var(--sp-3);flex:none;white-space:nowrap;transition:background var(--dur-fast),color var(--dur-fast),border-color var(--dur-fast)}
+.cx-btn{height:var(--h-control);padding:0 var(--sp-pop-lg);border-radius:var(--r-md);border:var(--border-w) solid var(--divider);background:var(--btn);color:var(--text-secondary);font:var(--fw-medium) var(--fs-body) var(--sans);cursor:pointer;display:inline-flex;align-items:center;gap:var(--sp-3);flex:none;white-space:nowrap;transition:background var(--dur-fast),color var(--dur-fast),border-color var(--dur-fast)}
 .cx-btn:hover{background:var(--btn-hover);color:var(--text-primary);border-color:var(--border-pop)}
 .cx-btn:disabled{opacity:.4;cursor:default}
 .cx-btn:disabled:hover{background:var(--btn);color:var(--text-secondary);border-color:var(--divider)}
@@ -43,7 +43,7 @@
 .cx-why{font-size:var(--fs-micro);color:var(--text-tertiary);flex:0 1 auto;min-width:0;margin-right:var(--sp-row);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:230px}
 
 /* ── Input / Select / SearchField ── */
-.cx-input{width:100%;height:var(--h-input);padding:0 var(--sp-pop);border-radius:var(--r-lg);border:var(--border-w) solid var(--divider);background:var(--surface-well);color:var(--text-primary);font:var(--fs-body) var(--sans);outline:none;transition:border-color var(--dur),box-shadow var(--dur)}
+.cx-input{width:100%;height:var(--h-input);padding:0 var(--sp-pop);border-radius:var(--r-md);border:var(--border-w) solid var(--divider);background:var(--surface-well);color:var(--text-primary);font:var(--fs-body) var(--sans);outline:none;transition:border-color var(--dur),box-shadow var(--dur)}
 .cx-input:focus{border-color:var(--action-primary);box-shadow:0 0 0 3px var(--focus-ring)}
 .cx-input::placeholder{color:var(--text-tertiary)}
 .cx-input--mono{font-family:var(--mono);font-size:var(--fs-body)}
@@ -93,8 +93,8 @@ select.cx-input{appearance:none;cursor:pointer;background-image:linear-gradient(
 .cx-spark i{width:3px;min-height:2px;background:var(--action-primary);opacity:.5;border-radius:var(--r-hairline);display:block}
 
 /* ── SegmentedControl ── */
-.cx-seg{display:flex;gap:var(--sp-1);padding:var(--sp-1);background:var(--surface-well);border:var(--border-w) solid var(--divider);border-radius:var(--r-xl)}
-.cx-seg button{flex:1;height:var(--h-ib);border:0;border-radius:var(--r-md);background:none;color:var(--text-tertiary);font:var(--fw-semi) var(--fs-small) var(--sans);cursor:pointer;white-space:nowrap;transition:background var(--dur-fast),color var(--dur-fast)}
+.cx-seg{display:flex;gap:var(--sp-1);padding:var(--sp-1);background:var(--surface-well);border:var(--border-w) solid var(--divider);border-radius:var(--r-lg)}
+.cx-seg button{flex:1;height:var(--h-control-xs);border:0;border-radius:var(--r-md);background:none;color:var(--text-tertiary);font:var(--fw-semi) var(--fs-small) var(--sans);cursor:pointer;white-space:nowrap;transition:background var(--dur-fast),color var(--dur-fast)}
 .cx-seg button:hover{color:var(--text-secondary)}
 .cx-seg button.is-on{background:var(--btn);color:var(--text-primary)}
 
@@ -156,13 +156,13 @@ select.cx-input{appearance:none;cursor:pointer;background-image:linear-gradient(
 .cx-modal--narrow{width:var(--w-modal-narrow)}
 .cx-modal--wide{width:var(--w-modal-wide)}
 .cx-modal__head{flex:none;display:flex;align-items:center;gap:var(--sp-5);padding:var(--sp-modal-head) var(--sp-6);border-bottom:var(--border-w) solid var(--divider)}
-.cx-modal__ic{width:26px;height:var(--h-ib);border-radius:var(--r-lg);display:grid;place-items:center;flex:none;background:var(--teal-dim);color:var(--action-primary)}
+.cx-modal__ic{width:var(--h-ib);height:var(--h-ib);border-radius:var(--r-md);display:grid;place-items:center;flex:none;background:var(--teal-dim);color:var(--action-primary)}
 .cx-modal__ic--danger{background:var(--red-dim);color:var(--red-text)}
 .cx-modal__title{min-width:0;flex:1;display:flex;flex-direction:column;gap:var(--sp-1)}
 .cx-modal__title b{font:var(--fw-semi) var(--fs-md) var(--sans)}
 .cx-modal__title span{font-size:var(--fs-small);color:var(--text-tertiary);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .cx-modal__body{flex:1;min-height:0;overflow-y:auto;padding:var(--sp-6)}
-.cx-modal__foot{flex:none;display:flex;align-items:center;gap:var(--sp-4);padding:var(--sp-pop-lg) var(--sp-6);border-top:var(--border-w) solid var(--divider);background:var(--wash-sunken)}
+.cx-modal__foot{flex:none;display:flex;align-items:center;gap:var(--sp-row);padding:var(--sp-pop-lg) var(--sp-6);border-top:var(--border-w) solid var(--divider);background:var(--wash-sunken)}
 .cx-modal__hint{font-size:var(--fs-micro);color:var(--text-tertiary);display:inline-flex;align-items:center;gap:var(--sp-3);min-width:0;flex:0 1 auto;overflow:hidden}
 .cx-modal__hint>svg{flex:none}
 .cx-modal__hint span{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}

--- a/src/styles/canopy-modals.css
+++ b/src/styles/canopy-modals.css
@@ -462,3 +462,22 @@
   border-radius: var(--r-xs);
   color: var(--action-primary);
 }
+
+/* the inline add-a-link field — sized to sit in the chip row it replaces */
+.cxm-linkin {
+  width: auto;
+  flex: 1 1 220px;
+  min-width: 180px;
+  height: var(--h-control-sm);
+  font-size: var(--fs-small);
+}
+.cxm-brc .x {
+  display: inline-flex;
+  color: var(--text-tertiary);
+  border-radius: var(--r-tiny);
+  margin-right: calc(var(--sp-micro) * -1);
+}
+.cxm-brc .x:hover {
+  background: var(--btn-hover);
+  color: var(--text-primary);
+}

--- a/src/styles/canopy-modals.css
+++ b/src/styles/canopy-modals.css
@@ -1,0 +1,464 @@
+/* Canopy dialog layer — form primitives and the pickers the modals share.
+
+   The modal card itself, its header/body/footer, buttons, inputs, alerts,
+   steps, key-value lists and tags all come from canopy-components.css. Only
+   what the dialogs add lives here.
+
+   The card floats, so it gets radius and shadow — but its INTERIOR is flat:
+   hairline-divided rows, never a stack of bordered pills. A bordered box
+   inside a bordered box is the bug this rule exists to prevent. */
+
+/* ── field scaffolding ─────────────────────────────────────────────── */
+.cxm-fld {
+  margin-bottom: var(--sp-pop-lg);
+}
+.cxm-fld:last-child {
+  margin-bottom: 0;
+}
+.cxm-sfld {
+  margin-top: var(--sp-4);
+}
+.cxm-sfld:first-child {
+  margin-top: 0;
+}
+.cxm-grid2 {
+  display: grid;
+  grid-template-columns: 148px 1fr;
+  gap: var(--sp-4);
+  align-items: center;
+}
+/* an uppercase section label; `--f` is the quieter per-field variant */
+.cxm-flab {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  font: var(--fw-bold) var(--fs-label) var(--sans);
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  margin-bottom: var(--sp-tight);
+}
+.cxm-flab--f {
+  text-transform: none;
+  letter-spacing: 0;
+  font-size: var(--fs-micro);
+  font-weight: var(--fw-medium);
+  color: var(--text-secondary);
+  margin-bottom: var(--sp-2);
+}
+.cxm-opt {
+  margin-left: auto;
+  letter-spacing: 0;
+  text-transform: none;
+  font-weight: var(--fw-regular);
+  font-size: var(--fs-micro);
+}
+.cxm-fhint {
+  font-size: var(--fs-micro);
+  color: var(--text-tertiary);
+  margin-top: var(--sp-tight);
+  line-height: var(--lh-body);
+}
+.cxm-fhint--bad {
+  color: var(--red-text);
+}
+.cxm-fhint--warn {
+  color: var(--state-attention);
+}
+
+/* ── checkbox row — a hairline-divided row, not a bordered pill ────── */
+.cxm-chk {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--sp-pop);
+  margin: 0 calc(var(--sp-6) * -1);
+  padding: var(--sp-pop) var(--sp-6);
+  border: 0;
+  border-bottom: var(--border-w) solid var(--divider);
+  background: none;
+  cursor: pointer;
+  transition: background var(--dur-fast);
+}
+.cxm-chk:hover {
+  background: var(--wash-pop-soft);
+}
+.cxm-chk input {
+  margin: var(--sp-hair) 0 0;
+  accent-color: var(--action-primary);
+  cursor: pointer;
+  flex: none;
+}
+.cxm-chk__tx {
+  min-width: 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-micro);
+}
+.cxm-chk__tx b {
+  font: var(--fw-medium) var(--fs-body) var(--sans);
+  color: var(--text-primary);
+}
+.cxm-chk__tx span {
+  font-size: var(--fs-micro);
+  color: var(--text-tertiary);
+  line-height: var(--lh-tight);
+}
+.cxm-chk__tx .mono {
+  font-family: var(--mono);
+}
+
+/* ── ref picker — shared by New worktree and Switch branch ─────────── */
+.cxm-pick {
+  position: relative;
+}
+.cxm-pick-f {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-row);
+  height: var(--h-logtool);
+  padding: 0 var(--sp-pop);
+  border-radius: var(--r-md);
+  border: var(--border-w) solid var(--divider);
+  background: var(--surface-well);
+  color: var(--text-tertiary);
+  cursor: text;
+}
+.cxm-pick-f:focus-within {
+  border-color: var(--action-primary);
+  box-shadow: 0 0 0 3px var(--teal-dim);
+}
+.cxm-pick-f input {
+  flex: 1;
+  background: none;
+  border: 0;
+  outline: none;
+  color: var(--text-primary);
+  font: var(--fs-body) var(--mono);
+  min-width: 0;
+}
+.cxm-pick-f input::placeholder {
+  color: var(--text-tertiary);
+  font-family: var(--sans);
+}
+.cxm-pick-l {
+  position: absolute;
+  top: calc(100% + var(--sp-2));
+  left: 0;
+  right: 0;
+  z-index: 5;
+  max-height: 196px;
+  overflow-y: auto;
+  padding: var(--sp-xs);
+  background: var(--raised);
+  border: var(--border-w) solid var(--border);
+  border-radius: var(--r-xl);
+  box-shadow: var(--shadow-pop);
+}
+.cxm-pick-g {
+  padding: var(--sp-tight) var(--sp-row) var(--sp-micro);
+  font: var(--fw-bold) var(--fs-label) var(--sans);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+.cxm-pick-i {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-row);
+  width: 100%;
+  padding: var(--sp-tight) var(--sp-row);
+  border: 0;
+  border-radius: var(--r-md);
+  background: none;
+  color: var(--text-primary);
+  font: var(--fs-body) var(--mono);
+  cursor: pointer;
+  text-align: left;
+}
+.cxm-pick-i:hover {
+  background: var(--raised-hi);
+}
+.cxm-pick-i.is-on {
+  background: var(--teal-dim);
+}
+.cxm-pick-i:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.cxm-pick-i:disabled:hover {
+  background: none;
+}
+.cxm-pick-i .ic {
+  color: var(--text-tertiary);
+  display: inline-flex;
+  flex: none;
+}
+.cxm-pick-i .nm {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+/* creating a ref is constructive, so it carries the accent */
+.cxm-pick-i--new,
+.cxm-pick-i--new .ic {
+  color: var(--action-primary);
+}
+.cxm-pick-e {
+  padding: var(--sp-6) var(--sp-pop);
+  text-align: center;
+  font-size: var(--fs-small);
+  color: var(--text-tertiary);
+}
+
+/* ── disclosure (the optional agent handoff) ───────────────────────── */
+.cxm-disc {
+  border: 0;
+  border-top: var(--border-w) solid var(--divider);
+  border-radius: 0;
+  background: none;
+  margin: 0 calc(var(--sp-6) * -1);
+  padding: 0 var(--sp-6);
+}
+.cxm-disc > summary {
+  list-style: none;
+  cursor: pointer;
+  padding: var(--sp-pop) 0;
+  font: var(--fw-medium) var(--fs-body) var(--sans);
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  gap: var(--sp-row);
+}
+.cxm-disc > summary::-webkit-details-marker {
+  display: none;
+}
+.cxm-disc > summary:hover {
+  color: var(--text-primary);
+}
+.cxm-disc > summary .cv {
+  display: inline-flex;
+  color: var(--text-tertiary);
+  transition: transform 0.15s;
+}
+.cxm-disc[open] > summary .cv {
+  transform: rotate(90deg);
+}
+.cxm-disc > summary .sub {
+  margin-left: auto;
+  font-size: var(--fs-micro);
+  color: var(--text-tertiary);
+  font-weight: var(--fw-regular);
+}
+.cxm-disc__body {
+  padding: 0 0 var(--sp-pop-lg);
+}
+
+/* ── inline progress stream (create / setup running) ───────────────── */
+.cxm-prog {
+  display: flex;
+  gap: var(--sp-pop);
+  padding: var(--sp-pop-lg) 0 0;
+  border-top: var(--border-w) solid var(--divider);
+  margin-top: var(--sp-modal-head);
+}
+.cxm-prog__ic {
+  color: var(--action-primary);
+  display: inline-flex;
+  flex: none;
+  margin-top: var(--sp-hair);
+}
+.cxm-prog__lines {
+  min-width: 0;
+  flex: 1;
+  font: var(--fs-small) / 1.65 var(--mono);
+  color: var(--text-tertiary);
+}
+/* the newest line is the one you're actually reading */
+.cxm-prog__lines div:last-child {
+  color: var(--text-secondary);
+}
+
+/* ── service detail: metrics row ───────────────────────────────────── */
+.cxm-mrow {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-pop);
+}
+.cxm-met {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-hair);
+  flex: none;
+}
+.cxm-met .v {
+  font: var(--fs-body) var(--mono);
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+}
+.cxm-met .k {
+  font-size: var(--fs-label);
+  font-weight: var(--fw-bold);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+
+/* ── database: switcher list + action rows ─────────────────────────── */
+.cxm-dbl {
+  max-height: 152px;
+  overflow-y: auto;
+  border: var(--border-w) solid var(--divider);
+  border-radius: var(--r-lg);
+  background: var(--surface-well);
+  padding: var(--sp-xs);
+}
+.cxm-dbo {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-row);
+  width: 100%;
+  padding: var(--sp-tight) var(--sp-row);
+  border: 0;
+  border-radius: var(--r-sm);
+  background: none;
+  color: var(--text-primary);
+  font: var(--fs-small) var(--mono);
+  cursor: pointer;
+  text-align: left;
+}
+.cxm-dbo:hover {
+  background: var(--raised-hi);
+}
+.cxm-dbo.is-on {
+  background: var(--teal-dim);
+}
+.cxm-dbo .ic {
+  color: var(--text-tertiary);
+  display: inline-flex;
+  flex: none;
+}
+/* an action row is flat and hairline-divided — the modal is the only float */
+.cxm-act {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-pop);
+  width: 100%;
+  margin: 0 calc(var(--sp-6) * -1);
+  padding: var(--sp-4) var(--sp-6);
+  border: 0;
+  border-bottom: var(--border-w) solid var(--divider);
+  background: none;
+  color: var(--text-primary);
+  font: var(--fs-body) var(--sans);
+  cursor: pointer;
+  text-align: left;
+  width: calc(100% + var(--sp-6) * 2);
+  transition: background var(--dur-fast);
+}
+.cxm-act:hover {
+  background: var(--wash-pop-soft);
+}
+.cxm-act .ic {
+  color: var(--text-tertiary);
+  display: inline-flex;
+  flex: none;
+}
+.cxm-act .sub {
+  margin-left: auto;
+  font: var(--fs-micro) var(--mono);
+  color: var(--text-tertiary);
+  flex: none;
+}
+.cxm-act--danger {
+  color: var(--red-text);
+}
+.cxm-act--danger .ic {
+  color: var(--red-text);
+}
+
+/* ── context editor ────────────────────────────────────────────────── */
+.cxm-ctxref {
+  display: grid;
+  grid-template-columns: 92px 1fr;
+  gap: var(--sp-tight) var(--sp-pop);
+  align-items: start;
+}
+.cxm-ctxref > label {
+  font-size: var(--fs-micro);
+  color: var(--text-tertiary);
+  padding-top: var(--sp-row);
+}
+.cxm-ctxrt {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-tight);
+  font-size: var(--fs-small);
+  color: var(--text-tertiary);
+}
+.cxm-ctxrt > span {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  height: var(--h-gitchip);
+  padding: 0 var(--sp-row);
+  border-radius: var(--r-sm);
+  background: var(--surface-well);
+  border: var(--border-w) solid var(--divider);
+}
+.cxm-ctxrt em {
+  font-style: normal;
+  font-family: var(--mono);
+  color: var(--action-primary);
+}
+/* a link chip — the one place a dashed border means "add another" */
+.cxm-brc {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  height: var(--h-control-sm);
+  padding: 0 var(--sp-row);
+  border-radius: var(--r-sm);
+  border: var(--border-w) solid var(--divider);
+  background: var(--surface-well);
+  color: var(--text-secondary);
+  font: var(--fs-small) var(--mono);
+  cursor: pointer;
+  transition:
+    border-color var(--dur-fast),
+    color var(--dur-fast);
+}
+.cxm-brc:hover {
+  border-color: var(--border-pop);
+  color: var(--text-primary);
+}
+.cxm-brc--add {
+  border-style: dashed;
+  color: var(--text-tertiary);
+  font-family: var(--sans);
+}
+.cxm-links {
+  display: flex;
+  gap: var(--sp-3);
+  flex-wrap: wrap;
+}
+.cxm-preview {
+  padding: var(--sp-pop) var(--sp-pop-lg);
+  border: var(--border-w) solid var(--divider);
+  border-radius: var(--r-lg);
+  background: var(--surface-well);
+  min-height: 150px;
+  font-size: var(--fs-body);
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+.cxm-preview code {
+  font-family: var(--mono);
+  font-size: var(--fs-small);
+  background: var(--surface-app);
+  padding: var(--sp-hair) var(--sp-2);
+  border-radius: var(--r-xs);
+  color: var(--action-primary);
+}

--- a/src/styles/canopy-shell.css
+++ b/src/styles/canopy-shell.css
@@ -798,6 +798,17 @@
 .cxs-vdiv.is-on {
   background: var(--action-primary);
 }
+/* The pane tab strip joins the main pane's shared left gutter. The .cx-tabs
+   primitive sits on --sp-3, but inside the pane the worktree bar, service
+   rail, log toolbar and log lines all align on --gutter — the strip has to
+   join that edge or it is the one row that doesn't line up. */
+.cxs-main .cx-tabs {
+  padding-inline: var(--gutter);
+}
+.cxs-main .cx-tab {
+  padding-inline: var(--sp-row);
+}
+
 /* pane tabs: Logs / Terminal / Agent live TOGETHER — the integration fix.
    The tab group scrolls horizontally instead of overflowing, and the trailing
    control lives OUTSIDE the scroller so it stays reachable however many
@@ -906,7 +917,7 @@
 }
 .cxs-fchip {
   height: var(--h-control-sm);
-  padding: 0 var(--sp-3);
+  padding: 0 var(--sp-tight);
   border-radius: var(--r-md);
   border: var(--border-w) solid transparent;
   background: none;
@@ -1393,7 +1404,7 @@
   align-items: center;
   gap: var(--sp-2);
   height: var(--h-statusact);
-  padding: 0 var(--sp-3);
+  padding: 0 var(--sp-tight);
   border-radius: var(--r-xs);
   border: 0;
   background: none;

--- a/src/styles/canopy-shell.css
+++ b/src/styles/canopy-shell.css
@@ -2037,3 +2037,53 @@
   right: 0;
   min-width: 216px;
 }
+
+/* ── the agent pane's context bar ──────────────────────────────────
+   What the agent was seeded with, always visible above the session so it is
+   never a mystery what it was told. Clicking it opens the context editor. */
+.cxs-ctxbar {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-row);
+  padding: var(--sp-tight) var(--sp-pop);
+  border-bottom: var(--border-w) solid var(--divider);
+  background: var(--surface-app);
+  cursor: pointer;
+  border-top: 0;
+  border-left: 0;
+  border-right: 0;
+  width: 100%;
+  text-align: left;
+  font-family: var(--sans);
+  transition: background var(--dur-fast);
+}
+.cxs-ctxbar:hover {
+  background: var(--surface);
+}
+.cxs-ctxbar .lb {
+  font-size: var(--fs-label);
+  font-weight: var(--fw-bold);
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  flex: none;
+}
+.cxs-ctxbar .ti {
+  font-size: var(--fs-small);
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+  flex: 1;
+}
+.cxs-ctxbar .ti.is-empty {
+  color: var(--text-tertiary);
+  font-style: italic;
+}
+.cxs-ctxbar .lk {
+  font-size: var(--fs-micro);
+  color: var(--text-tertiary);
+  flex: none;
+}

--- a/src/styles/canopy-shell.css
+++ b/src/styles/canopy-shell.css
@@ -7,7 +7,22 @@
 
    Narrow behaviour keys off the PANE, not the viewport — panes resize
    independently of the window, so @media cannot see them. Hence
-   container-type/container-name on .cxs-shell and .cxs-main. */
+   container-type/container-name on .cxs-shell and .cxs-main.
+
+   WHAT IS TOKENIZED: everything drawn from the design system's shared
+   vocabulary — spacing steps, the type ramp, weights, radii, colours,
+   shadows, chrome heights and the surfaces' widths. If a value is one the
+   system has an opinion about, it resolves from tokens.css.
+
+   WHAT IS NOT, and why: one-off element geometry. A 7px submodule dot, a 13px
+   checkbox, a 34px empty-state tile, a 25×23 pull button, the overview
+   table's nine column tracks, flex bases and max-heights. These are drawn
+   once, belong to a single element, and are the same category as a
+   grid-template value. Minting a token per one would add dozens of names with
+   a single call site each, which obscures the scale rather than expressing
+   it. Also literal by necessity: @media/@container conditions (custom
+   properties are not valid there — a language limit, not a choice) and a
+   #000 mask stop, which is luminance rather than colour. */
 
 .cxs-shell {
   height: 100%;
@@ -26,7 +41,7 @@
   height: var(--h-topbar);
   flex: none;
   display: grid;
-  grid-template-columns: minmax(min-content, 1fr) minmax(0, 360px) minmax(min-content, 1fr);
+  grid-template-columns: minmax(min-content, 1fr) minmax(0, var(--w-command)) minmax(min-content, 1fr);
   align-items: center;
   gap: var(--sp-pop);
   padding: 0 var(--sp-pop) 0 var(--sp-5);
@@ -65,7 +80,7 @@
 /* command field: centred, the one global entry point */
 .cxs-gsearch {
   width: 100%;
-  max-width: 360px;
+  max-width: var(--w-command);
   min-width: 0;
   display: flex;
   align-items: center;
@@ -115,8 +130,8 @@
   display: inline-flex;
 }
 .cxs-tdiv {
-  width: 1px;
-  height: 16px;
+  width: var(--border-w);
+  height: var(--h-divider);
   background: var(--divider);
   flex: none;
 }
@@ -362,7 +377,7 @@
   gap: var(--sp-row);
   width: 100%;
   text-align: left;
-  height: 28px;
+  height: var(--h-control);
   padding: 0 var(--sp-row);
   border: 0;
   border-radius: var(--r-md);
@@ -456,9 +471,9 @@
   content: "";
   position: absolute;
   left: 0;
-  top: 5px;
-  bottom: 5px;
-  width: 2px;
+  top: var(--sp-2);
+  bottom: var(--sp-2);
+  width: var(--r-indicator);
   border-radius: var(--r-indicator);
   background: var(--action-primary);
 }
@@ -515,8 +530,13 @@
   flex: none;
   margin-right: calc(var(--sp-micro) * -1);
 }
-.cxs-wtr:hover .cxs-qa {
+.cxs-wtr:hover .cxs-qa,
+.cxs-qa:focus-within {
   display: flex;
+}
+/* a focused quick action must also displace the meta it overlays */
+.cxs-wtr:has(.cxs-qa:focus-within) .meta {
+  display: none;
 }
 .cxs-qa .qb {
   width: var(--h-quickact);
@@ -621,7 +641,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   flex: 0 1 auto;
-  min-width: 44px;
+  min-width: var(--w-branch-min);
 }
 .cxs-gitchips {
   display: flex;
@@ -662,8 +682,8 @@
   margin-left: auto;
 }
 .cxs-actdiv {
-  width: 1px;
-  height: 15px;
+  width: var(--border-w);
+  height: var(--h-divider-sm);
   background: var(--divider);
   margin: 0 var(--sp-2);
   flex: none;
@@ -735,8 +755,8 @@
   font-variant-numeric: tabular-nums;
 }
 .cxs-svc .act {
-  width: 16px;
-  height: 16px;
+  width: var(--sz-svc-act);
+  height: var(--sz-svc-act);
   border: 0;
   border-radius: var(--r-xs);
   background: none;
@@ -783,7 +803,7 @@
 }
 .cxs-vdiv {
   flex: none;
-  width: 1px;
+  width: var(--border-w);
   background: var(--divider);
   cursor: col-resize;
   position: relative;
@@ -1375,7 +1395,8 @@
   opacity: 0;
   transition: opacity var(--dur-fast);
 }
-.cxs-tbl tbody tr:hover .cxs-rowact {
+.cxs-tbl tbody tr:hover .cxs-rowact,
+.cxs-rowact:focus-within {
   opacity: 1;
 }
 .cxs-ovempty {

--- a/src/styles/canopy-shell.css
+++ b/src/styles/canopy-shell.css
@@ -2031,12 +2031,6 @@
   color: var(--text-secondary);
 }
 
-/* the worktree bar's More menu, anchored under its trigger */
-.cxs-moremenu {
-  top: var(--h-control-xs);
-  right: 0;
-  min-width: 216px;
-}
 
 /* ── the agent pane's context bar ──────────────────────────────────
    What the agent was seeded with, always visible above the session so it is

--- a/src/styles/canopy-shell.css
+++ b/src/styles/canopy-shell.css
@@ -634,7 +634,7 @@
   align-items: center;
   gap: var(--sp-micro);
   height: var(--h-gitchip);
-  padding: 0 var(--sp-3);
+  padding: 0 var(--sp-tight);
   border-radius: var(--r-sm);
   background: var(--surface-well);
   border: var(--border-w) solid var(--divider);
@@ -690,7 +690,7 @@
 .cxs-svc {
   display: inline-flex;
   align-items: center;
-  gap: var(--sp-3);
+  gap: var(--sp-row);
   height: var(--h-control-xs);
   padding: 0 var(--sp-4);
   border-radius: var(--r-md);

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -187,6 +187,11 @@
   --h-ib-tab: 21px; /* icon button inside a pane tab strip */
   --h-ib-tool: 22px; /* icon button inside a toolbar */
   --h-ib: 26px; /* the standard icon button, and segmented-control segments */
+  --h-divider: 16px; /* the topbar's vertical hairline */
+  --sz-attn-ic: 20px; /* the attention row's icon tile */
+  --sz-svc-act: 16px; /* the start/stop affordance inside a service chip */
+  --h-divider-sm: 15px; /* the worktree bar's shorter hairline */
+  --w-branch-min: 44px; /* the branch headline never ellipses below this */
 
   /* status dots — 6px reads only because of the halo; 5px is the inline
      variant used inside rows and tables where a halo would crowd. */
@@ -200,6 +205,7 @@
   --w-rail-collapsed: 52px;
 
   /* floating-surface widths */
+  --w-command: 360px; /* the ⌘K field's track in the topbar grid */
   --w-palette: 592px;
   --w-pullpop: 346px;
   --w-attnpop: 306px;

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -193,6 +193,9 @@
 
   --w-sidebar: 238px;
   --w-sidebar-narrow: 210px; /* below the 1180px breakpoint */
+  /* Declared by the handoff's layout.css but referenced by none of its
+     screens. Carried for token parity; nothing consumes it yet. */
+  --w-rail-collapsed: 52px;
 
   /* floating-surface widths */
   --w-palette: 592px;

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -176,7 +176,9 @@
   --h-control: 28px;
   --h-control-sm: 22px;
   --h-control-xs: 24px; /* topbar controls, service chips, crumb */
-  --h-input: 32px;
+  /* Both screens draw form inputs at 30px; .cx-input was this token's only
+     consumer, so the token was the outlier rather than the usage. */
+  --h-input: 30px;
   --h-logtool: 30px; /* log filter toolbar */
   --h-session: 20px; /* session chip in a pane's tab strip */
   --h-quickact: 19px; /* sidebar row hover action */


### PR DESCRIPTION
Implements `Canopy Modals.html` — the dialog layer. Follows #57, which ported the workspace shell. Settings and Onboarding are still on the old design and land as follow-up PRs.
Fixes: #50 

## The set

Nine surfaces in the design; two were already shipped in #57 (`PullPop` in the status bar, `MorePop` in the worktree bar). The remaining seven:

| Dialog | |
|---|---|
| **New worktree** | two modes, shared ref picker, optional agent handoff that seeds `.canopy/context.md`, live create progress from `worktree:op` |
| **Remove worktree** | real dirty report with the actual file list, type-the-branch-name to arm, ahead-count warning on branch deletion |
| **Switch branch** | in place; in-use branches shown but disabled, create-off-current when the typed name is unknown |
| **Database** | searchable switcher plus snapshot / export / restore / reset / migrate. Replaces the stopgap wrapper #57 put around `DatabaseControl` |
| **Context editor** | Write/Preview markdown, references, and the runtime strip the agent inherits |
| **Setup runner** *(new)* | the provisioning stream as a step list, rebuilt from the `worktree:op` markers the store already folds |
| **Service detail** *(new)* | cpu/mem/uptime with a CPU sparkline, port override with real clash detection, restart/stop, failure leading when the process died |

Every modal ends the same way: a ghost dismiss plus one primary that names its action.

## Behaviour changes

**A service chip in the rail now opens Service detail.** #57 made it filter the log stream — a decision taken before the modals file revealed the intended destination. Log filtering moves to the log toolbar's own chip row, which already existed, so one click never means two things.

**The agent pane's context bar is restored.** #57 omitted it. It is the context editor's trigger, so without it the editor was unreachable.

**The worktree ⋯ menu no longer clips.** It was rendering as a 7px sliver — 51 of its 58px cut off. Not a z-index problem: `.cxs-wtbar` sets `overflow: hidden` so a long branch name ellipses, and an ancestor's clip beats any z-index a descendant sets. `.cxs-main`'s `container-type: inline-size` compounded it by making the pane both a stacking context and the containing block for absolute children. Fixed with `AnchoredMenu`, which portals to `<body>` and positions from the trigger's viewport rect.

## Backend

Two gaps turned out to be frontend-side and are fixed here rather than filed: the store was discarding `exitCode` from `service:status`, and kept no CPU history for the sparkline. The mock tick now mirrors the event path so a plain browser behaves like the real app.

Three are genuine and left **visibly absent**, each with a `TODO` at the call site:

- **#58** — no preview of a worktree's derived path/ports/database, so "You'll get" shows the path and `—` for the rest. Deriving `basePort + index × 10` in the frontend would duplicate backend logic that can drift, and a wrong port is worse than a blank one.
- **#59** — no way to read a service's resolved environment or its derived port, so Service detail omits the Environment panel entirely and the port hint stays neutral. Clash detection *is* implemented, since that only needs the tree.
- **#60** — `worktree:op` carries step identity but no parsed result, so setup steps show no "1,842 packages" metadata.

**#59 is the one worth doing first** — the Environment panel answers "why is this service talking to the wrong database?", which is the classic worktree-isolation bug.

## Design system

`canopy-modals.css` adds only what the dialogs need; the card, buttons, inputs, alerts, steps, key-value lists and tags all come from the component layer. Fully tokenized from the start, and token parity with the handoff is now complete (126/126 — the last missing one, `--w-rail-collapsed`, is an orphan the handoff declares and never uses).

Audited the result mechanically: 21 shell classes' computed height/padding/gap asserted against `Canopy Redesign.html` with the palette, overview, git chips and session chips forced open. Two 1px drifts found and fixed (`.cxs-gc` padding, `.cxs-svc` gap) — both the same over-tokenization mistake, rounding an 8px/6px literal onto the nearest scale step.

### Handoff contradictions, now six

#57 documented four. Two more here:

| Conflict | Resolved as |
|---|---|
| `.cx-svc` is 22px; the Redesign screen's rail chip is 24px | screen wins — the primitive sits unused |
| `.cx-chip`, `.cx-row`, `.cx-label` likewise overridden by screen variants | screen wins |

Same rule as before: a screen overriding a *generic* primitive wins; a screen contradicting a *specific* token plus stated reasoning loses.

Also worth recording: `.agb` and `.aask` — the agent banner and its inline "Commit these changes?" prompt — are **not implementable as designed**. The handoff mocks the agent as a structured React step list; the real app runs it as a PTY through xterm, so its output and questions live inside the terminal. Rendering them means parsing agent output into steps, which is #54's territory.

## Follow-ups

- `WorktreeHeader`, `ServiceCard`, `Console`, `AgentLane`, `SubmoduleMenu` (~1,500 lines) are unreferenced. Service detail now reimplements what `ServiceCard` held, so they are finally safe to delete — separate PR.
- Port `Canopy Settings.html` and `Canopy Onboarding.html`; ~4,900 lines of old-design CSS goes with them.
- Revisit tokens once every screen is ported and the real gaps are visible rather than guessed.

## Verification

`tsc` clean, `vite build` passes, and the dialogs were exercised in a live browser. The ⋯ menu fix was verified by hit-testing with `elementFromPoint` at every corner rather than eyeballing — the earlier check confirmed only that it *opened*, which is how the clipping slipped through in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmnwuEkt2Wprsh8qLHfgJL
