### PR TITLE
Add the design-build skill

### DIFF
--- a/.claude/skills/design-build/SKILL.md
+++ b/.claude/skills/design-build/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: design-build
+description: Implement a screen from a Canopy design handoff — token-faithful, backend-honest, and verified by measurement rather than eye. Use when asked to build, port, or revamp a screen from a design file (Canopy Redesign.html, Canopy Modals.html, Canopy Settings.html, Canopy Onboarding.html) or any design-system handoff.
+---
+
+# Building a screen from the design handoff
+
+This encodes what two shipped ports (#57 workspace, #61 dialogs) actually cost.
+Every rule below exists because skipping it produced a defect that reached a
+build. Read `verify.md` in this directory for the measurement recipes.
+
+The single most important idea: **you cannot verify a design port by reading
+stylesheets.** Every bug that survived an audit survived because the audit
+compared CSS instead of the rendered result.
+
+---
+
+## Phase 0 — Read the design properly
+
+1. **Locate the handoff.** Usually a zip the user extracts. Contains
+   `tokens/`, `components/components.css`, one HTML per screen, `cx*.jsx`
+   modules, `readme.md`, `github.md`.
+2. **Read `readme.md` and `github.md` first.** The readme states load-bearing
+   rules (the radius rule, colour meanings, elastic-vs-fixed, container
+   queries) and `github.md` maps each screen to the source files it was drawn
+   from. Both are authoritative context you cannot infer from CSS.
+3. **Read the screen's JSX, not only its `<style>`.** The stylesheet tells you
+   how things look; only the markup tells you **what exists**. A menu with the
+   right CSS and three of its eight rows passes a stylesheet diff.
+4. **Render it.** Serve the handoff directory and open the screen:
+
+   ```
+   cd <handoff>/project && python3 -m http.server 5310
+   ```
+
+   It is a live React app. Drive it, open its flows, and measure it. This is
+   the reference for every later comparison.
+
+---
+
+## Phase 1 — Audit the backend before writing UI
+
+**Never trust a claim about the backend — including your own, and including a
+reviewer's. Verify against the source.** In #61 every one of four reviewer
+claims about Rust behaviour was true and two were worse than described; a
+regex was matched against a marker format that never existed.
+
+For each capability the design implies, find the actual command in
+`src-tauri/src/` and the typed wrapper in `src/ipc.ts`. Check:
+
+- the **exact output format** you will parse (`setup.rs` emits
+  `{label} [1/3]: cmd`, not `[1/3]: cmd`)
+- **truncation** (`git::dirty_report` caps at `.take(10)` — a count of 10 is a
+  floor, not a total)
+- **validation ranges** (`set_service_port` rejects outside 1024–65535)
+- **derivation rules** you intend to mirror (`sanitize_branch` preserves case
+  and maps to `_`; the dir is `{repo.path}-worktrees`)
+
+Classify every gap as **frontend-fixable** or **backend-missing**. Things that
+look like backend gaps often are not: a discarded `exitCode`, missing stats
+history, and unshared context state were all frontend fixes in #61.
+
+---
+
+## Phase 2 — Build
+
+### Token discipline
+
+- **Everything from the design system's vocabulary resolves from tokens**:
+  spacing, type ramp, weights, radii, colours, shadows, chrome heights,
+  surface widths.
+- **Never round a literal onto a scale that cannot express it.** If the design
+  uses 8px and the scale has 7 and 9, do not pick 7 — *count the usage*, and
+  if it earns a place, extend the scale. In the Canopy handoff 8px was the
+  most-used spacing value in the entire screen and was not on the scale.
+  Rounding produced a dozen 1px drifts across two PRs.
+- **Add tokens by role when the index scale can't be interleaved** — the
+  component layer ships verbatim against `--sp-1…8`, so renumbering silently
+  repoints it.
+- **One-off element geometry stays literal**: a 7px dot, a 13px checkbox,
+  table column tracks. A token per single call site obscures the scale.
+- `@media` / `@container` conditions **cannot** use custom properties. That is
+  a language limit, not a choice — say so rather than claiming full coverage.
+- **Never claim "zero hardcoded values" without auditing.** State exactly what
+  is tokenized and what is not.
+
+### Resolving handoff contradictions
+
+The handoff contradicts itself. Seven instances across two ports. Apply this
+rule and **record each one in the PR**:
+
+> A screen overriding a **generic primitive** for its own context **wins**.
+> A screen contradicting a **specific token backed by documented rationale**
+> **loses**.
+
+Worked examples:
+- `components.css` sets the search input `--fs-small`; the screen sets
+  `--fs-body` → **screen wins** (generic primitive, screen context).
+- The screen sets `.topbar` 38px; `--h-topbar` is 36px and the readme states
+  "chrome totals 106px" → **token wins** (specific token + stated reasoning).
+
+### Missing backend — degrade visibly, never fabricate
+
+| Scope | Treatment |
+|---|---|
+| A whole page/screen | render it, with a **coming-soon banner** at the top |
+| A button or icon | render it **disabled** with a `title` of "Coming soon" |
+| A single value | render `—` with a `title` explaining it isn't measured yet |
+| A whole panel | **omit it**, with a `TODO(#n)` explaining why |
+
+Rules:
+- **Never wire a control to plausible-looking data.** A fabricated path is
+  worse than a blank one — the panel exists to tell the truth.
+- **Never approximate a backend derivation.** Either mirror it exactly (and
+  cite the source line) or show nothing.
+- Every degraded spot gets a `TODO(#n)` at the call site naming the issue.
+- File the issue **before** building the degraded state, so the marker has a
+  number.
+
+Use `components/*` helpers where they exist; add `.cx-banner` /
+`.cx-soon` styling to the shared component layer rather than per screen.
+
+---
+
+## Phase 3 — Verify by measurement
+
+Run **all four** passes. See `verify.md` for copy-paste recipes. Skipping any
+one of these has let a real defect ship.
+
+1. **Geometry** — computed `height`/`padding`/`gap`/`radius`/`font-size` from
+   both the rendered design and the app, diffed programmatically.
+2. **Inventory** — every button label, section label, field, action row, kv
+   key, step and checkbox in each surface. *This is the pass that catches a
+   three-row menu that should have eight.*
+3. **Tokens** — every token the handoff declares exists; every token used
+   actually resolves rather than silently falling back.
+4. **Content** — copy, tooltips, empty states, and the design's voice rules
+   (imperative buttons that name the action; `reason · ACTION`; numbers
+   specific; sentence case; no emoji).
+
+Non-negotiables while verifying:
+
+- **Force hidden surfaces open.** A palette, overview, modal or git chip that
+  is not on screen is silently skipped and reported as passing.
+- **Hit-test interactive elements** with `elementFromPoint` at their corners.
+  "The menu opened" is not "the menu is visible" — a clipped menu opens fine.
+- **Check the alignment rules the readme states**, not just per-element
+  numbers. Two legitimately-tokenized values can still break a stated shared
+  edge.
+- **When a diff looks like a defect, check the design before fixing.** Several
+  "failures" were the test being wrong: a `narrow` modal really is 440px, a
+  title input really is `--fs-md`.
+
+---
+
+## Phase 4 — Ship
+
+1. **Issues** — one per backend gap, assigned to the repo owner. State what
+   the design needs, what exists, what is needed, and **what the UI does in
+   the meantime**. Cite source files and line numbers.
+2. **PR** — document, in the body:
+   - what was implemented and what was deliberately left out
+   - every handoff contradiction and how it was resolved
+   - every backend gap with its issue number
+   - what verification was actually run (and what it does *not* cover)
+3. **No `Co-Authored-By` trailer** on commits or the PR. This repo does not
+   use it.
+4. Follow the repo's squash-merge convention; keep the detail in the PR body.
+
+---
+
+## Failure modes seen in the wild
+
+Check each of these before declaring done. All shipped at least once.
+
+**Layout / floating**
+- An ancestor's `overflow: hidden` clips a popover — **no z-index escapes a
+  clip**. `container-type` compounds it (layout containment makes the element
+  a stacking context *and* the containing block). Portal floating menus to
+  `<body>` and position from the trigger's viewport rect.
+- Hover-only reveals (`opacity: 0`, `display: none`) are invisible to keyboard
+  users. Add `:focus-within`.
+
+**State / correctness**
+- **Closure capture**: `select(key)` does not update the current render, so a
+  launcher closing over "the selection" targets the previous one. Pass
+  explicit targets.
+- **Snapshot staleness**: a captured node freezes at the status it had when
+  clicked. Resolve from the subscribed tree each render.
+- **Per-caller hook state** (`useWtContext`) is not shared — read persisted
+  state at action time.
+- **`busy` defaulting to true** makes a dialog unclosable before its first
+  event. Gate dismissal on authoritative state only.
+- **Transitional statuses**: `isLive()` excludes `stopping`, so a
+  mid-shutdown worktree reads as idle and offers "Start".
+
+**Safety**
+- Destructive dialogs must **fail closed**: a failed probe is not "clean".
+- Never present a truncated backend list as complete.
+
+**Accessibility**
+- `aria-modal="true"` without a focus trap is a false promise; restore focus
+  to the opener on close.
+- A collapsed region needs `inert`, not just `opacity: 0`.
+- Click-only `<span>`s are not operable; nested interactive elements swallow
+  each other's keys — gate on `e.target === e.currentTarget`.
+- A popover trigger must be able to **close its own popover** — exclude it
+  from the outside-click listener.

--- a/.claude/skills/design-build/SKILL.md
+++ b/.claude/skills/design-build/SKILL.md
@@ -86,18 +86,30 @@ history, and unshared context state were all frontend fixes in #61.
 
 ### Resolving handoff contradictions
 
-The handoff contradicts itself. Seven instances across two ports. Apply this
-rule and **record each one in the PR**:
+The handoff contradicts itself — repeatedly, and in ways only measurement
+finds. Apply this rule and **record each instance in the PR**:
 
 > A screen overriding a **generic primitive** for its own context **wins**.
 > A screen contradicting a **specific token backed by documented rationale**
 > **loses**.
 
-Worked examples:
-- `components.css` sets the search input `--fs-small`; the screen sets
-  `--fs-body` → **screen wins** (generic primitive, screen context).
-- The screen sets `.topbar` 38px; `--h-topbar` is 36px and the readme states
-  "chrome totals 106px" → **token wins** (specific token + stated reasoning).
+Every instance found across the two ports, so the next one starts from the
+record rather than rediscovering them:
+
+| # | Conflict | Resolved |
+|---|---|---|
+| 1 | `.cx-search` input is `--fs-small`; the screen sets `--fs-body` | screen |
+| 2 | screen `.topbar` 38px; `--h-topbar` 36px + readme "chrome totals 106px" | token |
+| 3 | screen `.rail` 38px; `--h-rail` 34px + the same readme statement | token |
+| 4 | `components.css` type is 9/10/11/12px — each exactly 0.5px under the ramp | ramp |
+| 5 | `components.css` weights 500/520/560; the scale is 400/550/620/700 | scale |
+| 6 | `.cx-svc` is 22px; the workspace screen's rail chip is 24px | screen |
+| 7 | form controls — `.cx-input` height+radius, `.cx-btn`/`.cx-seg`/`.cx-modal__ic` radius, `.cx-seg button` height, `.cx-modal__foot` gap — all disagree with the modals screen | screen |
+
+Read the table as the pattern, not the total: rows 4 and 5 are one defect
+("the component layer drifted off its own scales") if you prefer to count
+that way. What matters is that the component layer and the screens disagree
+often enough that you must check, never assume.
 
 ### Missing backend — degrade visibly, never fabricate
 
@@ -124,19 +136,25 @@ Use `components/*` helpers where they exist; add `.cx-banner` /
 
 ## Phase 3 — Verify by measurement
 
-Run **all four** passes. See `verify.md` for copy-paste recipes. Skipping any
-one of these has let a real defect ship.
+Run **all five** passes. See `verify.md` for copy-paste recipes, one section
+per pass. Skipping any one of these has let a real defect ship.
 
 1. **Geometry** — computed `height`/`padding`/`gap`/`radius`/`font-size` from
-   both the rendered design and the app, diffed programmatically.
+   both the rendered design and the app, diffed programmatically. Treat a
+   non-numeric value as a failure: every comparison with `NaN` is false, so a
+   missing property otherwise reports as a match.
 2. **Inventory** — every button label, section label, field, action row, kv
    key, step and checkbox in each surface. *This is the pass that catches a
    three-row menu that should have eight.*
-3. **Tokens** — every token the handoff declares exists; every token used
-   actually resolves rather than silently falling back.
+3. **Tokens** — every token the handoff declares exists; every token
+   *referenced by the stylesheets* resolves. Derive that list from the sheets;
+   a hand-written allowlist only contains names you spelled correctly.
 4. **Content** — copy, tooltips, empty states, and the design's voice rules
    (imperative buttons that name the action; `reason · ACTION`; numbers
-   specific; sentence case; no emoji).
+   specific; sentence case; no emoji). Assert every coming-soon control
+   actually carries its tooltip.
+5. **Interaction** — hit-test visibility, keyboard operability, focus reveals,
+   and that a trigger can close its own popover.
 
 Non-negotiables while verifying:
 

--- a/.claude/skills/design-build/verify.md
+++ b/.claude/skills/design-build/verify.md
@@ -48,15 +48,23 @@ Then assert in the **app**, tolerating sub-pixel noise:
     const el = document.querySelector(sel);
     if (!el) { bad.push(`${sel} NOT RENDERED`); continue; }
     const c = getComputedStyle(el);
-    for (const [p, exp] of Object.entries(want))
-      if (Math.abs(parseFloat(c[p]) - parseFloat(exp)) >= 0.6)
+    for (const [p, exp] of Object.entries(want)) {
+      const got = parseFloat(c[p]), e = parseFloat(exp);
+      // NaN is the trap: every comparison with NaN is false, so a missing or
+      // non-numeric value (auto, "", a typo'd property) would report as a
+      // MATCH. Fail on non-finite before comparing.
+      if (!Number.isFinite(got) || !Number.isFinite(e))
+        bad.push(`${sel}{${p}} NON-NUMERIC design ${exp} ours ${c[p]}`);
+      else if (Math.abs(got - e) >= 0.6)
         bad.push(`${sel}{${p}} design ${exp} ours ${c[p]}`);
+    }
   }
   return bad.length ? bad : 'ALL MATCH';
 }
 ```
 
 **`NOT RENDERED` is a failure, not a pass.** Force the surface open first.
+**A non-numeric value is a failure too** — never let it slip through as equal.
 
 ### Stated alignment rules
 
@@ -133,36 +141,142 @@ grep -oE "^\s*--[a-z0-9-]+:" src/styles/tokens.css | tr -d ' :' | sort -u > /tmp
 comm -23 /tmp/d.txt /tmp/o.txt          # missing from ours
 ```
 
-Resolution — a `var()` typo falls back silently, so prove they resolve:
+Resolution — a `var()` typo falls back silently. Deriving the list from the
+stylesheets is the whole point: a hand-written allowlist only contains names
+you spelled correctly, so it can never catch the typo it claims to prove
+against.
+
+Not every token lives on `:root`. Scoped properties (`--gutter` on the main
+pane, `--tblmin` on the overview body) resolve only on their own subtree, so
+a root-only check reports them as broken every run and trains you to ignore
+it. Resolve each reference **where it is used**.
 
 ```js
+// every token REFERENCED by our stylesheets, resolved at its own use site
 () => {
-  const rs = getComputedStyle(document.documentElement);
-  return ['--sp-row','--fs-body','--h-ib','--r-md','--action-primary']
-    .filter(v => !rs.getPropertyValue(v).trim());   // empty array = all resolve
+  const refs = new Map();                       // token -> a selector using it
+  for (const sheet of document.styleSheets) {
+    let rules; try { rules = sheet.cssRules; } catch { continue; }  // cross-origin
+    const walk = (rs) => { for (const r of rs) {
+      if (r.style && r.selectorText) for (const p of r.style) {
+        const v = r.style.getPropertyValue(p);
+        for (const m of v.matchAll(/var\(\s*(--[a-zA-Z0-9-]+)/g))
+          if (!refs.has(m[1])) refs.set(m[1], r.selectorText);
+      }
+      if (r.cssRules) walk(r.cssRules);
+    }};
+    walk(rules);
+  }
+  const root = getComputedStyle(document.documentElement);
+  const unresolved = [];
+  for (const [token, selector] of refs) {
+    if (root.getPropertyValue(token).trim()) continue;          // global
+    // scoped: resolve on an element the referencing rule actually matches
+    let el = null;
+    for (const s of selector.split(',')) {
+      try { el = document.querySelector(s.trim()); } catch { /* :hover etc */ }
+      if (el) break;
+    }
+    if (!el || !getComputedStyle(el).getPropertyValue(token).trim())
+      unresolved.push({ token, selector, reachable: !!el });
+  }
+  return { referenced: refs.size, unresolved };   // unresolved must be empty
 }
 ```
 
-Literal audit — run before making any claim about coverage:
+> A `var()` with a fallback (`var(--x, 6px)`) still renders when `--x` is
+> missing. This finds the missing definition regardless.
+>
+> `reachable: false` means the recipe could not find an element to test on —
+> render the surface that uses it before trusting the result.
+
+Literal audit — run before making any claim about coverage.
+
+Two traps make a naive audit report cleaner than reality:
+
+- `grep -v "var(--"` **hides mixed declarations**. `padding: var(--sp-3) 11px`
+  contains a literal and is skipped. Real drift hid behind exactly this.
+- Scanning one stylesheet says nothing about the others.
 
 ```bash
+# px literals per stylesheet, KEEPING mixed token+literal declarations and
+# excluding only custom-property definitions
+for f in src/styles/*.css; do
+  n=$(grep -oE "^\s+[a-z-]+: *[^;]+;" "$f" | grep -vE "^\s*--" \
+      | grep -oE "\b[0-9]+(\.[0-9]+)?px" | wc -l | tr -d ' ')
+  printf "  %-28s %s px literals\n" "$(basename $f)" "$n"
+done
+
+# then list them, so each can be judged rather than counted
+grep -nE "^\s+[a-z-]+: *[^;]+;" src/styles/<sheet>.css | grep -E "[0-9]+px" | grep -vE "^\s*--"
+
+# raw colours anywhere
 grep -ohE "rgba?\([0-9., ]+\)|#[0-9a-fA-F]{3,8}\b" src/styles/*.css | sort | uniq -c
-grep -nE "^\s+[a-z-]+: *[^;]*[0-9]+px" src/styles/canopy-shell.css | grep -v "var(--"
 ```
 
 ---
 
-## 4. Interaction
+## 4. Content
+
+Geometry can match perfectly while the copy is wrong. Compare text, not just
+boxes — and against the design's stated voice rules.
+
+```js
+// run on BOTH pages and diff the results
+() => {
+  const t = el => el?.textContent.replace(/\s+/g, ' ').trim();
+  return {
+    buttons:   [...document.querySelectorAll('button')].map(t).filter(Boolean),
+    tooltips:  [...document.querySelectorAll('[title]')].map(e => e.getAttribute('title')),
+    labels:    [...document.querySelectorAll('.cxm-flab,.cxs-grp,.cx-label')].map(t),
+    empties:   [...document.querySelectorAll('.cxs-empty .et,.cxs-empty .es')].map(t),
+    hints:     [...document.querySelectorAll('.cxm-fhint,.cx-modal__hint')].map(t),
+  };
+}
+```
+
+Then check the handoff's content rules by hand — they are judgement, not regex:
+
+- buttons name their **specific action** ("Restart Server", not "OK"/"Confirm")
+- an action carries its reason as `reason · ACTION`, lowercase, not repeating
+  the button
+- confirmations are **past tense** and unremarkable, no exclamation marks
+- numbers are **specific** ("18 passed · 0 failed"), never "some"/"a few"
+- warnings say **what is lost**, concretely, with the actual list
+- **sentence case** everywhere except tracked uppercase section labels
+- **no emoji**; Unicode arrows and geometric bullets are typography, not
+  decoration
+- empty states **name the next step**, never a bare "Nothing here"
+
+Every coming-soon control must carry its tooltip — assert it rather than
+trusting it:
+
+```js
+() => [...document.querySelectorAll('[data-soon]')]
+  .filter(el => !/coming soon/i.test(el.getAttribute('title') || ''))   // must be empty
+```
+
+---
+
+## 5. Interaction
 
 Existence is not usability.
 
 ```js
-// visible, not merely present — a clipped menu still "opens"
+// visible, not merely present — a clipped menu still "opens".
+// All FOUR corners: clipping is usually one-sided, so testing two can pass a
+// menu cut off at top-right or bottom-left.
 () => {
   const el = document.querySelector('.cx-pop[role="menu"]');
   const r = el.getBoundingClientRect();
   const hit = (x,y) => { const t = document.elementFromPoint(x,y); return !!t && el.contains(t); };
-  return hit(r.left+4, r.top+4) && hit(r.right-4, r.bottom-4) && hit(r.left+r.width/2, r.bottom-4);
+  const corners = {
+    topLeft:     hit(r.left + 4,  r.top + 4),
+    topRight:    hit(r.right - 4, r.top + 4),
+    bottomLeft:  hit(r.left + 4,  r.bottom - 4),
+    bottomRight: hit(r.right - 4, r.bottom - 4),
+  };
+  return { corners, fullyVisible: Object.values(corners).every(Boolean) };
 }
 ```
 

--- a/.claude/skills/design-build/verify.md
+++ b/.claude/skills/design-build/verify.md
@@ -1,0 +1,210 @@
+# Verification recipes
+
+Copy-paste measurement passes for Phase 3 of `design-build`. Run them through
+Chrome DevTools MCP (`evaluate_script`) against two pages: the rendered design
+and the running app.
+
+```bash
+# reference: the design handoff, live
+cd <handoff>/project && python3 -m http.server 5310
+
+# subject: the app
+npm run dev -- --port 5320
+```
+
+Open both, then measure. The design page is authoritative for every number.
+
+---
+
+## 1. Geometry
+
+Extract from the **design** first — never hand-type expected values from
+reading CSS, and beware ambiguous selectors (in the Canopy handoff `.pt` is
+both a pane tab *and* a service-chip port; scope to `.ptabs .pt`).
+
+```js
+() => {
+  const g = (sel, ...props) => {
+    const el = document.querySelector(sel);
+    if (!el) return `${sel}: absent`;
+    const c = getComputedStyle(el);
+    return Object.fromEntries(props.map(p => [p, c[p]]));
+  };
+  return {
+    bar:  g('.wtbar', 'height', 'paddingLeft'),
+    chip: g('.svc', 'height', 'paddingLeft', 'gap', 'borderRadius'),
+    // …one entry per element you implemented
+  };
+}
+```
+
+Then assert in the **app**, tolerating sub-pixel noise:
+
+```js
+() => {
+  const DESIGN = { '.cxs-wtbar': {height:'36px', paddingLeft:'10px'} /* … */ };
+  const bad = [];
+  for (const [sel, want] of Object.entries(DESIGN)) {
+    const el = document.querySelector(sel);
+    if (!el) { bad.push(`${sel} NOT RENDERED`); continue; }
+    const c = getComputedStyle(el);
+    for (const [p, exp] of Object.entries(want))
+      if (Math.abs(parseFloat(c[p]) - parseFloat(exp)) >= 0.6)
+        bad.push(`${sel}{${p}} design ${exp} ours ${c[p]}`);
+  }
+  return bad.length ? bad : 'ALL MATCH';
+}
+```
+
+**`NOT RENDERED` is a failure, not a pass.** Force the surface open first.
+
+### Stated alignment rules
+
+Per-element numbers can all pass while a stated rule breaks. Assert the rule
+itself:
+
+```js
+() => {
+  const px = s => getComputedStyle(document.querySelector(s)).paddingLeft;
+  const g = ['.cxs-wtbar','.cxs-rail','.cx-tabs','.cxs-ltool','.cx-log'].map(px);
+  return new Set(g).size === 1 ? `aligned at ${g[0]}` : `MISALIGNED: ${g}`;
+}
+```
+
+---
+
+## 2. Inventory
+
+**The pass that catches missing content.** Walk every flow in the design,
+capture what each surface renders, then do the same in the app and compare
+lists — not counts.
+
+```js
+async () => {
+  const sleep = ms => new Promise(r => setTimeout(r, ms));
+  const out = {};
+  for (const f of [...document.querySelectorAll('.flow')]) {
+    f.click(); await sleep(450);
+    const m = document.querySelector('.mod');       // app: '.cx-modal'
+    if (!m) continue;
+    out[f.textContent.trim()] = {
+      title:        m.querySelector('.mt b')?.textContent,
+      width:        getComputedStyle(m).width,
+      footButtons:  [...m.querySelectorAll('.mf .btn')].map(b => b.textContent.trim()),
+      footHint:     m.querySelector('.mf .hint')?.textContent.trim(),
+      sectionLabels:[...m.querySelectorAll('.flab')].map(l => l.textContent.trim()),
+      checkboxes:   [...m.querySelectorAll('.chk .ct b')].map(b => b.textContent.trim()),
+      actionRows:   [...m.querySelectorAll('.act-i')].map(b => b.textContent.trim()),
+      kvKeys:       [...m.querySelectorAll('.kv dt')].map(d => d.textContent.trim()),
+      steps:        [...m.querySelectorAll('.step .tx')].map(s => s.textContent.trim()),
+      inputs:       m.querySelectorAll('input,textarea,select').length,
+    };
+  }
+  return out;
+}
+```
+
+Menus and popovers need the same treatment — count **rows and separators**:
+
+```js
+() => {
+  const pop = document.querySelector('.cx-pop[role="menu"]');
+  return {
+    width: Math.round(pop.getBoundingClientRect().width),
+    separators: pop.querySelectorAll('.cx-pop__sep').length,
+    items: [...pop.querySelectorAll('.cx-pop__item')].map(b => b.textContent.trim()),
+  };
+}
+```
+
+> A dialog that will not close wedges this walk and every later surface reports
+> the stuck one's contents. If several results look identical, suspect that
+> before suspecting the app.
+
+---
+
+## 3. Tokens
+
+Declared-vs-present:
+
+```bash
+cat <handoff>/tokens/*.css | grep -oE "^\s*--[a-z0-9-]+:" | tr -d ' :' | sort -u > /tmp/d.txt
+grep -oE "^\s*--[a-z0-9-]+:" src/styles/tokens.css | tr -d ' :' | sort -u > /tmp/o.txt
+comm -23 /tmp/d.txt /tmp/o.txt          # missing from ours
+```
+
+Resolution — a `var()` typo falls back silently, so prove they resolve:
+
+```js
+() => {
+  const rs = getComputedStyle(document.documentElement);
+  return ['--sp-row','--fs-body','--h-ib','--r-md','--action-primary']
+    .filter(v => !rs.getPropertyValue(v).trim());   // empty array = all resolve
+}
+```
+
+Literal audit — run before making any claim about coverage:
+
+```bash
+grep -ohE "rgba?\([0-9., ]+\)|#[0-9a-fA-F]{3,8}\b" src/styles/*.css | sort | uniq -c
+grep -nE "^\s+[a-z-]+: *[^;]*[0-9]+px" src/styles/canopy-shell.css | grep -v "var(--"
+```
+
+---
+
+## 4. Interaction
+
+Existence is not usability.
+
+```js
+// visible, not merely present — a clipped menu still "opens"
+() => {
+  const el = document.querySelector('.cx-pop[role="menu"]');
+  const r = el.getBoundingClientRect();
+  const hit = (x,y) => { const t = document.elementFromPoint(x,y); return !!t && el.contains(t); };
+  return hit(r.left+4, r.top+4) && hit(r.right-4, r.bottom-4) && hit(r.left+r.width/2, r.bottom-4);
+}
+```
+
+```js
+// a trigger must be able to close what it opened
+async () => {
+  const sleep = ms => new Promise(r => setTimeout(r, ms));
+  const t = document.querySelector('.cxs-attn');
+  t.click(); await sleep(300);
+  const opened = !!document.querySelector('.cxs-attnpop');
+  t.dispatchEvent(new MouseEvent('mousedown', {bubbles:true})); t.click(); await sleep(300);
+  return { opened, closes: !document.querySelector('.cxs-attnpop') };
+}
+```
+
+```js
+// keyboard reveals and inert regions
+() => ({
+  rowActionsOnFocus: (() => {
+    const r = document.querySelector('.cxs-rowact');
+    const before = getComputedStyle(r).opacity;
+    r.querySelector('button')?.focus();
+    return before === '0' && getComputedStyle(r).opacity === '1';
+  })(),
+  collapsedIsInert: document.querySelector('.cxs-side.is-hidden')?.hasAttribute('inert'),
+})
+```
+
+Cross-target actions — prove the effect landed **and did not leak**:
+
+```js
+// act on worktree B while A is selected; B gains the session, A gains nothing
+```
+
+---
+
+## Reporting
+
+State what you measured **and what you did not**. "The modals match" is only
+true for the properties in your spec and the surfaces you could open. Name the
+dialogs you could not reach and why.
+
+Two apparent mismatches are usually the test, not the code — check the design
+before fixing: modifier-driven sizes (`narrow` → 440px) and deliberate
+per-instance overrides (a title input at `--fs-md`).

--- a/src/styles/canopy-components.css
+++ b/src/styles/canopy-components.css
@@ -207,5 +207,7 @@ select.cx-input{appearance:none;cursor:pointer;background-image:linear-gradient(
 .cx-banner__link{margin-left:auto;flex:none;font-size:var(--fs-micro);color:var(--text-tertiary);white-space:nowrap}
 /* the inline marker on a control that is drawn but not yet wired */
 .cx-soon{font:var(--fw-bold) var(--fs-label) var(--sans);letter-spacing:.05em;text-transform:uppercase;color:var(--state-attention);background:var(--warn-dim);padding:var(--sp-1) var(--sp-tight);border-radius:var(--r-xs);flex:none}
-[data-soon]{cursor:not-allowed}
-[data-soon]:hover{background:none}
+/* these must out-specify .cx-btn:disabled / .cx-ib:disabled above, which
+   otherwise win and restore `cursor: default` and a hover background */
+[data-soon],.cx-btn[data-soon]:disabled,.cx-ib[data-soon]:disabled{cursor:not-allowed}
+[data-soon]:hover,.cx-btn[data-soon]:disabled:hover,.cx-ib[data-soon]:disabled:hover{background:none}

--- a/src/styles/canopy-components.css
+++ b/src/styles/canopy-components.css
@@ -195,3 +195,17 @@ select.cx-input{appearance:none;cursor:pointer;background-image:linear-gradient(
 .cx-kv dt{color:var(--text-tertiary)}
 .cx-kv dd{margin:0;font:var(--fs-small) var(--mono);color:var(--text-secondary);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .cx-kv dd em{font-style:normal;color:var(--action-primary)}
+
+/* ── Coming soon ───────────────────────────────────────────────────
+   For designed surfaces whose backend does not exist yet. A whole screen
+   gets the banner; a single control gets .cx-soon plus a "Coming soon"
+   title and disabled state. Amber, because this is a pending state rather
+   than a failure — red would say something is broken. */
+.cx-banner{display:flex;align-items:center;gap:var(--sp-4);padding:var(--sp-4) var(--sp-5);border-bottom:var(--border-w) solid var(--amber-border);background:var(--warn-dim);color:var(--amber-text);font-size:var(--fs-small);line-height:var(--lh-body);flex:none}
+.cx-banner__ic{color:var(--state-attention);display:inline-flex;flex:none}
+.cx-banner b{color:var(--state-attention);font-weight:var(--fw-semi)}
+.cx-banner__link{margin-left:auto;flex:none;font-size:var(--fs-micro);color:var(--text-tertiary);white-space:nowrap}
+/* the inline marker on a control that is drawn but not yet wired */
+.cx-soon{font:var(--fw-bold) var(--fs-label) var(--sans);letter-spacing:.05em;text-transform:uppercase;color:var(--state-attention);background:var(--warn-dim);padding:var(--sp-1) var(--sp-tight);border-radius:var(--r-xs);flex:none}
+[data-soon]{cursor:not-allowed}
+[data-soon]:hover{background:none}

--- a/src/styles/canopy-shell.css
+++ b/src/styles/canopy-shell.css
@@ -256,7 +256,7 @@
   gap: var(--sp-4);
   width: 100%;
   text-align: left;
-  padding: var(--sp-3) 11px;
+  padding: var(--sp-3) var(--sp-pop-lg);
   border: 0;
   border-bottom: var(--border-w) solid var(--divider);
   background: none;
@@ -1094,8 +1094,8 @@
   flex-wrap: wrap;
   align-items: center;
   gap: var(--sp-4);
-  margin: var(--sp-2) var(--gutter) 2px;
-  padding: var(--sp-3) 10px;
+  margin: var(--sp-2) var(--gutter) var(--sp-1);
+  padding: var(--sp-3) var(--sp-pop);
   border: var(--border-w) solid var(--red-border);
   border-radius: var(--r-lg);
   background: var(--red-dim);
@@ -1232,7 +1232,7 @@
   --tblmin: 760px;
 }
 .cxs-ovsec {
-  padding: 11px var(--sp-5) 4px;
+  padding: var(--sp-pop-lg) var(--sp-5) var(--sp-xs);
 }
 .cxs-ovlabel {
   font-size: var(--fs-label);
@@ -1240,7 +1240,7 @@
   letter-spacing: 0.11em;
   text-transform: uppercase;
   color: var(--text-tertiary);
-  margin: 0 0 var(--sp-3) 2px;
+  margin: 0 0 var(--sp-3) var(--sp-1);
 }
 /* Every section's table shares ONE geometry so columns align down the page.
    Column 1 (the branch — each row's identity) is sized explicitly and widest;


### PR DESCRIPTION
Adds a `design-build` skill capturing the workflow from the two shipped design ports — #57 (workspace shell) and #61 (dialog layer).

## Why

Both ports found real defects *after* I had already declared the work verified. The common cause was the same every time: **I compared stylesheets instead of the rendered result.**

- A menu with correct CSS and three of its eight rows passed a class-coverage audit.
- A popover clipped to a 7px sliver reported as "opened" because the check asked whether it existed, not whether it was visible.
- A "modals are identical" claim held for the one screen I had measured and not the six dialogs I had not.

The skill is written as specifics, not general advice. Every rule exists because skipping it shipped something.

## What it covers

**Phase 0 — read the design properly.** Serve the handoff and *run* it; read the JSX for element inventory, not only the `<style>` block; read `readme.md`/`github.md` for the stated rules and screen map.

**Phase 1 — audit the backend before writing UI.** Verify every claim against `src-tauri/src/`, including your own. Exact output formats, truncation, validation ranges and derivation rules are all things you cannot infer — and all four produced defects in #61.

**Phase 2 — build.** Token discipline (never round a literal onto a scale that cannot express it — count the usage and extend the scale instead); the stated rule for resolving the handoff's seven self-contradictions; and visible degradation where the backend is missing:

| Scope | Treatment |
|---|---|
| whole screen | coming-soon banner |
| button / icon | disabled + "Coming soon" tooltip |
| single value | `—` with an explanatory title |
| whole panel | omit, with `TODO(#n)` |

Never fabricate. A wrong path is worse than a blank one.

**Phase 3 — verify by measurement.** Four passes — geometry, inventory, tokens, content — with the non-negotiables that caught real bugs: force hidden surfaces open or they are silently skipped; hit-test with `elementFromPoint`; assert the readme's *stated* alignment rules, not just per-element numbers; and check the design before "fixing" an apparent mismatch, because several were the test being wrong.

**Phase 4 — ship.** Issues per gap with what the UI does meanwhile; PR documenting contradictions, gaps and what verification does *not* cover; no `Co-Authored-By` trailer.

## Failure-mode checklist

The end of `SKILL.md` lists what actually shipped at least once — ancestor `overflow:hidden` beating z-index, `container-type` containment, closure capture on selection, snapshot staleness, `busy` defaulting true making a dialog unclosable, destructive dialogs failing open, truncated lists presented as complete, hover-only reveals invisible to keyboard, `aria-modal` without a focus trap, and popover triggers that cannot close their own popover.

## Also included

`.cx-banner` / `.cx-soon` in the component layer, fully tokenized, so the degradation rules are actionable rather than aspirational.

## Note

`verify.md` holds copy-paste recipes for each pass, including the traps that produced false results — ambiguous selectors (`.pt` is both a pane tab and a service-chip port) and a stuck dialog wedging an entire inventory walk so every later surface reports the stuck one's contents.
