### PR TITLE
Rail: surface repo custom commands as buttons

### DIFF
--- a/src/app/canopy/CommandButtons.tsx
+++ b/src/app/canopy/CommandButtons.tsx
@@ -1,0 +1,127 @@
+/* Custom commands (Settings → Commands) surfaced as real buttons in the rail —
+   they belong beside the runtime they operate on, and the rail has room the
+   worktree bar does not.
+
+   The first command gets its own labelled run button; the rest collapse into a
+   single "Commands" menu so the bar cannot grow without bound as the user adds
+   more. Mirrors the design's CmdButtons (cx-app.jsx). The backend `CustomCmd`
+   is `{ label, command }` with no group field, so the design's per-group
+   headers only render if a group ever appears in the data. */
+import { useEffect, useRef, useState } from "react";
+import { Chevron, Play } from "../../icons";
+import { hasBackend, ipc, type CustomCmd } from "../../ipc";
+import { mockCustomCommands } from "../../mock";
+import { useStore } from "../../store";
+import type { WorktreeNode } from "../../types";
+
+// CustomCmd has no `group` yet; read it defensively so grouping still works if
+// one is ever added to the settings schema.
+type Grouped = CustomCmd & { group?: string };
+
+export default function CommandButtons({ wt }: { wt: WorktreeNode }) {
+  const [open, setOpen] = useState(false);
+  const [cmds, setCmds] = useState<CustomCmd[]>([]);
+  const box = useRef<HTMLDivElement>(null);
+  const settingsRev = useStore((s) => s.settingsRev);
+  const showToast = useStore((s) => s.showToast);
+  // commands are repo-scoped; a worktree doesn't carry its repo id, so derive it
+  // from the tree. The selector returns a primitive, so this only re-renders
+  // when the owning repo actually changes.
+  const repoId = useStore((s) => s.tree.find((r) => r.worktrees.some((w) => w.wtKey === wt.wtKey))?.repoId);
+
+  // per-repo commands; reload when settings are saved
+  useEffect(() => {
+    if (!hasBackend()) {
+      setCmds(mockCustomCommands());
+      return;
+    }
+    if (!repoId) {
+      setCmds([]);
+      return;
+    }
+    let alive = true;
+    ipc
+      .getSettings()
+      .then((s) => {
+        if (alive) setCmds(s.repos.find((r) => r.id === repoId)?.customCommands ?? []);
+      })
+      .catch(() => alive && setCmds([]));
+    return () => {
+      alive = false;
+    };
+  }, [repoId, settingsRev]);
+
+  // outside-click closes; the trigger lives inside `box`, so clicking it again
+  // toggles rather than being swallowed as an outside click — a popover trigger
+  // must be able to close its own popover
+  useEffect(() => {
+    if (!open) return;
+    const d = (e: MouseEvent) => {
+      if (box.current && !box.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", d);
+    return () => document.removeEventListener("mousedown", d);
+  }, [open]);
+
+  if (cmds.length === 0) return null;
+
+  const run = (c: CustomCmd) => {
+    setOpen(false);
+    showToast(`Running ${c.label} — ${wt.branch}`);
+    if (!hasBackend()) return;
+    ipc
+      .runCustomCommand(wt.wtKey, c.command)
+      .then(() => showToast(`${c.label} finished — ${wt.branch}`))
+      .catch((e) => showToast(`${c.label} failed — ${String(e)}`));
+  };
+
+  const flat = cmds.slice(0, 1);
+  const rest = cmds.slice(1);
+  const groups = rest.reduce<Record<string, Grouped[]>>((a, c) => {
+    const g = (c as Grouped).group || "";
+    (a[g] ??= []).push(c);
+    return a;
+  }, {});
+
+  return (
+    <div className="cxs-cmds" ref={box}>
+      {flat.map((c, i) => (
+        <button key={i} className="cxs-cmdb cxs-cmdb--run1" title={c.command} onClick={() => run(c)}>
+          <Play size={10} />
+          <span className="t">{c.label}</span>
+        </button>
+      ))}
+      {rest.length > 0 && (
+        <>
+          <button
+            className={"cxs-cmdb" + (open ? " is-on" : "")}
+            title="Custom commands"
+            onClick={() => setOpen((o) => !o)}
+            aria-haspopup="menu"
+            aria-expanded={open}
+          >
+            <Play size={10} />
+            <span className="t">Commands</span>
+            <Chevron size={11} />
+          </button>
+          {open && (
+            <div className="cxs-cmdpop" role="menu">
+              {Object.entries(groups).map(([g, list]) => (
+                <div key={g || "_"}>
+                  {g && <div className="cxs-cg">{g}</div>}
+                  {list.map((c, i) => (
+                    <button key={i} className="cxs-cmdrow" role="menuitem" onClick={() => run(c)}>
+                      <Play size={10} />
+                      <span className="l">{c.label}</span>
+                      <span className="c">{c.command}</span>
+                    </button>
+                  ))}
+                </div>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/canopy/ServiceRail.tsx
+++ b/src/app/canopy/ServiceRail.tsx
@@ -9,6 +9,7 @@ import { useStore } from "../../store";
 import type { ServiceNode, WorktreeNode } from "../../types";
 import { isLive } from "../../types";
 import { svcDotClass } from "../nextAction";
+import CommandButtons from "./CommandButtons";
 
 export default function ServiceRail({
   wt,
@@ -25,13 +26,7 @@ export default function ServiceRail({
   const restartService = useStore((s) => s.restartService);
   const openPort = useStore((s) => s.openPort);
 
-  if (wt.services.length === 0 && !wt.dbName) {
-    return (
-      <div className="cxs-rail">
-        <span className="cxs-railempty">No services configured for this worktree.</span>
-      </div>
-    );
-  }
+  const empty = wt.services.length === 0 && !wt.dbName;
 
   const action = (s: ServiceNode) => {
     if (s.status === "error") return { title: `Restart ${s.name}`, icon: <Restart size={11} />, run: () => restartService(s.svcKey) };
@@ -42,7 +37,9 @@ export default function ServiceRail({
 
   return (
     <div className="cxs-rail">
-      {wt.services.map((s) => {
+      <div className="cxs-railscroll">
+        {empty && <span className="cxs-railempty">No services configured for this worktree.</span>}
+        {wt.services.map((s) => {
         const st = stats[s.svcKey];
         const live = s.status === "running";
         const act = action(s);
@@ -112,12 +109,17 @@ export default function ServiceRail({
         );
       })}
 
-      {wt.dbName && (
-        <div className="cxs-svc cxs-svc--off cxs-svc--db" onClick={onDatabase} role="button" tabIndex={0} title="Database tools">
-          <Database size={11} />
-          <span className="nm">{wt.dbName}</span>
-        </div>
-      )}
+        {wt.dbName && (
+          <div className="cxs-svc cxs-svc--off cxs-svc--db" onClick={onDatabase} role="button" tabIndex={0} title="Database tools">
+            <Database size={11} />
+            <span className="nm">{wt.dbName}</span>
+          </div>
+        )}
+      </div>
+
+      {/* custom commands sit beside the runtime they operate on; the rail is
+          overflow-visible so this menu can escape it, unlike the scroll area */}
+      <CommandButtons wt={wt} />
     </div>
   );
 }

--- a/src/mock.ts
+++ b/src/mock.ts
@@ -14,6 +14,17 @@ const svc = (
 const min = 60;
 const nowS = () => Date.now() / 1000;
 
+/* Custom commands for the no-backend dev build, so the rail's command buttons
+   render without a real settings file. Mirrors the design's CMDS seed. */
+export function mockCustomCommands(): { label: string; command: string }[] {
+  return [
+    { label: "Lint", command: "pnpm lint" },
+    { label: "Unit tests", command: "pnpm test --run" },
+    { label: "Typecheck", command: "pnpm tsc --noEmit" },
+    { label: "Storybook", command: "pnpm storybook" },
+  ];
+}
+
 export function mockTree(): RepoNode[] {
   return [
     {

--- a/src/styles/canopy-shell.css
+++ b/src/styles/canopy-shell.css
@@ -695,16 +695,144 @@
   height: var(--h-rail);
   display: flex;
   align-items: center;
-  gap: var(--sp-3);
+  gap: var(--sp-row);
   padding: 0 var(--gutter);
   border-bottom: var(--border-w) solid var(--divider);
   background: var(--surface-app);
+  /* visible so the commands menu can escape the rail; the services scroll in
+     their own overflow region below */
+  overflow: visible;
+}
+/* service chips scroll horizontally and fade out under the pinned commands */
+.cxs-railscroll {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
   overflow-x: auto;
   overflow-y: hidden;
   scrollbar-width: none;
+  -webkit-mask-image: linear-gradient(90deg, #000 calc(100% - 18px), transparent);
+  mask-image: linear-gradient(90deg, #000 calc(100% - 18px), transparent);
 }
-.cxs-rail::-webkit-scrollbar {
+.cxs-railscroll::-webkit-scrollbar {
   display: none;
+}
+
+/* ── custom commands (Settings → Commands) ─────────────────────────
+   one labelled run button + a collapsing menu, pinned to the rail's end */
+.cxs-cmds {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  position: relative;
+  flex: none;
+  margin-left: auto;
+}
+.cxs-cmdb {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  height: var(--h-control-sm);
+  padding: 0 var(--sp-row);
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  border-radius: var(--r-md);
+  border: var(--border-w) solid var(--divider);
+  background: var(--surface-well);
+  color: var(--text-secondary);
+  font-family: var(--sans);
+  font-size: var(--fs-small);
+  font-weight: var(--fw-medium);
+  cursor: pointer;
+  white-space: nowrap;
+  transition:
+    background var(--dur-fast),
+    color var(--dur-fast);
+}
+.cxs-cmdb:hover,
+.cxs-cmdb.is-on {
+  background: var(--surface-card);
+  color: var(--text-primary);
+}
+.cxs-cmdb > svg {
+  flex: none;
+}
+.cxs-cmdb .t {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cxs-cmdpop {
+  position: absolute;
+  top: calc(var(--h-control-sm) + var(--sp-row));
+  right: 0;
+  z-index: 40;
+  min-width: 216px;
+  /* bound the width so a long command ellipsizes inside the row instead of
+     ballooning the popover and pushing the label off-screen */
+  max-width: 360px;
+  padding: 4px;
+  border-radius: var(--r-xl);
+  background: var(--surface-float);
+  border: var(--border-w) solid var(--border-pop);
+  box-shadow: var(--shadow-pop);
+}
+.cxs-cmdpop .cxs-cg {
+  padding: var(--sp-2) var(--sp-row) 3px;
+  font: var(--fw-bold) var(--fs-label) var(--sans);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+.cxs-cmdrow {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-row);
+  width: 100%;
+  height: 26px;
+  padding: 0 var(--sp-row);
+  border: 0;
+  border-radius: var(--r-md);
+  background: none;
+  cursor: pointer;
+  color: var(--text-secondary);
+  text-align: left;
+}
+.cxs-cmdrow:hover {
+  background: var(--btn);
+  color: var(--text-primary);
+}
+.cxs-cmdrow .l {
+  font-family: var(--sans);
+  font-size: var(--fs-small);
+  flex: none;
+}
+.cxs-cmdrow .c {
+  font-family: var(--mono);
+  font-size: var(--fs-micro);
+  color: var(--text-tertiary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+  flex: 1;
+  text-align: right;
+}
+@container pane (max-width: 520px) {
+  .cxs-cmdb {
+    padding: 0 var(--sp-3);
+  }
+  .cxs-cmdb > svg {
+    display: none;
+  }
+}
+@container pane (max-width: 440px) {
+  .cxs-cmds .cxs-cmdb--run1 {
+    display: none;
+  }
 }
 /* running services read as filled tokens; idle ones recede to text */
 .cxs-svc {


### PR DESCRIPTION
Closes #63

## What
Repo-level custom commands (Settings → Commands) weren't surfaced anywhere in the redesigned workspace. This adds them to the service rail.

- First command → a labelled run button; the rest collapse into a **Commands** menu, so the rail can't grow without bound.
- Token-faithful to the design handoff (`cx-app.jsx` `CmdButtons`); rail is `overflow: visible` so the menu escapes it while services scroll in a masked region.
- Commands are repo-scoped (`{ label, command }`); resolved from the tree since a worktree carries no repo id. Runs via the existing `run_custom_command` IPC. A `mockCustomCommands()` seed lets the no-backend dev build render them.
- Popover is width-bounded (`max-width`) so a long command ellipsizes instead of pushing the label off-screen.

## Verified
`tsc` clean; rendered the rail + open menu in headless Chrome and measured geometry against the design (radius/height/padding/tokens match); confirmed the menu isn't clipped and long commands ellipsize.
