### PR TITLE
Worktree: fetch origin before create; fast-forward reused local branch

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -634,6 +634,15 @@ pub async fn create_worktree(
 
     emit_op(&app, &wt_path, "create", "progress", format!("creating worktree for {branch}…"));
 
+    // Refresh remote-tracking refs (and submodule objects) BEFORE `git worktree
+    // add`, so a worktree made from an origin branch — and the submodule commits
+    // it pins — reflects the remote rather than a stale local ref. Best-effort:
+    // an offline or remote-less repo still creates from whatever it has locally.
+    emit_op(&app, &wt_path, "create", "progress", "fetching origin…");
+    if let Err(e) = git::fetch_all(&repo.path).await {
+        emit_op(&app, &wt_path, "create", "progress", format!("fetch skipped — {e}"));
+    }
+
     let app2 = app.clone();
     let wt_path2 = wt_path.clone();
     let result = git::create_worktree(

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -494,6 +494,16 @@ pub async fn create_worktree(
         run_git(repo_path, &["worktree", "add", wt_path, "-b", branch, base]).await?;
     } else {
         run_git(repo_path, &["worktree", "add", wt_path, branch]).await?;
+        // A remote pick reusing an existing local branch passes the origin ref
+        // as `base`. Fast-forward the checkout to it so the worktree (and the
+        // submodule commits it pins) reflect origin rather than a stale local
+        // branch — the "created before pulling" regression. ff-only never
+        // discards local commits; a diverged branch simply stays put.
+        if let Some(b) = base.map(str::trim).filter(|b| !b.is_empty()) {
+            if let Err(e) = run_git(wt_path, &["merge", "--ff-only", b]).await {
+                progress(format!("note: {branch} is not a fast-forward of {b} — left as-is ({e})"));
+            }
+        }
     }
 
     let subs = submodule_paths(wt_path).await;


### PR DESCRIPTION
Closes #64

## Bug
Creating a worktree from an origin branch checked out a **stale** ref; on submodule repos the worktree's submodules landed on the wrong/detached commit — because the worktree was created **before** origin was fetched.

## Fix
- `commands.rs`: fetch origin (`--prune --recurse-submodules`) before `git worktree add` — best-effort, so an offline/remote-less repo still creates from local.
- `git.rs`: a remote pick reusing an existing local branch passed `origin/<branch>` as base but the backend ignored it; now `git merge --ff-only origin/<branch>` after checkout so the worktree (and its submodule pins) reflect origin. ff-only is non-destructive — a diverged branch is left as-is with a note.

## Verified
`cargo check` clean. Reproduced against throwaway submodule repos: a stale local branch (pinning `sub@v1`) now fast-forwards to origin and the worktree pins the fresh `sub@v2`; the diverged case is left untouched.
