### PR TITLE
Submodule branch picker: add search and bottom padding

### DIFF
--- a/src/app/canopy/StatusBar.tsx
+++ b/src/app/canopy/StatusBar.tsx
@@ -4,7 +4,7 @@
    text plus one welded control: the word "Pull" pulls everything, the ▾ opens
    per-submodule control. Anchored to the control that opened it, not centred. */
 import { useEffect, useRef, useState } from "react";
-import { Bell, Chevron, Fork, Info, Pull, Single, Sparkle, Split, Spinner } from "../../icons";
+import { Bell, Chevron, Fork, Info, Pull, Search, Single, Sparkle, Split, Spinner } from "../../icons";
 import { hasBackend, ipc, type Branches } from "../../ipc";
 import { useStore, type LaneSession } from "../../store";
 import type { SubmoduleStatus, WorktreeNode } from "../../types";
@@ -290,6 +290,7 @@ function PullPop({ wt, onClose, anchor }: { wt: WorktreeNode; onClose: () => voi
 
 function SubBranches({ wtKey, sub, onPick }: { wtKey: string; sub: SubmoduleStatus; onPick: (b: string) => void }) {
   const [branches, setBranches] = useState<Branches | null>(null);
+  const [q, setQ] = useState("");
   useEffect(() => {
     let alive = true;
     ipc
@@ -301,18 +302,45 @@ function SubBranches({ wtKey, sub, onPick }: { wtKey: string; sub: SubmoduleStat
     };
   }, [wtKey, sub.path]);
 
-  const names = branches ? [...new Set([...branches.local, ...branches.remote])] : [];
+  const all = branches ? [...new Set([...branches.local, ...branches.remote])] : [];
+  const t = q.trim().toLowerCase();
+  const names = t ? all.filter((b) => b.toLowerCase().includes(t)) : all;
+  // a search box earns its space once the list is long enough to scroll
+  const showSearch = all.length > 6;
   return (
     <div className="cxs-pp-brl">
-      {!branches && <div className="cxs-pp-empty">Loading branches…</div>}
-      {branches && names.length === 0 && <div className="cxs-pp-empty">No branches found.</div>}
-      {names.map((b) => (
-        <button key={b} className={"cxs-pp-bri" + (b === sub.branch ? " is-current" : "")} onClick={() => onPick(b)}>
-          <Fork size={10} />
-          <span className="n">{b}</span>
-          {b === sub.branch && <span className="cx-tag">current</span>}
-        </button>
-      ))}
+      {showSearch && (
+        <div className="cxs-pp-search">
+          <Search size={11} />
+          <input
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="Search branches…"
+            spellCheck={false}
+            autoFocus
+            // Escape clears the query first; an empty query lets it bubble to
+            // the popover's own Escape-to-close handler
+            onKeyDown={(e) => {
+              if (e.key === "Escape" && q) {
+                e.stopPropagation();
+                setQ("");
+              }
+            }}
+          />
+        </div>
+      )}
+      <div className="cxs-pp-brscroll">
+        {!branches && <div className="cxs-pp-empty">Loading branches…</div>}
+        {branches && all.length === 0 && <div className="cxs-pp-empty">No branches found.</div>}
+        {branches && all.length > 0 && names.length === 0 && <div className="cxs-pp-empty">No branches match “{q}”.</div>}
+        {names.map((b) => (
+          <button key={b} className={"cxs-pp-bri" + (b === sub.branch ? " is-current" : "")} onClick={() => onPick(b)}>
+            <Fork size={10} />
+            <span className="n">{b}</span>
+            {b === sub.branch && <span className="cx-tag">current</span>}
+          </button>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/styles/canopy-shell.css
+++ b/src/styles/canopy-shell.css
@@ -1715,8 +1715,38 @@
   border-radius: var(--r-xl);
   background: var(--surface-well);
   padding: var(--sp-xs);
+  overflow: hidden;
+}
+/* search box pinned above the scrolling branch list */
+.cxs-pp-search {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  padding: 0 var(--sp-3);
+  height: var(--h-control-sm);
+  margin-bottom: var(--sp-xs);
+  border-radius: var(--r-sm);
+  background: var(--surface-app);
+  border: var(--border-w) solid var(--border);
+  color: var(--text-tertiary);
+}
+.cxs-pp-search input {
+  flex: 1;
+  min-width: 0;
+  border: 0;
+  background: none;
+  outline: none;
+  color: var(--text-primary);
+  font: var(--fs-small) var(--sans);
+}
+.cxs-pp-search input::placeholder {
+  color: var(--text-tertiary);
+}
+.cxs-pp-brscroll {
   max-height: 190px;
   overflow-y: auto;
+  /* breathing room so the last row isn't flush against the frame */
+  padding-bottom: var(--sp-2);
 }
 .cxs-pp-bri {
   display: flex;


### PR DESCRIPTION
Closes #65

## What
The per-submodule branch dropdown in the Pull popover (StatusBar) listed every branch with no filter, and the last row sat flush against the frame.

- Add a **Search branches…** box pinned above the list (shown once there are more than 6 branches). Escape clears the query first, then closes the popover.
- Split the list into a pinned search header + a scrolling region with `padding-bottom` so the last row isn't flush.

## Verified
`tsc` clean; rendered the popover markup against the real stylesheets — search box pinned, list scrolls, last row has breathing room.
