### PR TITLE
Rail commands: address Copilot review feedback (follow-up to #67)

### DIFF
--- a/src/app/canopy/CommandButtons.tsx
+++ b/src/app/canopy/CommandButtons.tsx
@@ -3,12 +3,12 @@
    worktree bar does not.
 
    The first command gets its own labelled run button; the rest collapse into a
-   single "Commands" menu so the bar cannot grow without bound as the user adds
-   more. Mirrors the design's CmdButtons (cx-app.jsx). The backend `CustomCmd`
-   is `{ label, command }` with no group field, so the design's per-group
-   headers only render if a group ever appears in the data. */
+   single "Commands" popover so the bar cannot grow without bound as the user
+   adds more. Mirrors the design's CmdButtons (cx-app.jsx). The backend
+   `CustomCmd` is `{ label, command }` with no group field, so the design's
+   per-group headers only render if a group ever appears in the data. */
 import { useEffect, useRef, useState } from "react";
-import { Chevron, Play } from "../../icons";
+import { Chevron, Play, Spinner } from "../../icons";
 import { hasBackend, ipc, type CustomCmd } from "../../ipc";
 import { mockCustomCommands } from "../../mock";
 import { useStore } from "../../store";
@@ -21,13 +21,26 @@ type Grouped = CustomCmd & { group?: string };
 export default function CommandButtons({ wt }: { wt: WorktreeNode }) {
   const [open, setOpen] = useState(false);
   const [cmds, setCmds] = useState<CustomCmd[]>([]);
+  // the shell-side op buffer is shared per worktree, so only one custom command
+  // may run at a time — a second would interleave output and its completion
+  // would flip the worktree to idle while the first is still running
+  const [busy, setBusy] = useState(false);
   const box = useRef<HTMLDivElement>(null);
+  const trigger = useRef<HTMLButtonElement>(null);
   const settingsRev = useStore((s) => s.settingsRev);
   const showToast = useStore((s) => s.showToast);
   // commands are repo-scoped; a worktree doesn't carry its repo id, so derive it
   // from the tree. The selector returns a primitive, so this only re-renders
   // when the owning repo actually changes.
   const repoId = useStore((s) => s.tree.find((r) => r.worktrees.some((w) => w.wtKey === wt.wtKey))?.repoId);
+
+  // WorktreeView is reused (no key) across repo switches, so drop the previous
+  // repo's commands and close the menu the instant the repo changes — otherwise
+  // a stale command could briefly show and be run against the new worktree
+  useEffect(() => {
+    setCmds([]);
+    setOpen(false);
+  }, [repoId]);
 
   // per-repo commands; reload when settings are saved
   useEffect(() => {
@@ -51,28 +64,46 @@ export default function CommandButtons({ wt }: { wt: WorktreeNode }) {
     };
   }, [repoId, settingsRev]);
 
-  // outside-click closes; the trigger lives inside `box`, so clicking it again
-  // toggles rather than being swallowed as an outside click — a popover trigger
-  // must be able to close its own popover
+  // this is a plain popover of buttons (not an ARIA menu), so native Tab moves
+  // between rows; add outside-click + Escape dismissal, move focus in on open,
+  // and hand it back to the trigger on close
   useEffect(() => {
     if (!open) return;
     const d = (e: MouseEvent) => {
       if (box.current && !box.current.contains(e.target as Node)) setOpen(false);
     };
+    const k = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        setOpen(false);
+        trigger.current?.focus();
+      }
+    };
     document.addEventListener("mousedown", d);
-    return () => document.removeEventListener("mousedown", d);
+    document.addEventListener("keydown", k);
+    box.current?.querySelector<HTMLElement>(".cxs-cmdrow")?.focus();
+    return () => {
+      document.removeEventListener("mousedown", d);
+      document.removeEventListener("keydown", k);
+    };
   }, [open]);
 
   if (cmds.length === 0) return null;
 
   const run = (c: CustomCmd) => {
+    if (busy) return;
     setOpen(false);
-    showToast(`Running ${c.label} — ${wt.branch}`);
-    if (!hasBackend()) return;
+    if (!hasBackend()) {
+      showToast(`Running ${c.label} — ${wt.branch}`);
+      return;
+    }
+    setBusy(true);
+    showToast(`Running ${c.label} — ${wt.branch}…`);
     ipc
       .runCustomCommand(wt.wtKey, c.command)
       .then(() => showToast(`${c.label} finished — ${wt.branch}`))
-      .catch((e) => showToast(`${c.label} failed — ${String(e)}`));
+      .catch((e) => showToast(`${c.label} failed — ${String(e)}`))
+      .finally(() => setBusy(false));
   };
 
   const flat = cmds.slice(0, 1);
@@ -86,18 +117,20 @@ export default function CommandButtons({ wt }: { wt: WorktreeNode }) {
   return (
     <div className="cxs-cmds" ref={box}>
       {flat.map((c, i) => (
-        <button key={i} className="cxs-cmdb cxs-cmdb--run1" title={c.command} onClick={() => run(c)}>
-          <Play size={10} />
+        <button key={i} className="cxs-cmdb cxs-cmdb--run1" title={c.command} onClick={() => run(c)} disabled={busy}>
+          {busy ? <Spinner size={10} /> : <Play size={10} />}
           <span className="t">{c.label}</span>
         </button>
       ))}
       {rest.length > 0 && (
         <>
           <button
+            ref={trigger}
             className={"cxs-cmdb" + (open ? " is-on" : "")}
             title="Custom commands"
             onClick={() => setOpen((o) => !o)}
-            aria-haspopup="menu"
+            disabled={busy}
+            aria-haspopup="true"
             aria-expanded={open}
           >
             <Play size={10} />
@@ -105,12 +138,12 @@ export default function CommandButtons({ wt }: { wt: WorktreeNode }) {
             <Chevron size={11} />
           </button>
           {open && (
-            <div className="cxs-cmdpop" role="menu">
+            <div className="cxs-cmdpop">
               {Object.entries(groups).map(([g, list]) => (
                 <div key={g || "_"}>
                   {g && <div className="cxs-cg">{g}</div>}
                   {list.map((c, i) => (
-                    <button key={i} className="cxs-cmdrow" role="menuitem" onClick={() => run(c)}>
+                    <button key={i} className="cxs-cmdrow" onClick={() => run(c)} disabled={busy}>
                       <Play size={10} />
                       <span className="l">{c.label}</span>
                       <span className="c">{c.command}</span>

--- a/src/styles/canopy-shell.css
+++ b/src/styles/canopy-shell.css
@@ -765,6 +765,11 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+/* bound the labelled command so an unrestricted label from Settings ellipsizes
+   instead of ballooning .cxs-cmds and squeezing the service scroller to zero */
+.cxs-cmdb--run1 {
+  max-width: 160px;
+}
 .cxs-cmdpop {
   position: absolute;
   top: calc(var(--h-control-sm) + var(--sp-row));
@@ -829,11 +834,9 @@
     display: none;
   }
 }
-@container pane (max-width: 440px) {
-  .cxs-cmds .cxs-cmdb--run1 {
-    display: none;
-  }
-}
+/* the direct command button stays visible at every width — the "Commands"
+   menu only holds cmds[1..], so hiding it would make the first command (and,
+   when it's the only one, all commands) unreachable */
 /* running services read as filled tokens; idle ones recede to text */
 .cxs-svc {
   display: inline-flex;


### PR DESCRIPTION
Follow-up to #67 — addresses the Copilot review findings.

- **Stale commands on repo switch** — `WorktreeView` is reused without a key, so switching repos briefly kept the previous repo's commands and a click would run one against the new worktree. Now the cached commands are cleared and the menu closed the moment the repo id changes, before the new fetch resolves.
- **Concurrent launches** — all custom-command events share one per-worktree op buffer, so parallel runs interleaved output and the first completion flipped the worktree to idle. Added a `busy` guard; buttons disable while a command runs (matching the old header behavior).
- **False `menu` ARIA** — `role="menu"`/`menuitem` promised arrow-key navigation that wasn't implemented. Dropped to a plain popover of buttons (native Tab works) and added Escape-to-close, focus-in on open, and focus restore to the trigger on close.
- **First command unreachable at narrow widths** — the `≤440px` rule hid the direct button, but the menu only holds `cmds[1..]`, so the first (or only) command became unreachable. Removed that rule; the direct button stays visible.
- **Long labels** — added `max-width` to the direct button so an unrestricted Settings label ellipsizes instead of ballooning the group and squeezing the service scroller to zero.

`tsc` clean.
