### PR TITLE
Worktree ff note: accurate diagnostic (follow-up to #68)

### DIFF
--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -501,7 +501,7 @@ pub async fn create_worktree(
         // discards local commits; a diverged branch simply stays put.
         if let Some(b) = base.map(str::trim).filter(|b| !b.is_empty()) {
             if let Err(e) = run_git(wt_path, &["merge", "--ff-only", b]).await {
-                progress(format!("note: {branch} is not a fast-forward of {b} — left as-is ({e})"));
+                progress(format!("note: could not fast-forward {branch} to {b} — left as-is ({e})"));
             }
         }
     }


### PR DESCRIPTION
Follow-up to #68 — addresses the Copilot review finding.

The post-`worktree add` note claimed every `git merge --ff-only` failure was a non-fast-forward (and described the direction backwards). It now reports the attempted operation — "could not fast-forward `<branch>` to `<origin-ref>`, left as-is" — which stays accurate whether the ref was missing, diverged, or git failed for another reason.

`cargo check` clean.
