### PR TITLE
Submodule search: keyboard focus ring (follow-up to #69)

### DIFF
--- a/src/styles/canopy-shell.css
+++ b/src/styles/canopy-shell.css
@@ -1857,6 +1857,15 @@
   background: var(--surface-app);
   border: var(--border-w) solid var(--border);
   color: var(--text-tertiary);
+  transition:
+    border-color var(--dur),
+    box-shadow var(--dur);
+}
+/* the input drops its own outline, so give the wrapper the keyboard-focus ring
+   the auto-focused field otherwise lacks (matches .cx-search) */
+.cxs-pp-search:focus-within {
+  border-color: var(--action-primary);
+  box-shadow: 0 0 0 3px var(--focus-ring);
 }
 .cxs-pp-search input {
   flex: 1;


### PR DESCRIPTION
Follow-up to #69 — addresses the Copilot review finding.

The submodule branch search input clears its own outline, so the auto-focused field had no visible keyboard-focus indicator. Added the same `:focus-within` ring the shared `.cx-search` uses (`--action-primary` border + `--focus-ring` halo) to the `.cxs-pp-search` wrapper.
