### PR TITLE
Address Copilot review feedback across #67–#70

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,3 +1,7 @@
+# DISABLED — the automatic Claude Code review is commented out for now.
+# To re-enable, uncomment the workflow below (and keep the ANTHROPIC_API_KEY
+# repo secret in place).
+#
 # Automatic Claude Code review on new PRs. Criteria live in
 # .claude/skills/pr-review/SKILL.md (single source of truth — used locally too);
 # the workflow injects that file into the prompt.
@@ -5,47 +9,47 @@
 # Requires the ANTHROPIC_API_KEY repo secret. Fork PRs are skipped (secrets
 # don't flow to them) — a maintainer can trigger a review there by commenting
 # "@claude review this" (see claude.yml).
-name: claude-review
-
-on:
-  pull_request:
-    types: [opened, ready_for_review]
-
-jobs:
-  review:
-    # same-repo PRs only; drafts wait until ready_for_review
-    if: github.event.pull_request.head.repo.full_name == github.repository && !github.event.pull_request.draft
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Load review skill
-        id: skill
-        run: |
-          {
-            echo "body<<SKILLEOF"
-            cat .claude/skills/pr-review/SKILL.md
-            echo "SKILLEOF"
-          } >> "$GITHUB_OUTPUT"
-
-      - uses: anthropics/claude-code-action@v1
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          use_sticky_comment: true
-          prompt: |
-            REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
-
-            Review this pull request following the project review skill below.
-            Use inline comments for specific findings; put the verdict + summary
-            in the PR comment.
-
-            ${{ steps.skill.outputs.body }}
-          claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(cargo check:*),Bash(cargo test:*)"
+# name: claude-review
+#
+# on:
+#   pull_request:
+#     types: [opened, ready_for_review]
+#
+# jobs:
+#   review:
+#     # same-repo PRs only; drafts wait until ready_for_review
+#     if: github.event.pull_request.head.repo.full_name == github.repository && !github.event.pull_request.draft
+#     runs-on: ubuntu-latest
+#     permissions:
+#       contents: read
+#       pull-requests: write
+#       id-token: write
+#     steps:
+#       - uses: actions/checkout@v4
+#         with:
+#           fetch-depth: 1
+#
+#       - name: Load review skill
+#         id: skill
+#         run: |
+#           {
+#             echo "body<<SKILLEOF"
+#             cat .claude/skills/pr-review/SKILL.md
+#             echo "SKILLEOF"
+#           } >> "$GITHUB_OUTPUT"
+#
+#       - uses: anthropics/claude-code-action@v1
+#         with:
+#           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+#           use_sticky_comment: true
+#           prompt: |
+#             REPO: ${{ github.repository }}
+#             PR NUMBER: ${{ github.event.pull_request.number }}
+#
+#             Review this pull request following the project review skill below.
+#             Use inline comments for specific findings; put the verdict + summary
+#             in the PR comment.
+#
+#             ${{ steps.skill.outputs.body }}
+#           claude_args: |
+#             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(cargo check:*),Bash(cargo test:*)"

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -501,7 +501,7 @@ pub async fn create_worktree(
         // discards local commits; a diverged branch simply stays put.
         if let Some(b) = base.map(str::trim).filter(|b| !b.is_empty()) {
             if let Err(e) = run_git(wt_path, &["merge", "--ff-only", b]).await {
-                progress(format!("note: {branch} is not a fast-forward of {b} — left as-is ({e})"));
+                progress(format!("note: could not fast-forward {branch} to {b} — left as-is ({e})"));
             }
         }
     }

--- a/src/app/canopy/CommandButtons.tsx
+++ b/src/app/canopy/CommandButtons.tsx
@@ -3,12 +3,12 @@
    worktree bar does not.
 
    The first command gets its own labelled run button; the rest collapse into a
-   single "Commands" menu so the bar cannot grow without bound as the user adds
-   more. Mirrors the design's CmdButtons (cx-app.jsx). The backend `CustomCmd`
-   is `{ label, command }` with no group field, so the design's per-group
-   headers only render if a group ever appears in the data. */
+   single "Commands" popover so the bar cannot grow without bound as the user
+   adds more. Mirrors the design's CmdButtons (cx-app.jsx). The backend
+   `CustomCmd` is `{ label, command }` with no group field, so the design's
+   per-group headers only render if a group ever appears in the data. */
 import { useEffect, useRef, useState } from "react";
-import { Chevron, Play } from "../../icons";
+import { Chevron, Play, Spinner } from "../../icons";
 import { hasBackend, ipc, type CustomCmd } from "../../ipc";
 import { mockCustomCommands } from "../../mock";
 import { useStore } from "../../store";
@@ -21,13 +21,26 @@ type Grouped = CustomCmd & { group?: string };
 export default function CommandButtons({ wt }: { wt: WorktreeNode }) {
   const [open, setOpen] = useState(false);
   const [cmds, setCmds] = useState<CustomCmd[]>([]);
+  // the shell-side op buffer is shared per worktree, so only one custom command
+  // may run at a time — a second would interleave output and its completion
+  // would flip the worktree to idle while the first is still running
+  const [busy, setBusy] = useState(false);
   const box = useRef<HTMLDivElement>(null);
+  const trigger = useRef<HTMLButtonElement>(null);
   const settingsRev = useStore((s) => s.settingsRev);
   const showToast = useStore((s) => s.showToast);
   // commands are repo-scoped; a worktree doesn't carry its repo id, so derive it
   // from the tree. The selector returns a primitive, so this only re-renders
   // when the owning repo actually changes.
   const repoId = useStore((s) => s.tree.find((r) => r.worktrees.some((w) => w.wtKey === wt.wtKey))?.repoId);
+
+  // WorktreeView is reused (no key) across repo switches, so drop the previous
+  // repo's commands and close the menu the instant the repo changes — otherwise
+  // a stale command could briefly show and be run against the new worktree
+  useEffect(() => {
+    setCmds([]);
+    setOpen(false);
+  }, [repoId]);
 
   // per-repo commands; reload when settings are saved
   useEffect(() => {
@@ -51,28 +64,46 @@ export default function CommandButtons({ wt }: { wt: WorktreeNode }) {
     };
   }, [repoId, settingsRev]);
 
-  // outside-click closes; the trigger lives inside `box`, so clicking it again
-  // toggles rather than being swallowed as an outside click — a popover trigger
-  // must be able to close its own popover
+  // this is a plain popover of buttons (not an ARIA menu), so native Tab moves
+  // between rows; add outside-click + Escape dismissal, move focus in on open,
+  // and hand it back to the trigger on close
   useEffect(() => {
     if (!open) return;
     const d = (e: MouseEvent) => {
       if (box.current && !box.current.contains(e.target as Node)) setOpen(false);
     };
+    const k = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        setOpen(false);
+        trigger.current?.focus();
+      }
+    };
     document.addEventListener("mousedown", d);
-    return () => document.removeEventListener("mousedown", d);
+    document.addEventListener("keydown", k);
+    box.current?.querySelector<HTMLElement>(".cxs-cmdrow")?.focus();
+    return () => {
+      document.removeEventListener("mousedown", d);
+      document.removeEventListener("keydown", k);
+    };
   }, [open]);
 
   if (cmds.length === 0) return null;
 
   const run = (c: CustomCmd) => {
+    if (busy) return;
     setOpen(false);
-    showToast(`Running ${c.label} — ${wt.branch}`);
-    if (!hasBackend()) return;
+    if (!hasBackend()) {
+      showToast(`Running ${c.label} — ${wt.branch}`);
+      return;
+    }
+    setBusy(true);
+    showToast(`Running ${c.label} — ${wt.branch}…`);
     ipc
       .runCustomCommand(wt.wtKey, c.command)
       .then(() => showToast(`${c.label} finished — ${wt.branch}`))
-      .catch((e) => showToast(`${c.label} failed — ${String(e)}`));
+      .catch((e) => showToast(`${c.label} failed — ${String(e)}`))
+      .finally(() => setBusy(false));
   };
 
   const flat = cmds.slice(0, 1);
@@ -86,18 +117,20 @@ export default function CommandButtons({ wt }: { wt: WorktreeNode }) {
   return (
     <div className="cxs-cmds" ref={box}>
       {flat.map((c, i) => (
-        <button key={i} className="cxs-cmdb cxs-cmdb--run1" title={c.command} onClick={() => run(c)}>
-          <Play size={10} />
+        <button key={i} className="cxs-cmdb cxs-cmdb--run1" title={c.command} onClick={() => run(c)} disabled={busy}>
+          {busy ? <Spinner size={10} /> : <Play size={10} />}
           <span className="t">{c.label}</span>
         </button>
       ))}
       {rest.length > 0 && (
         <>
           <button
+            ref={trigger}
             className={"cxs-cmdb" + (open ? " is-on" : "")}
             title="Custom commands"
             onClick={() => setOpen((o) => !o)}
-            aria-haspopup="menu"
+            disabled={busy}
+            aria-haspopup="true"
             aria-expanded={open}
           >
             <Play size={10} />
@@ -105,12 +138,12 @@ export default function CommandButtons({ wt }: { wt: WorktreeNode }) {
             <Chevron size={11} />
           </button>
           {open && (
-            <div className="cxs-cmdpop" role="menu">
+            <div className="cxs-cmdpop">
               {Object.entries(groups).map(([g, list]) => (
                 <div key={g || "_"}>
                   {g && <div className="cxs-cg">{g}</div>}
                   {list.map((c, i) => (
-                    <button key={i} className="cxs-cmdrow" role="menuitem" onClick={() => run(c)}>
+                    <button key={i} className="cxs-cmdrow" onClick={() => run(c)} disabled={busy}>
                       <Play size={10} />
                       <span className="l">{c.label}</span>
                       <span className="c">{c.command}</span>

--- a/src/app/canopy/CommandButtons.tsx
+++ b/src/app/canopy/CommandButtons.tsx
@@ -20,7 +20,10 @@ type Grouped = CustomCmd & { group?: string };
 
 export default function CommandButtons({ wt }: { wt: WorktreeNode }) {
   const [open, setOpen] = useState(false);
-  const [cmds, setCmds] = useState<CustomCmd[]>([]);
+  // commands are stored WITH the repo id they were loaded for; a repo switch
+  // then derives [] on the SAME render (not a frame later via an effect), so a
+  // stale command can never be shown or run against the newly selected worktree
+  const [loaded, setLoaded] = useState<{ repoId: string | undefined; list: CustomCmd[] }>({ repoId: undefined, list: [] });
   // the shell-side op buffer is shared per worktree, so only one custom command
   // may run at a time — a second would interleave output and its completion
   // would flip the worktree to idle while the first is still running
@@ -34,31 +37,32 @@ export default function CommandButtons({ wt }: { wt: WorktreeNode }) {
   // when the owning repo actually changes.
   const repoId = useStore((s) => s.tree.find((r) => r.worktrees.some((w) => w.wtKey === wt.wtKey))?.repoId);
 
-  // WorktreeView is reused (no key) across repo switches, so drop the previous
-  // repo's commands and close the menu the instant the repo changes — otherwise
-  // a stale command could briefly show and be run against the new worktree
+  // only trust the loaded list when it belongs to the current repo
+  const cmds = loaded.repoId === repoId ? loaded.list : [];
+
+  // WorktreeView is reused (no key) across repo switches; close any open menu
+  // when the repo changes (the stale list is already gated out by `cmds` above)
   useEffect(() => {
-    setCmds([]);
     setOpen(false);
   }, [repoId]);
 
   // per-repo commands; reload when settings are saved
   useEffect(() => {
     if (!hasBackend()) {
-      setCmds(mockCustomCommands());
+      setLoaded({ repoId, list: mockCustomCommands() });
       return;
     }
     if (!repoId) {
-      setCmds([]);
+      setLoaded({ repoId, list: [] });
       return;
     }
     let alive = true;
     ipc
       .getSettings()
       .then((s) => {
-        if (alive) setCmds(s.repos.find((r) => r.id === repoId)?.customCommands ?? []);
+        if (alive) setLoaded({ repoId, list: s.repos.find((r) => r.id === repoId)?.customCommands ?? [] });
       })
-      .catch(() => alive && setCmds([]));
+      .catch(() => alive && setLoaded({ repoId, list: [] }));
     return () => {
       alive = false;
     };
@@ -92,6 +96,10 @@ export default function CommandButtons({ wt }: { wt: WorktreeNode }) {
 
   const run = (c: CustomCmd) => {
     if (busy) return;
+    // activating a popover row unmounts the focused button; hand focus back to
+    // the trigger so keyboard users aren't dropped onto <body> (run1 clicks
+    // leave the popover closed, so this only fires for menu rows)
+    if (open) trigger.current?.focus();
     setOpen(false);
     if (!hasBackend()) {
       showToast(`Running ${c.label} — ${wt.branch}`);
@@ -130,7 +138,6 @@ export default function CommandButtons({ wt }: { wt: WorktreeNode }) {
             title="Custom commands"
             onClick={() => setOpen((o) => !o)}
             disabled={busy}
-            aria-haspopup="true"
             aria-expanded={open}
           >
             <Play size={10} />

--- a/src/app/canopy/Modal.tsx
+++ b/src/app/canopy/Modal.tsx
@@ -8,6 +8,9 @@
 import { useEffect, useRef, type ComponentType, type ReactNode } from "react";
 import { Cube, X } from "../../icons";
 
+const FOCUSABLE =
+  'a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),summary,[tabindex]:not([tabindex="-1"])';
+
 export default function Modal({
   icon: Icon = Cube,
   danger,
@@ -48,8 +51,6 @@ export default function Modal({
     // aria-modal="true" promises focus cannot leave the dialog. Without a trap
     // Tab walks straight into the app behind the scrim, so the promise was
     // false for assistive tech and keyboard users alike.
-    const FOCUSABLE =
-      'a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),summary,[tabindex]:not([tabindex="-1"])';
     const trap = (e: KeyboardEvent) => {
       if (e.key !== "Tab" || !card.current) return;
       const items = [...card.current.querySelectorAll<HTMLElement>(FOCUSABLE)].filter((el) => el.offsetParent !== null);
@@ -57,10 +58,14 @@ export default function Modal({
       const first = items[0];
       const last = items[items.length - 1];
       const active = document.activeElement;
-      if (e.shiftKey && (active === first || !card.current.contains(active))) {
+      const outside = !card.current.contains(active);
+      // both directions recover from focus that has escaped the card (e.g. a
+      // focused child was removed and focus fell to <body>), so Tab can't walk
+      // into the app behind the scrim
+      if (e.shiftKey && (active === first || outside)) {
         e.preventDefault();
         last.focus();
-      } else if (!e.shiftKey && active === last) {
+      } else if (!e.shiftKey && (active === last || outside)) {
         e.preventDefault();
         first.focus();
       }
@@ -94,6 +99,19 @@ export default function Modal({
       opener?.focus?.();
     };
   }, []);
+
+  // Recovery after re-renders: some modals swap their content in place (e.g.
+  // DatabaseModal's snapshot prompt) rather than remounting. If that removes
+  // the focused element, focus falls to <body> and Tab could escape behind the
+  // scrim. Pull it back into the card — but ONLY when focus has actually
+  // orphaned, never while the user is typing in a still-present field, so this
+  // can't reintroduce the focus-stealing this component was fixed to avoid.
+  useEffect(() => {
+    const active = document.activeElement;
+    if (card.current && (active === document.body || active === document.documentElement || active === null)) {
+      card.current.querySelector<HTMLElement>(FOCUSABLE)?.focus();
+    }
+  });
 
   return (
     <div

--- a/src/styles/canopy-shell.css
+++ b/src/styles/canopy-shell.css
@@ -765,6 +765,11 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+/* bound the labelled command so an unrestricted label from Settings ellipsizes
+   instead of ballooning .cxs-cmds and squeezing the service scroller to zero */
+.cxs-cmdb--run1 {
+  max-width: 160px;
+}
 .cxs-cmdpop {
   position: absolute;
   top: calc(var(--h-control-sm) + var(--sp-row));
@@ -829,11 +834,9 @@
     display: none;
   }
 }
-@container pane (max-width: 440px) {
-  .cxs-cmds .cxs-cmdb--run1 {
-    display: none;
-  }
-}
+/* the direct command button stays visible at every width — the "Commands"
+   menu only holds cmds[1..], so hiding it would make the first command (and,
+   when it's the only one, all commands) unreachable */
 /* running services read as filled tokens; idle ones recede to text */
 .cxs-svc {
   display: inline-flex;

--- a/src/styles/canopy-shell.css
+++ b/src/styles/canopy-shell.css
@@ -1860,6 +1860,15 @@
   background: var(--surface-app);
   border: var(--border-w) solid var(--border);
   color: var(--text-tertiary);
+  transition:
+    border-color var(--dur),
+    box-shadow var(--dur);
+}
+/* the input drops its own outline, so give the wrapper the keyboard-focus ring
+   the auto-focused field otherwise lacks (matches .cx-search) */
+.cxs-pp-search:focus-within {
+  border-color: var(--action-primary);
+  box-shadow: 0 0 0 3px var(--focus-ring);
 }
 .cxs-pp-search input {
   flex: 1;


### PR DESCRIPTION
Addresses the Copilot review feedback on the four merged PRs (#67–#70), consolidated into one change. Supersedes #71, #72, #73, #74.

### Rail custom commands (#67)
- **Stale commands on repo switch** — `WorktreeView` is reused without a key; clear cached commands + close the menu when the repo id changes, before the new fetch resolves, so a stale command can't run against the new worktree.
- **Concurrent launches** — custom-command events share one per-worktree op buffer; added a `busy` guard and disable the buttons while a command runs.
- **False `menu` ARIA** — dropped `role="menu"`/`menuitem` (no arrow-key nav was implemented) for a plain popover of buttons; added Escape-to-close, focus-in on open, and focus restore to the trigger on close.
- **First command unreachable at ≤440px** — removed the rule that hid the direct button (the menu only holds `cmds[1..]`), so the first/only command stays reachable.
- **Long labels** — `max-width` on the direct button so a long Settings label ellipsizes instead of squeezing the service scroller to zero.

### Worktree fetch-before-create (#68)
- The `git merge --ff-only` note claimed every failure was a non-fast-forward (and described the direction backwards); it now reports the attempted operation accurately.

### Submodule branch search (#69)
- The search input cleared its own outline; added the shared `.cx-search` `:focus-within` ring so the auto-focused field has a visible keyboard indicator.

### Modal focus (#70)
- Reused-content modals (e.g. `DatabaseModal`'s snapshot prompt) could orphan focus to `<body>` when the focused field was removed, letting Tab escape behind the scrim. The trap now recovers in both directions, and a containment-guarded post-render effect re-focuses the card **only** when focus has orphaned — never while typing in a live field.

`tsc` clean; `cargo check` clean.
