### PR TITLE
Onboarding redesign + menu-bar tray (Canopy Tray)

### DIFF
--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -274,8 +274,23 @@ pub fn worktree_vars(app: &AppHandle, repo_id: &str, wt_key: &str, is_main: bool
             if let Some(bp) = s.base_port {
                 let key = svc_key(wt_key, &s.id);
                 let port = effective_port(&overrides, &key, bp as u32, idx).to_string();
-                m.insert(format!("WT_{}_PORT", s.id.to_uppercase()), port.clone());
-                m.insert(format!("WM_PORT_{}", s.id.to_uppercase()), port); // back-compat alias
+                let id_up = s.id.to_uppercase();
+                m.insert(format!("WT_{id_up}_PORT"), port.clone());
+                m.insert(format!("WM_PORT_{id_up}"), port.clone()); // back-compat alias
+                // Also expose the port under the service's human NAME, so an .env
+                // template can use `${WT_SERVER_PORT}` for a service named "Server"
+                // regardless of its internal id (ids like `svc-19` never matched a
+                // human-authored template). Additive: `or_insert` never clobbers an
+                // id-based var, and a name collision keeps the first service's port.
+                let name_slug: String = s
+                    .name
+                    .chars()
+                    .map(|c| if c.is_ascii_alphanumeric() { c.to_ascii_uppercase() } else { '_' })
+                    .collect();
+                let name_slug = name_slug.trim_matches('_');
+                if !name_slug.is_empty() {
+                    m.entry(format!("WT_{name_slug}_PORT")).or_insert(port);
+                }
             }
         }
     }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -226,6 +226,23 @@ export default function App() {
     return () => document.removeEventListener("keydown", k);
   });
 
+  /* commands from the menu-bar tray (a separate webview): it shows this window,
+     then emits — we open the matching surface here. */
+  useEffect(() => {
+    if (!hasBackend()) return;
+    const unlisten: Array<() => void> = [];
+    let dead = false;
+    const track = (p: Promise<() => void>) => p.then((u) => (dead ? u() : unlisten.push(u)));
+    import("@tauri-apps/api/event").then(({ listen }) => {
+      track(listen("tray:new-worktree", () => setShowNewWt(true)));
+      track(listen("tray:overview", () => setView("overview")));
+    });
+    return () => {
+      dead = true;
+      unlisten.forEach((u) => u());
+    };
+  }, []);
+
   const onboardingActive = showOnboarding || (tree.length === 0 && !obDismissed);
   const worktreeCount = tree.reduce((n, r) => n + r.worktrees.length, 0);
 

--- a/src/app/canopy/SidebarNav.tsx
+++ b/src/app/canopy/SidebarNav.tsx
@@ -3,8 +3,8 @@
    Grouping is what makes a long list scannable — worktrees sort themselves by
    what they want from you, not by which repo they happen to live in.
    "Needs you" outranks everything; pinned worktrees hold the top of the rest. */
-import { useMemo, useState } from "react";
-import { Chevron, Editor, Logs, Pin, Play, Plus, Search, SidebarIcon, Sparkle, Stop, Terminal } from "../../icons";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Chevron, Editor, Fork, Logs, Pin, Play, Plus, Search, SidebarIcon, Sparkle, Stop, Terminal } from "../../icons";
 import { useStore, type LaneSession } from "../../store";
 import { isLive, type RepoNode, type WorktreeNode } from "../../types";
 import { agentState, dotClass, wtDot, type AttnItem } from "../nextAction";
@@ -41,12 +41,15 @@ export default function SidebarNav({
   const openWorktree = useStore((s) => s.openWorktree);
   const pins = usePins();
   const [closed, setClosed] = useState<Record<string, boolean>>({});
+  const [repoFilter, setRepoFilter] = useState<string | null>(null);
 
   const flat = useMemo<Flat[]>(() => tree.flatMap((repo) => repo.worktrees.map((wt) => ({ wt, repo }))), [tree]);
   const q = query.toLowerCase().trim();
+  // a filter pointing at a removed repo falls back to "all" rather than hiding everything
+  const activeRepo = repoFilter && tree.some((r) => r.repoId === repoFilter) ? repoFilter : null;
 
   const groups = useMemo(() => {
-    const vis = flat.filter(({ wt, repo }) => !q || `${wt.branch} ${repo.name}`.toLowerCase().includes(q));
+    const vis = flat.filter(({ wt, repo }) => (!activeRepo || repo.repoId === activeRepo) && (!q || `${wt.branch} ${repo.name}`.toLowerCase().includes(q)));
     const needs = new Set(attn.map((a) => a.wtKey));
     const pinned = new Set(pins);
     const rest = vis.filter((f) => !needs.has(f.wt.wtKey));
@@ -64,7 +67,7 @@ export default function SidebarNav({
         items: rest.filter((f) => !pinned.has(f.wt.wtKey) && !f.wt.services.some((s) => isLive(s.status))),
       },
     ].filter((g) => g.items.length);
-  }, [flat, q, attn, pins]);
+  }, [flat, q, activeRepo, attn, pins]);
 
   return (
     <aside className={"cxs-side" + (hidden ? " is-hidden" : "")} inert={hidden || undefined} aria-hidden={hidden || undefined}>
@@ -77,6 +80,10 @@ export default function SidebarNav({
           <SidebarIcon size={14} />
         </button>
       </div>
+
+      {tree.length > 1 && (
+        <RepoFilter repos={tree.map((r) => ({ id: r.repoId, name: r.name }))} value={activeRepo} onPick={setRepoFilter} />
+      )}
 
       <div className="cxs-slist">
         <button className={"cxs-ovrow" + (view === "overview" ? " is-on" : "")} onClick={onOverview}>
@@ -98,10 +105,11 @@ export default function SidebarNav({
               <span className="gn">{g.items.length}</span>
             </button>
             {!closed[g.k] &&
-              g.items.map(({ wt }) => (
+              g.items.map(({ wt, repo }) => (
                 <WorktreeRow
                   key={wt.wtKey}
                   wt={wt}
+                  repoName={repo.name}
                   selected={wt.wtKey === selKey && view === "wt"}
                   sessions={sessions[wt.wtKey] ?? EMPTY}
                   onSelect={() => onSelect(wt.wtKey)}
@@ -128,8 +136,48 @@ export default function SidebarNav({
 
 const EMPTY: LaneSession[] = [];
 
+/* Filter the list to one repository. Hidden when there's only one repo — the
+   text field already narrows by branch (and repo name), so the dropdown only
+   earns its space once worktrees span more than one repo. */
+function RepoFilter({ repos, value, onPick }: { repos: { id: string; name: string }[]; value: string | null; onPick: (id: string | null) => void }) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!open) return;
+    const d = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", d);
+    return () => document.removeEventListener("mousedown", d);
+  }, [open]);
+  const sel = repos.find((r) => r.id === value);
+  return (
+    <div className="cxs-repobar" ref={ref}>
+      <button className="cxs-repobtn" onClick={() => setOpen((o) => !o)} title="Filter by repository" aria-haspopup="listbox" aria-expanded={open}>
+        <Fork size={11} />
+        <span className="nm">{sel ? sel.name : "All repositories"}</span>
+        <Chevron size={10} />
+      </button>
+      {open && (
+        <div className="cxs-repomenu" role="listbox">
+          <button className={"cxs-repoitem" + (value === null ? " is-on" : "")} role="option" aria-selected={value === null} onClick={() => { onPick(null); setOpen(false); }}>
+            <span className="nm">All repositories</span>
+          </button>
+          {repos.map((r) => (
+            <button key={r.id} className={"cxs-repoitem" + (r.id === value ? " is-on" : "")} role="option" aria-selected={r.id === value} onClick={() => { onPick(r.id); setOpen(false); }}>
+              <Fork size={11} />
+              <span className="nm">{r.name}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 function WorktreeRow({
   wt,
+  repoName,
   selected,
   sessions,
   onSelect,
@@ -138,6 +186,7 @@ function WorktreeRow({
   onEditor,
 }: {
   wt: WorktreeNode;
+  repoName: string;
   selected: boolean;
   sessions: LaneSession[];
   onSelect: () => void;
@@ -154,7 +203,7 @@ function WorktreeRow({
   const pinned = isPinned(wt.wtKey);
 
   return (
-    <div className={"cxs-wtr" + (selected ? " is-on" : "")} onClick={onSelect} role="button" tabIndex={0}
+    <div className={"cxs-wtr" + (selected ? " is-on" : "")} title={`${repoName}: ${wt.branch}`} onClick={onSelect} role="button" tabIndex={0}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();

--- a/src/onboarding/Onboarding.tsx
+++ b/src/onboarding/Onboarding.tsx
@@ -1,29 +1,31 @@
 // First run — one adaptive screen, not five steps. Ported from the redesign
-// handoff (Canopy Onboarding.html / cxo-onboard.jsx).
+// handoff (Canopy Onboarding.html / cxo-onboard.jsx, revised).
 //
 // The shipped wizard walked Repository → Stack → Services → Commands → Review.
 // Two of those didn't earn a screen: "Stack" asked you to confirm something
 // already read from the repo's manifests, and "Review" restated the screens
 // before it. Meanwhile the real value — detect_repo mapping package.json
 // scripts to services — sat behind step 3. So now: an empty state that finally
-// exists, one adaptive add screen (detection runs as you type; the stack is a
-// chip; the derivation is shown, not asserted), honest provisioning narration
-// over the real IPC calls, and a "ready" screen that ends on the next action.
+// exists (with the worktree value proposition drawn out), one adaptive add
+// screen (detection runs as you type; the stack is a chip; services are
+// inline-editable; the derivation is shown, not asserted), honest provisioning
+// narration over the real IPC calls, and a "ready" screen that ends on the
+// next action.
 //
-// Backend honesty notes:
-// • The empty state's "recently opened" list is omitted — Canopy has no MRU
-//   store, so there is nothing real to list. TODO: file an issue + wire it.
+// Adaptations from the design demo:
+// • The light/dark theme toggle is omitted — the app ships dark only; there is
+//   no light theme to switch to (tokens.css has no light values yet).
 // • Env template values use ${WT_SERVER_PORT} / ${WT_DB_NAME}, the variables the
 //   Rust setup runner actually interpolates (state.rs:142, setup.rs). The
-//   handoff/SettingsView names ${WT_SERVICE_PORT} / ${INT_DB_NAME} are NOT
-//   substituted by the backend and would land in .env as dead literals.
+//   handoff names ${WT_SERVICE_PORT} / ${INT_DB_NAME} are NOT substituted by the
+//   backend and would land in .env as dead literals.
 import { useEffect, useRef, useState } from "react";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import "../styles/onboarding.css";
 import { errText, hasBackend, ipc, type ProvisionEntry, type RepoCfg, type RepoDetection, type ServiceCfg } from "../ipc";
 import { useStore } from "../store";
-import { Browser, Check, ChevRight, Chevron, Cube, Doc, Fork, Plus, Server, Spinner } from "../icons";
+import { Bolt, Browser, Check, ChevRight, Chevron, Cube, Doc, Download, Fork, Plus, Server, Spinner, Trash } from "../icons";
 
 /* the one folder glyph the shared set doesn't carry */
 const Folder = ({ size = 14 }: { size?: number }) => (
@@ -49,6 +51,8 @@ interface WizSvc {
   on: boolean;
   name: string;
   kind: Kind;
+  dir: string;
+  dirEdited?: boolean;
   script?: string;
   cmd: string;
   port: string;
@@ -64,6 +68,10 @@ interface Cfg {
 let _uid = 0;
 const uid = (p: string) => p + ++_uid;
 const cap = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
+const slug = (v: string) => v.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+// Mirror the backend's port-variable name-slug (state.rs): each non-alphanumeric
+// char → "_", uppercased, trimmed. A service named "Server dev" → WT_SERVER_DEV_PORT.
+const envSlug = (v: string) => [...v].map((c) => (/[A-Za-z0-9]/.test(c) ? c.toUpperCase() : "_")).join("").replace(/^_+|_+$/g, "");
 const KIND_IC: Record<Kind, typeof Server> = { web: Browser, server: Server, worker: Cube };
 const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
@@ -72,6 +80,7 @@ const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
 function derive(det: RepoDetection): { services: WizSvc[]; cfg: Cfg } {
   const scripts = det.scripts ?? [];
   const find = (re: RegExp) => scripts.find((s) => re.test(s.name));
+  const dirOf = (command: string) => command.match(/--prefix\s+(\S+)/)?.[1] ?? "";
 
   const services: WizSvc[] = [];
   let portBase = 3000;
@@ -85,17 +94,19 @@ function derive(det: RepoDetection): { services: WizSvc[]; cfg: Cfg } {
       on: services.filter((x) => x.on).length < 2,
       name: cap(name.replace(/[:_-]/g, " ")),
       kind: web ? "web" : "server",
+      dir: dirOf(command),
+      dirEdited: true,
       script: name,
       cmd: command,
       port: String((portBase += services.length ? 10 : 0)),
     });
   }
   if (!services.length) {
-    services.push({ id: uid("s"), on: true, name: "Dev", kind: "server", cmd: "npm run dev", port: "3000" });
+    services.push({ id: uid("s"), on: true, name: "Dev", kind: "server", dir: "", dirEdited: true, cmd: "npm run dev", port: "3000" });
   }
   const build = find(/^(build|compile|plugins?:build)$/i);
   if (build) {
-    services.push({ id: uid("s"), on: false, name: cap(build.name.replace(/[:_-]/g, " ")), kind: "worker", script: build.name, cmd: build.command, port: "" });
+    services.push({ id: uid("s"), on: false, name: cap(build.name.replace(/[:_-]/g, " ")), kind: "worker", dir: dirOf(build.command), dirEdited: true, script: build.name, cmd: build.command, port: "" });
   }
 
   const reset = find(/^(db:reset|reset:db|resetdb)$/i);
@@ -107,12 +118,19 @@ function derive(det: RepoDetection): { services: WizSvc[]; cfg: Cfg } {
   else if (create) setup.push({ id: uid("u"), on: true, cmd: `npm run ${create.name}` });
   else if (migrate) setup.push({ id: uid("u"), on: true, cmd: `npm run ${migrate.name}` });
 
+  // The backend exposes each service's port as WT_<NAME-SLUG>_PORT (and by id).
+  // Point the default PORT env at the primary service's real variable so it
+  // actually resolves — a hardcoded ${WT_SERVER_PORT} only worked when a service
+  // happened to be named exactly "Server".
+  const primary = services.find((s) => s.on && s.kind === "server") ?? services.find((s) => s.on && s.port) ?? services[0];
+  const portVar = primary ? `\${WT_${envSlug(primary.name)}_PORT}` : "${WT_SERVER_PORT}";
+
   const cfg: Cfg = {
     resetDb: reset ? `npm run ${reset.name}` : "",
     migrate: migrate ? `npm run ${migrate.name}` : "",
-    worktreeDir: det.top ? `${det.top}-worktrees` : "",
+    worktreeDir: det.top ? `${det.top}/.worktrees` : "",
     env: [
-      { id: uid("e"), on: true, key: "PORT", value: "${WT_SERVER_PORT}" },
+      { id: uid("e"), on: true, key: "PORT", value: portVar },
       { id: uid("e"), on: true, key: "PG_DB", value: "${WT_DB_NAME}" },
     ],
     setup,
@@ -120,8 +138,13 @@ function derive(det: RepoDetection): { services: WizSvc[]; cfg: Cfg } {
   return { services, cfg };
 }
 
-function Tgl({ on, onClick }: { on: boolean; onClick: () => void }) {
-  return <button className={"tgl" + (on ? " on" : "")} role="switch" aria-checked={on} onClick={onClick}><i /></button>;
+/* the on/off control is a checkbox — a value you're setting, not a live switch */
+function Chk({ on, onClick, label }: { on: boolean; onClick: () => void; label?: string }) {
+  return (
+    <button className={"cbx" + (on ? " on" : "")} role="checkbox" aria-checked={on} aria-label={label || "Include"} onClick={onClick}>
+      {on ? <Check size={11} /> : null}
+    </button>
+  );
 }
 
 /* ── the stack: a chip, not a step ────────────────────────────────── */
@@ -159,34 +182,51 @@ function StackChip({ value, detected, onPick }: { value: string; detected?: stri
   );
 }
 
-/* ── A · empty state — first launch used to say nothing ───────────── */
-function EmptyState({ onAdd, onBrowse }: { onAdd: () => void; onBrowse: () => void }) {
+/* ── A · empty state — the ask on the left, the case for worktrees on the right ── */
+const HILITES: [typeof Fork, string, string][] = [
+  [Fork, "Leave work where it stands", "Each branch keeps its own checkout, so a review never costs you the thing you were halfway through."],
+  [Server, "Ports that don't fight", "Canopy assigns each worktree its own ports and database, so branches run side by side."],
+  [Bolt, "Ready when you get there", "Checkout, install, migrate and run happen together, so you come back to a working app."],
+];
+
+function EmptyState({ onAdd }: { onAdd: () => void }) {
   return (
-    <div className="emptywrap">
-      <div className="emptycard">
-        <div className="emptyring"><Fork size={26} /></div>
+    <div className="hero">
+      <div className="heroL">
+        <div className="heromark"><span className="fk"><Fork size={19} /></span>Canopy</div>
         <h1>No repositories yet</h1>
         <p>Canopy runs each branch as its own worktree — separate checkout, separate services, separate database. Point it at a repo and it reads your scripts to work out what to run.</p>
         <div className="emptyacts">
-          <button className="btn pri lg" onClick={onAdd}><Plus size={13} />Add a repository<span className="k">⌘N</span></button>
-          <button className="btn lg" onClick={onBrowse}><Folder size={13} />Browse…</button>
+          <button className="btn pri lg" onClick={onAdd}><Plus size={13} />Add a repository</button>
         </div>
-        <div className="whatnext">
-          <div className="slab">What happens next</div>
-          {[
-            ["Canopy reads the repo", "git remotes, branches, and the scripts in your manifest."],
-            ["It proposes what to run", "long-running scripts become services, with ports derived per worktree."],
-            ["You create a worktree", "a branch checked out, provisioned and running in one action."],
-          ].map(([t, d], i) => (
-            <div className="wn" key={t}>
-              <span className="n">{i + 1}</span>
-              <span className="t"><b>{t}</b><span>{d}</span></span>
+        <p className="herohint">Or drop a git repository anywhere in this window.</p>
+      </div>
+
+      <div className="heroR">
+        <div className="cmp">
+          <div className="cmp-card was">
+            <div className="cmp-h"><b>git checkout</b><span>one working copy</span></div>
+            <div className="cmp-row live"><span className="fd"><Folder size={12} /></span><span className="bd"><span className="b">main</span><span className="p">~/canopy</span></span><span className="s">:3000</span></div>
+            <div className="cmp-row off"><span className="fd" /><span className="bd"><span className="b">feat/wt-components-v2</span><span className="p">no checkout</span></span><span className="s">stashed</span></div>
+            <div className="cmp-row off"><span className="fd" /><span className="bd"><span className="b">fix/deduplicate-queries</span><span className="p">no checkout</span></span><span className="s">waiting</span></div>
+            <p className="cmp-n">Switching means stashing, checking out, reinstalling, restarting.</p>
+          </div>
+          <div className="cmp-card is">
+            <div className="cmp-h"><b>git worktree</b><span>three, at once</span></div>
+            <div className="cmp-row live"><span className="fd"><Folder size={12} /></span><span className="bd"><span className="b">main</span><span className="p">~/canopy</span></span><span className="s">:3000</span></div>
+            <div className="cmp-row live"><span className="fd"><Folder size={12} /></span><span className="bd"><span className="b">feat/wt-components-v2</span><span className="p">.worktrees/feat-wt-components-v2</span></span><span className="s">:3010</span></div>
+            <div className="cmp-row live"><span className="fd"><Folder size={12} /></span><span className="bd"><span className="b">fix/deduplicate-queries</span><span className="p">.worktrees/fix-deduplicate-queries</span></span><span className="s">:3020</span></div>
+            <p className="cmp-n">Every branch stays checked out, installed and running. Switching is switching windows.</p>
+          </div>
+        </div>
+        <div className="hilites">
+          {HILITES.map(([Ic, t, d]) => (
+            <div className="hi" key={t}>
+              <span className="t"><Ic size={13} /></span>
+              <span className="bd"><h3>{t}</h3><p>{d}</p></span>
             </div>
           ))}
         </div>
-        {/* The design shows a "Recently opened" list here. Canopy has no MRU
-            store, so there is nothing real to list — omitted rather than
-            fabricated. TODO: file an issue to persist opened-repo history. */}
       </div>
     </div>
   );
@@ -208,6 +248,7 @@ function AddScreen({
   onStack,
   setServices,
   setCfg,
+  flash,
   onSkip,
   onDone,
 }: {
@@ -224,9 +265,13 @@ function AddScreen({
   onStack: (id: string) => void;
   setServices: React.Dispatch<React.SetStateAction<WizSvc[]>>;
   setCfg: React.Dispatch<React.SetStateAction<Cfg>>;
+  flash: (m: string) => void;
   onSkip: () => void;
   onDone: () => void;
 }) {
+  const [edit, setEdit] = useState<string | null>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
+
   const on = services.filter((s) => s.on);
   const hits = new Set<string>();
   services.forEach((s) => s.on && s.script && hits.add(s.script));
@@ -235,8 +280,47 @@ function AddScreen({
     if (m) hits.add(m[1]);
   });
   const patch = (id: string, p: Partial<WizSvc>) => setServices((ss) => ss.map((s) => (s.id === id ? { ...s, ...p } : s)));
+  const dropSvc = (id: string) => {
+    setServices((ss) => ss.filter((s) => s.id !== id));
+    setEdit(null);
+  };
   const envOn = cfg.env.filter((e) => e.on).length;
   const setupOn = cfg.setup.filter((u) => u.on).length;
+
+  /* Import an existing .worktreemanager.json — reuses the FileReader path
+     Settings uses, so it round-trips with what provisioning writes out. */
+  const triggerImport = () => {
+    if (!hasBackend()) return flash("Import needs the desktop app");
+    fileRef.current?.click();
+  };
+  const onImportFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files?.[0];
+    e.target.value = "";
+    if (!f) return;
+    const r = new FileReader();
+    r.onload = () => {
+      try {
+        const parsed = JSON.parse(String(r.result)) as { provision?: unknown; setup?: unknown; migrate?: unknown };
+        const prov = Array.isArray(parsed.provision) ? (parsed.provision as Record<string, unknown>[]) : [];
+        const dotenv = prov.find((p) => p.format === "dotenv") ?? prov[0];
+        setCfg((c) => {
+          const next = { ...c };
+          if (dotenv && dotenv.keys && typeof dotenv.keys === "object") {
+            next.env = Object.entries(dotenv.keys as Record<string, unknown>).map(([k, v]) => ({ id: uid("e"), on: true, key: k, value: String(v) }));
+          }
+          if (Array.isArray(parsed.setup)) {
+            next.setup = (parsed.setup as unknown[]).filter((x) => typeof x === "string").map((cmd) => ({ id: uid("u"), on: true, cmd: cmd as string }));
+          }
+          if (Array.isArray(parsed.migrate) && typeof parsed.migrate[0] === "string") next.migrate = parsed.migrate[0] as string;
+          return next;
+        });
+        flash(`Imported ${f.name}`);
+      } catch {
+        flash(`Couldn't parse ${f.name} — invalid JSON`);
+      }
+    };
+    r.readAsText(f);
+  };
 
   return (
     <>
@@ -309,26 +393,79 @@ function AddScreen({
                       <span className="ln" />
                       <button
                         className="btn sm gh"
-                        onClick={() => setServices((ss) => ss.concat([{ id: uid("s"), on: true, name: "New service", kind: "server", cmd: "npm run dev", port: "" }]))}
+                        onClick={() => {
+                          const id = uid("s");
+                          setServices((ss) => ss.concat([{ id, on: true, name: "", kind: "server", dir: "", script: undefined, cmd: "", port: "" }]));
+                          setEdit(id);
+                        }}
                       >
-                        <Plus size={10} />Add
+                        <Plus size={10} />Add service
                       </button>
                     </div>
                     {services.map((s) => {
                       const Ic = KIND_IC[s.kind];
+                      const open = edit === s.id;
                       return (
-                        <div className={"svcrow " + (s.on ? "on" : "off")} key={s.id}>
-                          <span className="kic"><Ic size={13} /></span>
-                          <span className="bd">
-                            <span className="r1"><span className="nm">{s.name}</span><span className="tag">{s.kind}</span></span>
-                            <span className="cmd"><b>from</b> {s.script ? '"' + s.script + '"' : "manual"} · {s.cmd}</span>
-                          </span>
-                          {s.on ? (
-                            <input className="inp mono pin" value={s.port} placeholder="—" spellCheck={false} onChange={(e) => patch(s.id, { port: e.target.value })} />
-                          ) : (
-                            <span className={"port" + (s.port ? "" : " none")}>{s.port ? ":" + s.port : "no port"}</span>
+                        <div className={"svcitem" + (open ? " open" : "")} key={s.id}>
+                          <div className={"svcrow " + (s.on ? "on" : "off")}>
+                            <span className="kic"><Ic size={13} /></span>
+                            <button className="bd asbtn" onClick={() => setEdit(open ? null : s.id)} title={open ? "Done editing" : "Edit this service"}>
+                              <span className="r1">
+                                <span className="nm">{s.name || "Unnamed service"}</span>
+                                <span className="tag">{s.kind}</span>
+                                <span className="cv"><ChevRight size={11} /></span>
+                              </span>
+                              <span className="cmd">
+                                <b>from</b> {s.script ? '"' + s.script + '"' : "manual"}
+                                {s.dir ? <> · <b>in</b> {s.dir}</> : null} · {s.cmd || "no command yet"}
+                              </span>
+                            </button>
+                            {s.on ? (
+                              <input className="inp mono pin" value={s.port} placeholder="—" spellCheck={false} onChange={(e) => patch(s.id, { port: e.target.value })} />
+                            ) : (
+                              <span className={"port" + (s.port ? "" : " none")}>{s.port ? ":" + s.port : "no port"}</span>
+                            )}
+                            <Chk on={s.on} label={`Run ${s.name || "service"}`} onClick={() => patch(s.id, { on: !s.on })} />
+                          </div>
+                          {open && (
+                            <div className="svcedit">
+                              <label className="fld">
+                                <span>Name</span>
+                                <input
+                                  className="inp"
+                                  autoFocus
+                                  value={s.name}
+                                  placeholder="Frontend dev"
+                                  onChange={(e) => patch(s.id, s.dirEdited ? { name: e.target.value } : { name: e.target.value, dir: slug(e.target.value) })}
+                                />
+                              </label>
+                              <label className="fld">
+                                <span>Kind</span>
+                                <select className="inp sel" value={s.kind} onChange={(e) => patch(s.id, { kind: e.target.value as Kind })}>
+                                  <option value="web">web</option>
+                                  <option value="server">server</option>
+                                  <option value="worker">worker</option>
+                                </select>
+                              </label>
+                              <label className="fld">
+                                <span>Directory</span>
+                                <input className="inp mono" value={s.dir} placeholder="repo root" onChange={(e) => patch(s.id, { dir: e.target.value, dirEdited: true })} />
+                              </label>
+                              <label className="fld">
+                                <span>Port</span>
+                                <input className="inp mono" value={s.port} placeholder="none" onChange={(e) => patch(s.id, { port: e.target.value })} />
+                              </label>
+                              <label className="fld wide">
+                                <span>Command</span>
+                                <input className="inp mono" value={s.cmd} placeholder="npm run dev" onChange={(e) => patch(s.id, { cmd: e.target.value, script: undefined })} />
+                              </label>
+                              <div className="svcedit-f">
+                                <button className="btn sm bad" onClick={() => dropSvc(s.id)}><Trash size={11} />Remove</button>
+                                <span className="sp" />
+                                <button className="btn sm" onClick={() => setEdit(null)}>Done</button>
+                              </div>
+                            </div>
                           )}
-                          <Tgl on={s.on} onClick={() => patch(s.id, { on: !s.on })} />
                         </div>
                       );
                     })}
@@ -366,6 +503,11 @@ function AddScreen({
                       <span className="n">{envOn} env keys · {setupOn} setup steps · db commands found</span>
                     </summary>
                     <div className="advb">
+                      <div className="impline">
+                        <span>Already have a config? Import it instead of re-entering it.</span>
+                        <button className="btn sm" onClick={triggerImport}><Download size={11} />Import .worktreemanager.json</button>
+                        <input ref={fileRef} type="file" accept=".json,application/json" style={{ display: "none" }} onChange={onImportFile} />
+                      </div>
                       <div className="slab" style={{ marginTop: 4 }}>Env written into each worktree's .env<span className="ln" /></div>
                       <div className="kv">
                         {cfg.env.map((e) => (
@@ -385,12 +527,21 @@ function AddScreen({
                               style={{ opacity: e.on ? 1 : 0.5 }}
                               onChange={(ev) => setCfg((c) => ({ ...c, env: c.env.map((x) => (x.id === e.id ? { ...x, value: ev.target.value } : x)) }))}
                             />
-                            <Tgl on={e.on} onClick={() => setCfg((c) => ({ ...c, env: c.env.map((x) => (x.id === e.id ? { ...x, on: !x.on } : x)) }))} />
+                            <Chk on={e.on} label={`Write ${e.key || "env key"}`} onClick={() => setCfg((c) => ({ ...c, env: c.env.map((x) => (x.id === e.id ? { ...x, on: !x.on } : x)) }))} />
                           </div>
                         ))}
                       </div>
 
-                      <div className="slab" style={{ marginTop: 13 }}>Setup, run in order on create<span className="ln" /></div>
+                      <div className="slab" style={{ marginTop: 13 }}>
+                        Setup, run in order on create
+                        <span className="ln" />
+                        <button
+                          className="btn sm gh"
+                          onClick={() => setCfg((c) => ({ ...c, setup: c.setup.concat([{ id: uid("u"), on: true, cmd: "" }]) }))}
+                        >
+                          <Plus size={10} />Add step
+                        </button>
+                      </div>
                       {cfg.setup.map((u, i) => (
                         <div className="stepline" key={u.id}>
                           <span className="n2">{i + 1}</span>
@@ -398,10 +549,14 @@ function AddScreen({
                             className="inp mono"
                             style={{ flex: 1, opacity: u.on ? 1 : 0.5 }}
                             value={u.cmd}
+                            placeholder="npm install"
                             spellCheck={false}
                             onChange={(ev) => setCfg((c) => ({ ...c, setup: c.setup.map((x) => (x.id === u.id ? { ...x, cmd: ev.target.value } : x)) }))}
                           />
-                          <Tgl on={u.on} onClick={() => setCfg((c) => ({ ...c, setup: c.setup.map((x) => (x.id === u.id ? { ...x, on: !x.on } : x)) }))} />
+                          <button className="ico bad" title="Remove step" onClick={() => setCfg((c) => ({ ...c, setup: c.setup.filter((x) => x.id !== u.id) }))}>
+                            <Trash size={11} />
+                          </button>
+                          <Chk on={u.on} label={`Run step ${i + 1}`} onClick={() => setCfg((c) => ({ ...c, setup: c.setup.map((x) => (x.id === u.id ? { ...x, on: !x.on } : x)) }))} />
                         </div>
                       ))}
 
@@ -462,7 +617,6 @@ function Provisioning({ name, steps, onDone, onError, onCancel }: { name: string
       for (let i = 0; i < steps.length; i++) {
         if (cancelled.current) return;
         try {
-          // real work, but with a readable floor so narration doesn't flash past
           const [meta] = await Promise.all([steps[i].run(), delay(460)]);
           if (!alive || cancelled.current) return;
           setMetas((xs) => {
@@ -499,7 +653,6 @@ function Provisioning({ name, steps, onDone, onError, onCancel }: { name: string
             {i < n && metas[i] && <span className="mt">{metas[i]}</span>}
           </div>
         ))}
-        {/* a first run must be escapable while its one long operation runs */}
         <div className="runcancel">
           <button
             className="btn"
@@ -609,7 +762,6 @@ export default function Onboarding({ onClose, onCreateWorktree }: { onClose: () 
       setServices(sv);
       setCfg(cf);
       setPhase("scanning");
-      // a brief, honest beat while we "read" the manifest we just parsed
       setTimeout(() => {
         if (seq === detectSeq.current) setPhase("ready");
       }, 650);
@@ -626,7 +778,7 @@ export default function Onboarding({ onClose, onCreateWorktree }: { onClose: () 
     setDet(null);
     setDetErr(null);
     clearTimeout(debounce.current);
-    ++detectSeq.current; // invalidate any in-flight detect
+    ++detectSeq.current;
     if (!v.trim()) {
       setPhase("idle");
       return;
@@ -639,21 +791,23 @@ export default function Onboarding({ onClose, onCreateWorktree }: { onClose: () 
     if (!hasBackend()) return flash("Browse needs the desktop app");
     const picked = await openDialog({ directory: true, multiple: false, title: "Choose a git repository" });
     if (typeof picked === "string") {
+      setView("add");
       setPath(picked);
       detect(picked);
     }
   }
 
   /* real OS folder drop → the same path field (Tauri v2 webview drag-drop).
+     Active on the empty state too, so "drop anywhere in this window" is true.
      Degrades silently: typing and Browse still work if the event never fires. */
   useEffect(() => {
-    if (view !== "add" || !hasBackend()) return;
+    if ((view !== "add" && view !== "empty") || !hasBackend()) return;
     let un: (() => void) | undefined;
     let webview: ReturnType<typeof getCurrentWebview>;
     try {
       webview = getCurrentWebview();
     } catch {
-      return; // not a real Tauri webview — typing / Browse still work
+      return;
     }
     webview
       .onDragDropEvent((event) => {
@@ -664,6 +818,7 @@ export default function Onboarding({ onClose, onCreateWorktree }: { onClose: () 
           setOver(false);
           const p = pl.paths?.[0];
           if (p) {
+            setView("add");
             setPath(p);
             detect(p);
           }
@@ -688,8 +843,18 @@ export default function Onboarding({ onClose, onCreateWorktree }: { onClose: () 
     const envPairs = cfg.env.filter((e) => e.on && e.key.trim()).map((e) => [e.key, e.value] as [string, string]);
     const setupCmds = cfg.setup.filter((u) => u.on && u.cmd.trim()).map((u) => u.cmd);
 
+    const svcCfg = (): ServiceCfg[] =>
+      on.map((s) => ({
+        id: slug(s.name) || "service",
+        name: s.name,
+        kind: s.kind,
+        command: s.cmd,
+        cwd: s.dir.trim(),
+        basePort: s.port.trim() ? parseInt(s.port, 10) || null : null,
+        env: {},
+      }));
+
     if (!hasBackend()) {
-      // browser preview: narrate the same shape without touching a backend
       const ports = on.map((s) => s.port).filter(Boolean);
       setRunSteps([
         { t: `Registering ${det.name}`, run: async () => "" },
@@ -701,7 +866,6 @@ export default function Onboarding({ onClose, onCreateWorktree }: { onClose: () 
       return;
     }
 
-    // shared context threaded across the real steps
     const ctx: { repo: RepoCfg | null } = { repo: null };
     const steps: RunStep[] = [
       {
@@ -723,15 +887,7 @@ export default function Onboarding({ onClose, onCreateWorktree }: { onClose: () 
           const settings = await ipc.getSettings();
           const repo = settings.repos.find((r) => r.path === det.top);
           if (!repo) throw new Error("repo not found");
-          repo.services = on.map((s) => ({
-            id: s.name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") || "service",
-            name: s.name,
-            kind: s.kind,
-            command: s.cmd,
-            cwd: "",
-            basePort: s.port.trim() ? parseInt(s.port, 10) || null : null,
-            env: {},
-          })) as ServiceCfg[];
+          repo.services = svcCfg();
           repo.resetDb = cfg.resetDb;
           repo.migrateDb = cfg.migrate;
           if (cfg.worktreeDir.trim()) repo.worktreeDir = cfg.worktreeDir.trim();
@@ -783,7 +939,6 @@ export default function Onboarding({ onClose, onCreateWorktree }: { onClose: () 
     setCfg({ resetDb: "", migrate: "", worktreeDir: "", env: [], setup: [] });
   }
 
-  // keyboard: ⌘N opens add from empty; ⌘⏎ adds when ready; Esc skips a step
   useEffect(() => {
     const k = (e: KeyboardEvent) => {
       const mod = e.metaKey || e.ctrlKey;
@@ -816,7 +971,7 @@ export default function Onboarding({ onClose, onCreateWorktree }: { onClose: () 
         {view === "add" && <button className="ob-skip" onClick={() => setView("empty")}>Back</button>}
       </div>
 
-      {view === "empty" && <EmptyState onAdd={() => setView("add")} onBrowse={browse} />}
+      {view === "empty" && <EmptyState onAdd={() => setView("add")} />}
       {view === "add" && (
         <AddScreen
           det={det}
@@ -832,6 +987,7 @@ export default function Onboarding({ onClose, onCreateWorktree }: { onClose: () 
           onStack={setStack}
           setServices={setServices}
           setCfg={setCfg}
+          flash={flash}
           onSkip={() => setView("empty")}
           onDone={startProvision}
         />

--- a/src/onboarding/Onboarding.tsx
+++ b/src/onboarding/Onboarding.tsx
@@ -1,39 +1,36 @@
-// First-run onboarding wizard — 5 steps (Repository → Stack → Services →
-// Commands → Review) + a success overlay. Ported from the v0.4 design handoff
-// (Worktree Manager Onboarding.html) and wired to real IPC: detect_repo reads
-// the repo's package.json scripts + git, and on finish we add_repo → save the
-// service/command config to Settings + the repo's .worktreemanager.json.
+// First run — one adaptive screen, not five steps. Ported from the redesign
+// handoff (Canopy Onboarding.html / cxo-onboard.jsx).
+//
+// The shipped wizard walked Repository → Stack → Services → Commands → Review.
+// Two of those didn't earn a screen: "Stack" asked you to confirm something
+// already read from the repo's manifests, and "Review" restated the screens
+// before it. Meanwhile the real value — detect_repo mapping package.json
+// scripts to services — sat behind step 3. So now: an empty state that finally
+// exists, one adaptive add screen (detection runs as you type; the stack is a
+// chip; the derivation is shown, not asserted), honest provisioning narration
+// over the real IPC calls, and a "ready" screen that ends on the next action.
+//
+// Backend honesty notes:
+// • The empty state's "recently opened" list is omitted — Canopy has no MRU
+//   store, so there is nothing real to list. TODO: file an issue + wire it.
+// • Env template values use ${WT_SERVER_PORT} / ${WT_DB_NAME}, the variables the
+//   Rust setup runner actually interpolates (state.rs:142, setup.rs). The
+//   handoff/SettingsView names ${WT_SERVICE_PORT} / ${INT_DB_NAME} are NOT
+//   substituted by the backend and would land in .env as dead literals.
 import { useEffect, useRef, useState } from "react";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
 import "../styles/onboarding.css";
-import { errText, hasBackend, ipc, type ProvisionEntry, type RepoDetection, type ServiceCfg } from "../ipc";
+import { errText, hasBackend, ipc, type ProvisionEntry, type RepoCfg, type RepoDetection, type ServiceCfg } from "../ipc";
 import { useStore } from "../store";
-import { Check, Cog, Fork, Globe, Package, Server, Spinner } from "../icons";
+import { Browser, Check, ChevRight, Chevron, Cube, Doc, Fork, Plus, Server, Spinner } from "../icons";
 
-/* ── inline icons the shared set doesn't have ─────────────────────── */
+/* the one folder glyph the shared set doesn't carry */
 const Folder = ({ size = 14 }: { size?: number }) => (
   <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <path d="M4 5h5l2 2h9a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1Z" />
   </svg>
 );
-const ArrowRight = ({ size = 14 }: { size?: number }) => (
-  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <path d="M5 12h14" /><path d="M13 6l6 6-6 6" />
-  </svg>
-);
-const ArrowLeft = ({ size = 14 }: { size?: number }) => (
-  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <path d="M19 12H5" /><path d="M11 18l-6-6 6-6" />
-  </svg>
-);
-
-const STEPS = [
-  { t: "Repository", s: "Locate the repo" },
-  { t: "Stack", s: "Detect the framework" },
-  { t: "Services", s: "From package.json" },
-  { t: "Commands", s: "DB, env & setup" },
-  { t: "Review", s: "Confirm & add" },
-];
 
 const STACKS = [
   { id: "node", mono: "JS", name: "Node.js", desc: "package.json" },
@@ -67,14 +64,15 @@ interface Cfg {
 let _uid = 0;
 const uid = (p: string) => p + ++_uid;
 const cap = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
-const KIND_IC: Record<Kind, typeof Server> = { web: Globe, server: Server, worker: Cog };
+const KIND_IC: Record<Kind, typeof Server> = { web: Browser, server: Server, worker: Cube };
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
-/** Map detected package.json scripts + stack into service/command suggestions. */
+/** Map detected package.json scripts + stack into service/command suggestions.
+ * Port-derivation and env-template names mirror the Rust setup runner. */
 function derive(det: RepoDetection): { services: WizSvc[]; cfg: Cfg } {
   const scripts = det.scripts ?? [];
   const find = (re: RegExp) => scripts.find((s) => re.test(s.name));
 
-  // long-running candidates → services
   const services: WizSvc[] = [];
   let portBase = 3000;
   for (const { name, command } of scripts) {
@@ -95,7 +93,6 @@ function derive(det: RepoDetection): { services: WizSvc[]; cfg: Cfg } {
   if (!services.length) {
     services.push({ id: uid("s"), on: true, name: "Dev", kind: "server", cmd: "npm run dev", port: "3000" });
   }
-  // a build/compile script → an optional worker
   const build = find(/^(build|compile|plugins?:build)$/i);
   if (build) {
     services.push({ id: uid("s"), on: false, name: cap(build.name.replace(/[:_-]/g, " ")), kind: "worker", script: build.name, cmd: build.command, port: "" });
@@ -123,586 +120,749 @@ function derive(det: RepoDetection): { services: WizSvc[]; cfg: Cfg } {
   return { services, cfg };
 }
 
-function Switch({ on, onClick }: { on: boolean; onClick: () => void }) {
-  return <button className={"sw" + (on ? " on" : "")} onClick={onClick} aria-pressed={on} />;
+function Tgl({ on, onClick }: { on: boolean; onClick: () => void }) {
+  return <button className={"tgl" + (on ? " on" : "")} role="switch" aria-checked={on} onClick={onClick}><i /></button>;
 }
+
+/* ── the stack: a chip, not a step ────────────────────────────────── */
+function StackChip({ value, detected, onPick }: { value: string; detected?: string; onPick: (id: string) => void }) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLSpanElement>(null);
+  useEffect(() => {
+    if (!open) return;
+    const d = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", d);
+    return () => document.removeEventListener("mousedown", d);
+  }, [open]);
+  const s = STACKS.find((x) => x.id === value) || STACKS[7];
+  return (
+    <span className="stackwrap" ref={ref}>
+      <button className="stackchip" onClick={() => setOpen((o) => !o)} title="Change the detected stack">
+        <span className="mn">{s.mono}</span>
+        {s.name}
+        <Chevron size={10} />
+      </button>
+      {open && (
+        <div className="stackmenu" role="listbox">
+          {STACKS.map((x) => (
+            <button key={x.id} className={"smi" + (x.id === value ? " on" : "")} role="option" aria-selected={x.id === value} onClick={() => { onPick(x.id); setOpen(false); }}>
+              <span className="mn">{x.mono}</span>
+              <span className="nm">{x.name}</span>
+              {x.id === detected ? <span className="det">detected</span> : <span className="ds">{x.desc}</span>}
+            </button>
+          ))}
+        </div>
+      )}
+    </span>
+  );
+}
+
+/* ── A · empty state — first launch used to say nothing ───────────── */
+function EmptyState({ onAdd, onBrowse }: { onAdd: () => void; onBrowse: () => void }) {
+  return (
+    <div className="emptywrap">
+      <div className="emptycard">
+        <div className="emptyring"><Fork size={26} /></div>
+        <h1>No repositories yet</h1>
+        <p>Canopy runs each branch as its own worktree — separate checkout, separate services, separate database. Point it at a repo and it reads your scripts to work out what to run.</p>
+        <div className="emptyacts">
+          <button className="btn pri lg" onClick={onAdd}><Plus size={13} />Add a repository<span className="k">⌘N</span></button>
+          <button className="btn lg" onClick={onBrowse}><Folder size={13} />Browse…</button>
+        </div>
+        <div className="whatnext">
+          <div className="slab">What happens next</div>
+          {[
+            ["Canopy reads the repo", "git remotes, branches, and the scripts in your manifest."],
+            ["It proposes what to run", "long-running scripts become services, with ports derived per worktree."],
+            ["You create a worktree", "a branch checked out, provisioned and running in one action."],
+          ].map(([t, d], i) => (
+            <div className="wn" key={t}>
+              <span className="n">{i + 1}</span>
+              <span className="t"><b>{t}</b><span>{d}</span></span>
+            </div>
+          ))}
+        </div>
+        {/* The design shows a "Recently opened" list here. Canopy has no MRU
+            store, so there is nothing real to list — omitted rather than
+            fabricated. TODO: file an issue to persist opened-repo history. */}
+      </div>
+    </div>
+  );
+}
+
+/* ── B · one adaptive add screen ──────────────────────────────────── */
+type Phase = "idle" | "detecting" | "scanning" | "ready";
+function AddScreen({
+  det,
+  detErr,
+  phase,
+  path,
+  over,
+  stack,
+  services,
+  cfg,
+  onPath,
+  onBrowse,
+  onStack,
+  setServices,
+  setCfg,
+  onSkip,
+  onDone,
+}: {
+  det: RepoDetection | null;
+  detErr: string | null;
+  phase: Phase;
+  path: string;
+  over: boolean;
+  stack: string;
+  services: WizSvc[];
+  cfg: Cfg;
+  onPath: (v: string) => void;
+  onBrowse: () => void;
+  onStack: (id: string) => void;
+  setServices: React.Dispatch<React.SetStateAction<WizSvc[]>>;
+  setCfg: React.Dispatch<React.SetStateAction<Cfg>>;
+  onSkip: () => void;
+  onDone: () => void;
+}) {
+  const on = services.filter((s) => s.on);
+  const hits = new Set<string>();
+  services.forEach((s) => s.on && s.script && hits.add(s.script));
+  [cfg.resetDb, cfg.migrate].forEach((c) => {
+    const m = c.match(/npm run (\S+)/);
+    if (m) hits.add(m[1]);
+  });
+  const patch = (id: string, p: Partial<WizSvc>) => setServices((ss) => ss.map((s) => (s.id === id ? { ...s, ...p } : s)));
+  const envOn = cfg.env.filter((e) => e.on).length;
+  const setupOn = cfg.setup.filter((u) => u.on).length;
+
+  return (
+    <>
+      <div className="obody">
+        <div className="obinner">
+          <div className="ohead">
+            <h1>Add a repository</h1>
+            <p>Canopy verifies the repo, reads its scripts, and proposes what to run per worktree. Everything here is editable later in Settings.</p>
+          </div>
+
+          {/* the drop target doubles as the path field */}
+          <div className={"drop" + (over ? " over" : "") + (path ? " filled" : "")}>
+            <div className="droprow">
+              <span className="ic"><Folder size={14} /></span>
+              <input
+                className="inp mono"
+                style={{ flex: 1 }}
+                value={path}
+                spellCheck={false}
+                placeholder="~/code/my-app  ·  or drop a folder here"
+                onChange={(e) => onPath(e.target.value)}
+              />
+              <button className="btn" onClick={onBrowse}><Folder size={12} />Browse…</button>
+            </div>
+            {!path && <div className="drophint">Drop a git repository, or <b>paste its path</b>.</div>}
+          </div>
+
+          {phase === "detecting" && (
+            <div className="detect">
+              <div className="scanning" style={{ borderTop: 0 }}>
+                <span className="sp2 spin"><Spinner size={16} /></span>
+                Verifying the repository…
+              </div>
+            </div>
+          )}
+
+          {detErr && phase === "idle" && path.trim() !== "" && (
+            <div className="detect">
+              <div className="scanning" style={{ borderTop: 0, color: "var(--red-text)" }}>{detErr}</div>
+            </div>
+          )}
+
+          {(phase === "scanning" || phase === "ready") && det && (
+            <div className="detect">
+              <div className="dtop">
+                <span className="badge"><Fork size={17} /></span>
+                <span className="info">
+                  <h3>{det.name}</h3>
+                  <span className="meta">
+                    <span><span className="k">path</span> {det.top}</span>
+                    {det.branch && <span><span className="k">branch</span> {det.branch}</span>}
+                  </span>
+                </span>
+                {/* was step 2 of 5; now a chip, already answered */}
+                <StackChip value={stack} detected={det.stack} onPick={onStack} />
+                <span className="okchip"><Check size={11} />Git repo</span>
+              </div>
+
+              {phase === "scanning" ? (
+                <div className="scanning">
+                  <span className="sp2 spin"><Spinner size={16} /></span>
+                  Reading package.json and workspaces…
+                </div>
+              ) : (
+                <>
+                  <div className="dsec">
+                    <div className="slab">
+                      Services Canopy will run
+                      <span className="n">{on.length} of {services.length} on</span>
+                      <span className="ln" />
+                      <button
+                        className="btn sm gh"
+                        onClick={() => setServices((ss) => ss.concat([{ id: uid("s"), on: true, name: "New service", kind: "server", cmd: "npm run dev", port: "" }]))}
+                      >
+                        <Plus size={10} />Add
+                      </button>
+                    </div>
+                    {services.map((s) => {
+                      const Ic = KIND_IC[s.kind];
+                      return (
+                        <div className={"svcrow " + (s.on ? "on" : "off")} key={s.id}>
+                          <span className="kic"><Ic size={13} /></span>
+                          <span className="bd">
+                            <span className="r1"><span className="nm">{s.name}</span><span className="tag">{s.kind}</span></span>
+                            <span className="cmd"><b>from</b> {s.script ? '"' + s.script + '"' : "manual"} · {s.cmd}</span>
+                          </span>
+                          {s.on ? (
+                            <input className="inp mono pin" value={s.port} placeholder="—" spellCheck={false} onChange={(e) => patch(s.id, { port: e.target.value })} />
+                          ) : (
+                            <span className={"port" + (s.port ? "" : " none")}>{s.port ? ":" + s.port : "no port"}</span>
+                          )}
+                          <Tgl on={s.on} onClick={() => patch(s.id, { on: !s.on })} />
+                        </div>
+                      );
+                    })}
+                    <div className="hint">Ports are a base — each worktree gets <code>base + index × 10</code>, so five branches never collide.</div>
+                  </div>
+
+                  {/* the derivation, shown rather than asserted */}
+                  {det.scripts.length > 0 && (
+                    <div className="dsec">
+                      <div className="slab">Where that came from<span className="ln" /></div>
+                      <div className="peek">
+                        <div className="bar"><Doc size={11} />package.json — scripts</div>
+                        <div className="bd">
+                          <div className="ln"><span className="pun">{"{"}</span></div>
+                          {det.scripts.map((s, i) => (
+                            <div className="ln" key={s.name}>
+                              {"  "}
+                              <span className={"key" + (hits.has(s.name) ? " hit" : "")}>"{s.name}"</span>
+                              <span className="pun">: </span>
+                              <span className="str">"{s.command}"</span>
+                              <span className="pun">{i < det.scripts.length - 1 ? "," : ""}</span>
+                            </div>
+                          ))}
+                          <div className="ln"><span className="pun">{"}"}</span></div>
+                        </div>
+                      </div>
+                    </div>
+                  )}
+
+                  {/* pre-filled correctly, so collapsed — was a whole step */}
+                  <details className="adv">
+                    <summary>
+                      <span className="cv"><ChevRight size={11} /></span>
+                      Provisioning and setup
+                      <span className="n">{envOn} env keys · {setupOn} setup steps · db commands found</span>
+                    </summary>
+                    <div className="advb">
+                      <div className="slab" style={{ marginTop: 4 }}>Env written into each worktree's .env<span className="ln" /></div>
+                      <div className="kv">
+                        {cfg.env.map((e) => (
+                          <div key={e.id} style={{ display: "contents" }}>
+                            <input
+                              className="inp mono"
+                              value={e.key}
+                              spellCheck={false}
+                              style={{ opacity: e.on ? 1 : 0.5 }}
+                              onChange={(ev) => setCfg((c) => ({ ...c, env: c.env.map((x) => (x.id === e.id ? { ...x, key: ev.target.value } : x)) }))}
+                            />
+                            <span className="eq">=</span>
+                            <input
+                              className="inp mono"
+                              value={e.value}
+                              spellCheck={false}
+                              style={{ opacity: e.on ? 1 : 0.5 }}
+                              onChange={(ev) => setCfg((c) => ({ ...c, env: c.env.map((x) => (x.id === e.id ? { ...x, value: ev.target.value } : x)) }))}
+                            />
+                            <Tgl on={e.on} onClick={() => setCfg((c) => ({ ...c, env: c.env.map((x) => (x.id === e.id ? { ...x, on: !x.on } : x)) }))} />
+                          </div>
+                        ))}
+                      </div>
+
+                      <div className="slab" style={{ marginTop: 13 }}>Setup, run in order on create<span className="ln" /></div>
+                      {cfg.setup.map((u, i) => (
+                        <div className="stepline" key={u.id}>
+                          <span className="n2">{i + 1}</span>
+                          <input
+                            className="inp mono"
+                            style={{ flex: 1, opacity: u.on ? 1 : 0.5 }}
+                            value={u.cmd}
+                            spellCheck={false}
+                            onChange={(ev) => setCfg((c) => ({ ...c, setup: c.setup.map((x) => (x.id === u.id ? { ...x, cmd: ev.target.value } : x)) }))}
+                          />
+                          <Tgl on={u.on} onClick={() => setCfg((c) => ({ ...c, setup: c.setup.map((x) => (x.id === u.id ? { ...x, on: !x.on } : x)) }))} />
+                        </div>
+                      ))}
+
+                      <div className="slab" style={{ marginTop: 13 }}>Database<span className="n">from db:* scripts</span><span className="ln" /></div>
+                      <div className="kv">
+                        <span style={{ font: "var(--fs-small) var(--sans)", color: "var(--text-tertiary)" }}>Migrate</span>
+                        <span />
+                        <input className="inp mono" value={cfg.migrate} spellCheck={false} onChange={(e) => setCfg((c) => ({ ...c, migrate: e.target.value }))} />
+                        <span />
+                        <span style={{ font: "var(--fs-small) var(--sans)", color: "var(--text-tertiary)" }}>Reset</span>
+                        <span />
+                        <input className="inp mono" value={cfg.resetDb} spellCheck={false} onChange={(e) => setCfg((c) => ({ ...c, resetDb: e.target.value }))} />
+                        <span />
+                        <span style={{ font: "var(--fs-small) var(--sans)", color: "var(--text-tertiary)" }}>Worktrees in</span>
+                        <span />
+                        <input className="inp mono" value={cfg.worktreeDir} spellCheck={false} onChange={(e) => setCfg((c) => ({ ...c, worktreeDir: e.target.value }))} />
+                        <span />
+                      </div>
+                    </div>
+                  </details>
+                </>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* one action. no step dots, because there are no steps to count. */}
+      <div className="ofoot">
+        <button className="ob-skip" onClick={onSkip}>Skip for now</button>
+        <span className="sp" />
+        {phase === "ready" && det && (
+          <span className="sum">
+            <b>{det.name}</b> · {on.length} {on.length === 1 ? "service" : "services"} · {setupOn} setup steps
+          </span>
+        )}
+        <button className="btn pri" disabled={phase !== "ready"} onClick={onDone}>
+          <Check size={12} />Add repository<span className="k">⌘⏎</span>
+        </button>
+      </div>
+    </>
+  );
+}
+
+/* ── C · provisioning — narrates the real work ────────────────────── */
+interface RunStep {
+  t: string;
+  run: () => Promise<string>;
+}
+function Provisioning({ name, steps, onDone, onError, onCancel }: { name: string; steps: RunStep[]; onDone: () => void; onError: (msg: string) => void; onCancel: () => void }) {
+  const [n, setN] = useState(0);
+  const [metas, setMetas] = useState<string[]>([]);
+  const cancelled = useRef(false);
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      for (let i = 0; i < steps.length; i++) {
+        if (cancelled.current) return;
+        try {
+          // real work, but with a readable floor so narration doesn't flash past
+          const [meta] = await Promise.all([steps[i].run(), delay(460)]);
+          if (!alive || cancelled.current) return;
+          setMetas((xs) => {
+            const c = [...xs];
+            c[i] = meta;
+            return c;
+          });
+          setN(i + 1);
+        } catch (e) {
+          if (alive && !cancelled.current) onError(String(e));
+          return;
+        }
+      }
+      if (alive && !cancelled.current) {
+        await delay(300);
+        if (alive && !cancelled.current) onDone();
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div className="runwrap">
+      <div className="runcard">
+        <h2>Setting up {name}</h2>
+        <p>Nothing is cloned or installed yet — that happens per worktree.</p>
+        {steps.map((s, i) => (
+          <div className={"stp " + (i < n ? "done" : i === n ? "act" : "pend")} key={s.t}>
+            <span className="bl">{i < n ? "✓" : i === n ? <span className="spin"><Spinner size={11} /></span> : "○"}</span>
+            <span className="tx">{s.t}</span>
+            {i < n && metas[i] && <span className="mt">{metas[i]}</span>}
+          </div>
+        ))}
+        {/* a first run must be escapable while its one long operation runs */}
+        <div className="runcancel">
+          <button
+            className="btn"
+            onClick={() => {
+              cancelled.current = true;
+              onCancel();
+            }}
+          >
+            Cancel setup
+          </button>
+          <span>Nothing is cloned or installed — you can start over.</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ── D · ready — ends on the next action, not a dead end ──────────── */
+function Ready({ det, services, cfg, onCreate, onGoToCanopy, onRestart }: { det: RepoDetection; services: WizSvc[]; cfg: Cfg; onCreate: () => void; onGoToCanopy: () => void; onRestart: () => void }) {
+  const on = services.filter((s) => s.on);
+  const svcSummary = on.map((s) => (s.port ? `${s.name} :${s.port}` : s.name)).join(" · ") || "none";
+  const envOn = cfg.env.filter((e) => e.on).length;
+  const setupOn = cfg.setup.filter((u) => u.on).length;
+  return (
+    <div className="runwrap">
+      <div className="emptycard">
+        <div className="donering"><Check size={26} /></div>
+        <h1>{det.name} is ready</h1>
+        <p>Canopy is watching this repo. Create a worktree to check out a branch with its own services, ports and database.</p>
+        <div className="doneacts">
+          <button className="btn pri lg" onClick={onCreate}><Plus size={13} />Create first worktree<span className="k">⌘N</span></button>
+          <button className="btn lg" onClick={onGoToCanopy}>Go to Canopy</button>
+        </div>
+        <div className="donefacts">
+          <div className="df"><div className="l">Services</div><div className="v">{svcSummary}</div></div>
+          <div className="df"><div className="l">Worktrees in</div><div className="v">{cfg.worktreeDir || "—"}</div></div>
+          <div className="df"><div className="l">On create</div><div className="v">{envOn} env keys · {setupOn} setup steps</div></div>
+          <div className="df"><div className="l">Database</div><div className="v">one per worktree · <em>${"{WT_DB_NAME}"}</em></div></div>
+        </div>
+        <div className="hint" style={{ textAlign: "center", marginTop: 16 }}>
+          Change any of this in Settings → <span style={{ color: "var(--text-secondary)" }}>{det.name}</span>.{" "}
+          <a onClick={(e) => { e.preventDefault(); onRestart(); }}>Replay this flow</a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ── shell ────────────────────────────────────────────────────────── */
+type View = "empty" | "add" | "run" | "done";
 
 export default function Onboarding({ onClose, onCreateWorktree }: { onClose: () => void; onCreateWorktree: () => void }) {
   const showToast = useStore((s) => s.showToast);
   const select = useStore((s) => s.select);
-  const [step, setStep] = useState(0);
+
+  const [view, setView] = useState<View>("empty");
   const [path, setPath] = useState("");
   const [det, setDet] = useState<RepoDetection | null>(null);
-  const [detecting, setDetecting] = useState(false);
   const [detErr, setDetErr] = useState<string | null>(null);
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [over, setOver] = useState(false);
   const [stack, setStack] = useState("node");
   const [services, setServices] = useState<WizSvc[]>([]);
   const [cfg, setCfg] = useState<Cfg>({ resetDb: "", migrate: "", worktreeDir: "", env: [], setup: [] });
-  const [scanned, setScanned] = useState(false);
-  const [scanning, setScanning] = useState(false);
-  const [busy, setBusy] = useState(false);
-  const [done, setDone] = useState(false);
-  const scrollRef = useRef<HTMLDivElement>(null);
+  const [runSteps, setRunSteps] = useState<RunStep[]>([]);
+  const [toast, setToast] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (scrollRef.current) scrollRef.current.scrollTop = 0;
-  }, [step]);
+  const detectSeq = useRef(0);
+  const debounce = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const toastTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
-  // brief "scanning" animation the first time we reach the Services step
-  useEffect(() => {
-    if (step === 2 && !scanned) {
-      setScanning(true);
-      const id = setTimeout(() => {
-        setScanning(false);
-        setScanned(true);
-      }, 900);
-      return () => clearTimeout(id);
-    }
-  }, [step, scanned]);
+  const flash = (m: string) => {
+    setToast(m);
+    clearTimeout(toastTimer.current);
+    toastTimer.current = setTimeout(() => setToast(null), 2000);
+  };
 
-  async function runDetect(p: string) {
+  useEffect(() => () => {
+    clearTimeout(debounce.current);
+    clearTimeout(toastTimer.current);
+  }, []);
+
+  /* Detection runs as you type — the shipped version waited for blur, so a
+     pasted path did nothing until you clicked away. */
+  async function detect(p: string) {
     const trimmed = p.trim();
-    if (!trimmed || !hasBackend()) {
-      if (!hasBackend()) setDetErr("Detection needs the desktop app");
+    if (!trimmed) {
+      setPhase("idle");
+      setDet(null);
+      setDetErr(null);
       return;
     }
-    setDetecting(true);
+    if (!hasBackend()) {
+      setDetErr("Detection needs the desktop app");
+      setPhase("idle");
+      return;
+    }
+    const seq = ++detectSeq.current;
+    setPhase("detecting");
     setDetErr(null);
     try {
       const d = await ipc.detectRepo(trimmed);
+      if (seq !== detectSeq.current) return; // a newer keystroke superseded this
       setDet(d);
       setStack(d.stack || "other");
       const { services: sv, cfg: cf } = derive(d);
       setServices(sv);
       setCfg(cf);
-      setScanned(false);
+      setPhase("scanning");
+      // a brief, honest beat while we "read" the manifest we just parsed
+      setTimeout(() => {
+        if (seq === detectSeq.current) setPhase("ready");
+      }, 650);
     } catch (e) {
+      if (seq !== detectSeq.current) return;
       setDet(null);
       setDetErr(errText(e));
-    } finally {
-      setDetecting(false);
+      setPhase("idle");
     }
+  }
+
+  function onPath(v: string) {
+    setPath(v);
+    setDet(null);
+    setDetErr(null);
+    clearTimeout(debounce.current);
+    ++detectSeq.current; // invalidate any in-flight detect
+    if (!v.trim()) {
+      setPhase("idle");
+      return;
+    }
+    setPhase("detecting");
+    debounce.current = setTimeout(() => detect(v), 450);
   }
 
   async function browse() {
-    if (!hasBackend()) return showToast("Browse needs the desktop app");
+    if (!hasBackend()) return flash("Browse needs the desktop app");
     const picked = await openDialog({ directory: true, multiple: false, title: "Choose a git repository" });
     if (typeof picked === "string") {
       setPath(picked);
-      runDetect(picked);
+      detect(picked);
     }
   }
 
-  async function finish() {
-    if (!det || busy) return;
+  /* real OS folder drop → the same path field (Tauri v2 webview drag-drop).
+     Degrades silently: typing and Browse still work if the event never fires. */
+  useEffect(() => {
+    if (view !== "add" || !hasBackend()) return;
+    let un: (() => void) | undefined;
+    let webview: ReturnType<typeof getCurrentWebview>;
+    try {
+      webview = getCurrentWebview();
+    } catch {
+      return; // not a real Tauri webview — typing / Browse still work
+    }
+    webview
+      .onDragDropEvent((event) => {
+        const pl = event.payload;
+        if (pl.type === "over" || pl.type === "enter") setOver(true);
+        else if (pl.type === "leave") setOver(false);
+        else if (pl.type === "drop") {
+          setOver(false);
+          const p = pl.paths?.[0];
+          if (p) {
+            setPath(p);
+            detect(p);
+          }
+        }
+      })
+      .then((f) => {
+        un = f;
+      })
+      .catch(() => {});
+    return () => {
+      un?.();
+      setOver(false);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [view]);
+
+  /* Build the provisioning steps, each wired to a real IPC call so the
+     narration reports what actually happened, not a canned script. */
+  function startProvision() {
+    if (!det) return;
+    const on = services.filter((s) => s.on);
+    const envPairs = cfg.env.filter((e) => e.on && e.key.trim()).map((e) => [e.key, e.value] as [string, string]);
+    const setupCmds = cfg.setup.filter((u) => u.on && u.cmd.trim()).map((u) => u.cmd);
+
     if (!hasBackend()) {
-      setDone(true);
+      // browser preview: narrate the same shape without touching a backend
+      const ports = on.map((s) => s.port).filter(Boolean);
+      setRunSteps([
+        { t: `Registering ${det.name}`, run: async () => "" },
+        { t: `Saving ${on.length} ${on.length === 1 ? "service" : "services"}`, run: async () => (ports.length ? `ports ${ports.join(", ")}` : "") },
+        { t: "Writing .worktreemanager.json", run: async () => `${envPairs.length} env ${envPairs.length === 1 ? "key" : "keys"}` },
+        { t: "Reading branches", run: async () => "preview" },
+      ]);
+      setView("run");
       return;
     }
-    setBusy(true);
-    try {
-      // register the repo (idempotent — ignore "already registered")
-      await ipc.addRepo(det.top).catch((e) => {
-        if (!errText(e).toLowerCase().includes("already")) throw e;
-      });
-      const settings = await ipc.getSettings();
-      const repo = settings.repos.find((r) => r.path === det.top);
-      if (!repo) throw new Error("repo not found after add");
 
-      const svcCfgs: ServiceCfg[] = services
-        .filter((s) => s.on)
-        .map((s) => ({
-          id: s.name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") || "service",
-          name: s.name,
-          kind: s.kind,
-          command: s.cmd,
-          cwd: "",
-          basePort: s.port.trim() ? parseInt(s.port, 10) || null : null,
-          env: {},
-        }));
-
-      repo.services = svcCfgs;
-      repo.resetDb = cfg.resetDb;
-      repo.migrateDb = cfg.migrate;
-      if (cfg.worktreeDir.trim()) repo.worktreeDir = cfg.worktreeDir.trim();
-      await ipc.saveSettings(settings);
-
-      // repo provisioning file (.worktreemanager.json): the root .env overrides
-      // become a single dotenv "provision" entry; plus the setup commands.
-      const envPairs = cfg.env.filter((e) => e.on && e.key.trim()).map((e) => [e.key, e.value] as [string, string]);
-      const setupCmds = cfg.setup.filter((u) => u.on && u.cmd.trim()).map((u) => u.cmd);
-      const provision: ProvisionEntry[] = envPairs.length
-        ? [{ path: ".env", format: "dotenv", from: "", interpolate: false, keys: envPairs }]
-        : [];
-      await ipc.saveRepoConfig(repo.id, provision, setupCmds);
-
-      setDone(true);
-    } catch (e) {
-      showToast(`Couldn't add repo — ${e}`);
-    } finally {
-      setBusy(false);
-    }
+    // shared context threaded across the real steps
+    const ctx: { repo: RepoCfg | null } = { repo: null };
+    const steps: RunStep[] = [
+      {
+        t: `Registering ${det.name}`,
+        run: async () => {
+          await ipc.addRepo(det.top).catch((e) => {
+            if (!String(e).toLowerCase().includes("already")) throw e;
+          });
+          const settings = await ipc.getSettings();
+          const repo = settings.repos.find((r) => r.path === det.top);
+          if (!repo) throw new Error("repo not found after add");
+          ctx.repo = repo;
+          return "";
+        },
+      },
+      {
+        t: `Saving ${on.length} ${on.length === 1 ? "service" : "services"}`,
+        run: async () => {
+          const settings = await ipc.getSettings();
+          const repo = settings.repos.find((r) => r.path === det.top);
+          if (!repo) throw new Error("repo not found");
+          repo.services = on.map((s) => ({
+            id: s.name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") || "service",
+            name: s.name,
+            kind: s.kind,
+            command: s.cmd,
+            cwd: "",
+            basePort: s.port.trim() ? parseInt(s.port, 10) || null : null,
+            env: {},
+          })) as ServiceCfg[];
+          repo.resetDb = cfg.resetDb;
+          repo.migrateDb = cfg.migrate;
+          if (cfg.worktreeDir.trim()) repo.worktreeDir = cfg.worktreeDir.trim();
+          await ipc.saveSettings(settings);
+          ctx.repo = repo;
+          const ports = on.map((s) => s.port.trim()).filter(Boolean);
+          return ports.length ? `ports ${ports.join(", ")}` : "";
+        },
+      },
+      {
+        t: "Writing .worktreemanager.json",
+        run: async () => {
+          if (!ctx.repo) throw new Error("repo not resolved");
+          const provision: ProvisionEntry[] = envPairs.length ? [{ path: ".env", format: "dotenv", from: "", interpolate: false, keys: envPairs }] : [];
+          await ipc.saveRepoConfig(ctx.repo.id, provision, setupCmds);
+          return `${envPairs.length} env ${envPairs.length === 1 ? "key" : "keys"} · ${setupCmds.length} setup`;
+        },
+      },
+      {
+        t: "Reading branches",
+        run: async () => {
+          if (!ctx.repo) return "";
+          try {
+            const b = await ipc.listBranches(ctx.repo.id);
+            const n = b.local.length + b.remote.length;
+            return `${n} ${n === 1 ? "branch" : "branches"}`;
+          } catch {
+            return "";
+          }
+        },
+      },
+    ];
+    setRunSteps(steps);
+    setView("run");
   }
 
-  const canNext = step === 0 ? !!det : true;
-  const next = () => (step < 4 ? setStep(step + 1) : finish());
-  const back = () => setStep(Math.max(0, step - 1));
+  function goToCanopy() {
+    if (det) select(det.top);
+    onClose();
+  }
 
-  const hitNames = new Set<string>();
-  services.forEach((s) => s.script && hitNames.add(s.script));
-  [cfg.resetDb, cfg.migrate].forEach((c) => {
-    const m = c.match(/npm run (\S+)/);
-    if (m) hitNames.add(m[1]);
+  function restart() {
+    setView("empty");
+    setPath("");
+    setDet(null);
+    setDetErr(null);
+    setPhase("idle");
+    setServices([]);
+    setCfg({ resetDb: "", migrate: "", worktreeDir: "", env: [], setup: [] });
+  }
+
+  // keyboard: ⌘N opens add from empty; ⌘⏎ adds when ready; Esc skips a step
+  useEffect(() => {
+    const k = (e: KeyboardEvent) => {
+      const mod = e.metaKey || e.ctrlKey;
+      if (mod && e.key.toLowerCase() === "n" && view === "empty") {
+        e.preventDefault();
+        setView("add");
+      } else if (mod && e.key === "Enter" && view === "add" && phase === "ready") {
+        e.preventDefault();
+        startProvision();
+      } else if (e.key === "Escape" && (view === "empty" || view === "add")) {
+        e.preventDefault();
+        view === "empty" ? onClose() : setView("empty");
+      }
+    };
+    document.addEventListener("keydown", k);
+    return () => document.removeEventListener("keydown", k);
   });
+
+  const title = view === "empty" || view === "done" ? "Canopy" : "Canopy — Add repository";
 
   return (
     <div className="ob-root">
       <div className="ob-tb" data-tauri-drag-region>
         <div className="ob-tb-title" data-tauri-drag-region>
-          <span className="fork">
-            <Fork size={15} />
-          </span>
-          Canopy — Add repository
+          <span className="fork"><Fork size={15} /></span>
+          {title}
         </div>
         <span className="sp" data-tauri-drag-region />
-        <button className="ob-skip" onClick={onClose}>
-          Skip setup
-        </button>
+        {view === "empty" && <button className="ob-skip" onClick={onClose}>Skip setup</button>}
+        {view === "add" && <button className="ob-skip" onClick={() => setView("empty")}>Back</button>}
       </div>
 
-      <div className="ob-body">
-        {/* stepper rail */}
-        <div className="rail">
-          <div className="rail-brand">
-            <span className="fork-badge">
-              <Fork size={18} />
-            </span>
-            <div>
-              <h2>Welcome to Canopy</h2>
-              <p>Let's add your first repo</p>
-            </div>
-          </div>
-          <div className="steps">
-            {STEPS.map((s, i) => (
-              <div key={s.t} className={"step-item" + (i === step ? " active" : i < step ? " done" : "")}>
-                <span className="step-num">{i < step ? <Check size={13} /> : i + 1}</span>
-                <span className="step-lbl">
-                  <span className="t">{s.t}</span>
-                  <span className="s">{s.s}</span>
-                </span>
-              </div>
-            ))}
-          </div>
-          <div className="rail-foot">Worktrees let each branch run its own services on its own ports — no more stashing to switch tasks.</div>
-        </div>
-
-        {/* main */}
-        <div className="ob-main">
-          <div className="ob-scroll" ref={scrollRef}>
-            <div className="ob-content">
-              {step === 0 && (
-                <div>
-                  <div className="step-head">
-                    <p className="kicker">Step 1 of 5</p>
-                    <h1>Point Canopy at a repository</h1>
-                    <p>Choose the git repo you want to manage worktrees for. Canopy verifies it and reads its remotes and scripts.</p>
-                  </div>
-                  <div className="field-col">
-                    <label className="fld-label">
-                      <Folder size={13} />
-                      Repository path
-                    </label>
-                    <div className="input-row">
-                      <input
-                        className="input mono"
-                        value={path}
-                        placeholder="/Users/you/code/my-app"
-                        spellCheck={false}
-                        onChange={(e) => {
-                          setPath(e.target.value);
-                          setDet(null);
-                        }}
-                        onBlur={(e) => e.target.value.trim() && runDetect(e.target.value)}
-                      />
-                      <button className="btn ghost" onClick={browse}>
-                        <Folder size={14} />
-                        Browse
-                      </button>
-                    </div>
-                  </div>
-
-                  {detecting && (
-                    <div className="scan">
-                      <span className="sp">
-                        <Spinner size={18} />
-                      </span>
-                      Verifying repository…
-                    </div>
-                  )}
-                  {detErr && !detecting && (
-                    <div className="scan" style={{ color: "var(--stop)" }}>
-                      {detErr}
-                    </div>
-                  )}
-                  {det && !detecting && (
-                    <div className="detect-card" key={det.top}>
-                      <span className="fork-badge">
-                        <Fork size={18} />
-                      </span>
-                      <div className="info">
-                        <h3>{det.name}</h3>
-                        <div className="meta">
-                          {det.branch && (
-                            <span>
-                              <span className="k">branch</span> {det.branch}
-                            </span>
-                          )}
-                          {det.origin && (
-                            <span>
-                              <span className="k">origin</span> {det.origin}
-                            </span>
-                          )}
-                        </div>
-                      </div>
-                      <span className="git-chip">
-                        <Check size={13} />
-                        Git repository
-                      </span>
-                    </div>
-                  )}
-                </div>
-              )}
-
-              {step === 1 && (
-                <div>
-                  <div className="step-head">
-                    <p className="kicker">Step 2 of 5</p>
-                    <h1>What's the stack?</h1>
-                    <p>Canopy inspected the repo's manifests. Confirm the detected stack or pick another — it decides where we look for services and scripts.</p>
-                  </div>
-                  <div className="stack-grid">
-                    {STACKS.map((s) => (
-                      <button key={s.id} className={"stack-card" + (stack === s.id ? " sel" : "")} onClick={() => setStack(s.id)}>
-                        {det?.stack === s.id && stack !== s.id && <span className="stack-badge">Detected</span>}
-                        {stack === s.id && (
-                          <span className="stack-check">
-                            <Check size={18} />
-                          </span>
-                        )}
-                        <span className="stack-mono">{s.mono}</span>
-                        <div>
-                          <h3>{s.name}</h3>
-                          <p>{s.desc}</p>
-                        </div>
-                      </button>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {step === 2 && (
-                <div>
-                  <div className="step-head">
-                    <p className="kicker">Step 3 of 5</p>
-                    <h1>{scanning ? "Reading your services" : "Services from package.json"}</h1>
-                    {!scanning && (
-                      <p>
-                        Canopy mapped your <span style={{ fontFamily: "var(--mono)", color: "var(--dim)" }}>scripts</span> to long-running services. Toggle what Canopy should run per worktree.
-                      </p>
-                    )}
-                  </div>
-
-                  {det && det.scripts.length > 0 && (
-                    <div className="pkg-peek">
-                      <div className="bar">
-                        <span className="ic">
-                          <Package size={13} />
-                        </span>
-                        package.json — scripts
-                      </div>
-                      <div className="pkg-body">
-                        <div className="ln">
-                          <span className="pun">{"{"}</span>
-                        </div>
-                        {det.scripts.map((s, i) => (
-                          <div className="ln" key={s.name}>
-                            {"  "}
-                            <span className={"key" + (hitNames.has(s.name) ? " hit" : "")}>"{s.name}"</span>
-                            <span className="pun">: </span>
-                            <span className="str">"{s.command}"</span>
-                            <span className="pun">{i < det.scripts.length - 1 ? "," : ""}</span>
-                          </div>
-                        ))}
-                        <div className="ln">
-                          <span className="pun">{"}"}</span>
-                        </div>
-                      </div>
-                    </div>
-                  )}
-
-                  {scanning ? (
-                    <div className="scan">
-                      <span className="sp">
-                        <Spinner size={18} />
-                      </span>
-                      Scanning package.json and workspaces…
-                    </div>
-                  ) : (
-                    <>
-                      <div className="sug-head">
-                        <h3>Suggested services</h3>
-                        <span className="desc">
-                          {services.filter((s) => s.on).length} of {services.length} on
-                        </span>
-                        <span className="line" />
-                        <button
-                          className="add-action"
-                          onClick={() => setServices([...services, { id: uid("s"), on: true, name: "New service", kind: "server", cmd: "npm run dev", port: "" }])}
-                        >
-                          + Add manually
-                        </button>
-                      </div>
-                      <div className="sug-list">
-                        {services.map((s) => {
-                          const Ic = KIND_IC[s.kind];
-                          return (
-                            <div className={"sug " + (s.on ? "on" : "off")} key={s.id}>
-                              <span className="kind-ic">
-                                <Ic size={16} />
-                              </span>
-                              <div className="body">
-                                <div className="row1">
-                                  <span className="name">{s.name}</span>
-                                  <span className="tag">{s.kind}</span>
-                                </div>
-                                <div className="cmd">
-                                  <b>from</b> {s.script ? `"${s.script}"` : "manual"} · {s.cmd}
-                                </div>
-                              </div>
-                              <span className={"port" + (s.port ? "" : " none")}>{s.port ? ":" + s.port : "no port"}</span>
-                              <Switch on={s.on} onClick={() => setServices(services.map((x) => (x.id === s.id ? { ...x, on: !x.on } : x)))} />
-                            </div>
-                          );
-                        })}
-                      </div>
-                    </>
-                  )}
-                </div>
-              )}
-
-              {step === 3 && (
-                <div>
-                  <div className="step-head">
-                    <p className="kicker">Step 4 of 5</p>
-                    <h1>Commands &amp; environment</h1>
-                    <p>Pre-filled from your scripts. These run automatically whenever you create a new worktree — tweak or toggle any of them.</p>
-                  </div>
-
-                  <div className="cfg-group">
-                    <div className="sug-head">
-                      <h3>Database</h3>
-                      <span className="desc">from db:* scripts</span>
-                      <span className="line" />
-                    </div>
-                    <div className="cfg-two">
-                      <div className="field-col">
-                        <label className="fld-label">Reset DB</label>
-                        <input className="input mono" value={cfg.resetDb} spellCheck={false} onChange={(e) => setCfg({ ...cfg, resetDb: e.target.value })} />
-                      </div>
-                      <div className="field-col">
-                        <label className="fld-label">Migrate</label>
-                        <input className="input mono" value={cfg.migrate} spellCheck={false} onChange={(e) => setCfg({ ...cfg, migrate: e.target.value })} />
-                      </div>
-                    </div>
-                  </div>
-
-                  <div className="cfg-group">
-                    <div className="sug-head">
-                      <h3>Env overrides</h3>
-                      <span className="desc">per-worktree .env keys</span>
-                      <span className="line" />
-                    </div>
-                    {cfg.env.map((e) => (
-                      <div className="kv-line" key={e.id}>
-                        <input
-                          className="input mono"
-                          value={e.key}
-                          spellCheck={false}
-                          style={{ opacity: e.on ? 1 : 0.5 }}
-                          onChange={(ev) => setCfg({ ...cfg, env: cfg.env.map((x) => (x.id === e.id ? { ...x, key: ev.target.value } : x)) })}
-                        />
-                        <span className="kv-eq">=</span>
-                        <input
-                          className="input mono"
-                          value={e.value}
-                          spellCheck={false}
-                          style={{ opacity: e.on ? 1 : 0.5 }}
-                          onChange={(ev) => setCfg({ ...cfg, env: cfg.env.map((x) => (x.id === e.id ? { ...x, value: ev.target.value } : x)) })}
-                        />
-                        <Switch on={e.on} onClick={() => setCfg({ ...cfg, env: cfg.env.map((x) => (x.id === e.id ? { ...x, on: !x.on } : x)) })} />
-                      </div>
-                    ))}
-                  </div>
-
-                  <div className="cfg-group">
-                    <div className="sug-head">
-                      <h3>Setup commands</h3>
-                      <span className="desc">run on worktree create</span>
-                      <span className="line" />
-                    </div>
-                    {cfg.setup.map((u, i) => (
-                      <div className="step-line" key={u.id}>
-                        <span className="step-num2">{i + 1}</span>
-                        <input
-                          className="input mono"
-                          value={u.cmd}
-                          spellCheck={false}
-                          style={{ opacity: u.on ? 1 : 0.5 }}
-                          onChange={(ev) => setCfg({ ...cfg, setup: cfg.setup.map((x) => (x.id === u.id ? { ...x, cmd: ev.target.value } : x)) })}
-                        />
-                        <Switch on={u.on} onClick={() => setCfg({ ...cfg, setup: cfg.setup.map((x) => (x.id === u.id ? { ...x, on: !x.on } : x)) })} />
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {step === 4 && det && (
-                <div>
-                  <div className="step-head">
-                    <p className="kicker">Step 5 of 5</p>
-                    <h1>Review &amp; add</h1>
-                    <p>Here's what Canopy will save. You can change any of this later in Settings.</p>
-                  </div>
-                  <div className="rev-card">
-                    <div className="rev-top">
-                      <span className="fork-badge">
-                        <Fork size={17} />
-                      </span>
-                      <div>
-                        <h3>
-                          {det.name} <span style={{ color: "var(--faint)", fontWeight: 500, fontSize: 13 }}>· {(STACKS.find((s) => s.id === stack) || {}).name || "Custom"}</span>
-                        </h3>
-                        <div className="path">{det.top}</div>
-                      </div>
-                      <span className="sp" />
-                      {det.branch && (
-                        <span className="git-chip">
-                          <Check size={13} />
-                          {det.branch}
-                        </span>
-                      )}
-                    </div>
-                    <div className="rev-grid">
-                      <div className="rev-cell">
-                        <div className="lbl">Services · {services.filter((s) => s.on).length}</div>
-                        <div className="rev-list">
-                          {services
-                            .filter((s) => s.on)
-                            .map((s) => (
-                              <div className="r" key={s.id}>
-                                <span className="d" />
-                                {s.name}
-                                {s.port ? " · :" + s.port : ""}
-                              </div>
-                            ))}
-                        </div>
-                      </div>
-                      <div className="rev-cell">
-                        <div className="lbl">Worktree dir</div>
-                        <div className="val">
-                          <span className="mono">{cfg.worktreeDir}</span>
-                        </div>
-                      </div>
-                      <div className="rev-cell">
-                        <div className="lbl">DB commands</div>
-                        <div className="val">
-                          {(cfg.resetDb ? 1 : 0) + (cfg.migrate ? 1 : 0)} configured
-                        </div>
-                      </div>
-                      <div className="rev-cell">
-                        <div className="lbl">Env &amp; setup</div>
-                        <div className="val">
-                          {cfg.env.filter((e) => e.on).length} env overrides · {cfg.setup.filter((u) => u.on).length} setup steps
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              )}
-            </div>
-          </div>
-
-          <div className="ob-foot">
-            {step > 0 && (
-              <button className="btn ghost" onClick={back} disabled={busy}>
-                <ArrowLeft size={14} />
-                Back
-              </button>
-            )}
-            <div className="grow" />
-            <div className="dots">
-              {STEPS.map((_, i) => (
-                <i key={i} className={i === step ? "on" : ""} />
-              ))}
-            </div>
-            <div className="grow" />
-            <button className="btn primary" onClick={next} disabled={!canNext || busy}>
-              {busy ? (
-                <>
-                  <Spinner size={14} />
-                  Adding…
-                </>
-              ) : step === 4 ? (
-                <>
-                  <Check size={14} />
-                  Add repository
-                </>
-              ) : (
-                <>
-                  Continue
-                  <ArrowRight size={14} />
-                </>
-              )}
-            </button>
-          </div>
-        </div>
-      </div>
-
-      {done && (
-        <div className="done-veil">
-          <div className="done-card">
-            <div className="done-ring">
-              <Check size={30} />
-            </div>
-            <h2>{det?.name ?? "Repository"} is ready</h2>
-            <p>Canopy is watching this repo. Create your first worktree to spin up an isolated branch with its own services.</p>
-            <div className="done-actions">
-              <button
-                className="btn primary"
-                onClick={() => {
-                  onClose();
-                  onCreateWorktree();
-                }}
-              >
-                Create first worktree
-              </button>
-              <button
-                className="btn ghost"
-                onClick={() => {
-                  if (det) {
-                    // select the repo's main checkout so the main window has something to show
-                    select(det.top);
-                  }
-                  onClose();
-                }}
-              >
-                Go to Canopy
-              </button>
-            </div>
-          </div>
-        </div>
+      {view === "empty" && <EmptyState onAdd={() => setView("add")} onBrowse={browse} />}
+      {view === "add" && (
+        <AddScreen
+          det={det}
+          detErr={detErr}
+          phase={phase}
+          path={path}
+          over={over}
+          stack={stack}
+          services={services}
+          cfg={cfg}
+          onPath={onPath}
+          onBrowse={browse}
+          onStack={setStack}
+          setServices={setServices}
+          setCfg={setCfg}
+          onSkip={() => setView("empty")}
+          onDone={startProvision}
+        />
       )}
+      {view === "run" && (
+        <Provisioning
+          name={det?.name ?? "repository"}
+          steps={runSteps}
+          onDone={() => setView("done")}
+          onError={(msg) => {
+            showToast(`Couldn't add repo — ${msg}`);
+            setView("add");
+          }}
+          onCancel={() => setView("add")}
+        />
+      )}
+      {view === "done" && det && (
+        <Ready
+          det={det}
+          services={services}
+          cfg={cfg}
+          onCreate={() => {
+            onClose();
+            onCreateWorktree();
+          }}
+          onGoToCanopy={goToCanopy}
+          onRestart={restart}
+        />
+      )}
+
+      {toast && <div className="toast">{toast}</div>}
     </div>
   );
 }

--- a/src/popover.tsx
+++ b/src/popover.tsx
@@ -9,8 +9,8 @@ import "./styles/popover.css";
 
 applyPlatformClass();
 
-const GUTTER_X = 0; // window hugs the card (no shadow gutter)
-const GUTTER_Y = 0;
+const POP_W = 348; // design width
+const POP_MAX_H = 472; // design cap — the list scrolls inside past this
 
 function PopoverRoot() {
   const ref = useRef<HTMLDivElement>(null);
@@ -18,26 +18,25 @@ function PopoverRoot() {
 
   useEffect(() => initSync(), []);
 
-  // Fit the window to the content, capped at the available screen height
-  // (menu bar → dock; screen.availHeight already excludes both). When the list
-  // is taller than that, the window stops growing and .wm-groups scrolls inside.
+  // Fit the window to the content, capped at the design's 472px (and never past
+  // the available screen height). Past the cap the .list scrolls inside.
   useEffect(() => {
     if (!hasBackend() || !ref.current) return;
     const el = ref.current;
     let raf = 0;
     const measure = async () => {
-      const pop = el.querySelector(".wm-pop") as HTMLElement | null;
-      const groups = el.querySelector(".wm-groups") as HTMLElement | null;
-      // full content height even when the list is clamped + scrolling
-      const base = pop ? pop.clientHeight : el.offsetHeight;
-      const overflow = groups ? Math.max(0, groups.scrollHeight - groups.clientHeight) : 0;
-      const natural = Math.ceil(base + overflow) + GUTTER_Y;
-      // window top sits ~6px below the menu bar; leave a small margin off the dock
-      const maxH = Math.max(260, window.screen.availHeight - 14);
+      const ph = el.querySelector(".ph") as HTMLElement | null;
+      const list = el.querySelector(".list") as HTMLElement | null;
+      const pf = el.querySelector(".pf") as HTMLElement | null;
+      // header + footer are fixed; the list contributes its full content height
+      const natural = ph && pf && list
+        ? Math.ceil(ph.offsetHeight + pf.offsetHeight + list.scrollHeight + 2 /* card borders */)
+        : el.offsetHeight;
+      const maxH = Math.min(POP_MAX_H, Math.max(260, window.screen.availHeight - 14));
       const h = Math.min(natural, maxH);
       const { getCurrentWindow, LogicalSize } = await import("@tauri-apps/api/window");
       getCurrentWindow()
-        .setSize(new LogicalSize(284 + GUTTER_X, h))
+        .setSize(new LogicalSize(POP_W, h))
         .catch(() => {});
     };
     // measure after layout settles, and again once more to converge if clamped

--- a/src/popover/Popover.tsx
+++ b/src/popover/Popover.tsx
@@ -1,112 +1,448 @@
-// Menu-bar popover — ported from design handoff popover.jsx (worktree granularity)
-import { useStore } from "../store";
+// Menu-bar tray — ported from the design system's "Canopy Tray.html".
+// A per-repo, status-grouped worktree list with search, keyboard nav, hover
+// actions, a footer menu and a health status bar. State comes from the shared
+// store; gaps the tray can't own (creating worktrees, settings, the updater)
+// degrade to opening the manager rather than fabricating behaviour.
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useStore, getUptimeSec } from "../store";
 import type { RepoNode, WorktreeNode } from "../types";
-import { aggStatus, isLive } from "../types";
-import { Database, External, Fork, Globe, Power, Spinner, WindowIcon } from "../icons";
+import { aggStatus, fmtUptime } from "../types";
+import { hasBackend } from "../ipc";
+import { Alert, Check, Chevron, Database, Editor, External, Fork, Play, Plus, Power, Search, Settings, Spinner, Stop, Terminal, WindowIcon } from "../icons";
 
-function RepoHeader({ repo }: { repo: RepoNode }) {
+/** design status buckets: run · err (serving) / boot (transitional) / off (idle) */
+type Vis = "run" | "err" | "boot" | "off";
+function visOf(wt: WorktreeNode): Vis {
+  const s = aggStatus(wt);
+  if (s === "running") return "run";
+  if (s === "error") return "err";
+  if (s === "starting" || s === "stopping") return "boot";
+  return "off";
+}
+const serving = (v: Vis) => v === "run" || v === "err";
+
+/** the service whose port + uptime represents the worktree (web first) */
+function primary(wt: WorktreeNode) {
+  return wt.services.find((s) => s.kind === "web" && s.port != null) ?? wt.services.find((s) => s.port != null) ?? wt.services[0];
+}
+
+/** case-insensitive query highlight → text with a <mark> around the match */
+function hl(text: string, q: string): ReactNode {
+  if (!q) return text;
+  const i = text.toLowerCase().indexOf(q);
+  if (i < 0) return text;
   return (
-    <div className="wm-group">
-      <span className="wm-fork">
-        <Fork size={13} />
-      </span>
-      <span className="wm-repo">{repo.name}</span>
-    </div>
+    <>
+      {text.slice(0, i)}
+      <mark className="mk">{text.slice(i, i + q.length)}</mark>
+      {text.slice(i + q.length)}
+    </>
   );
 }
 
-function WorktreeRow({ wt }: { wt: WorktreeNode }) {
-  const resetting = useStore((s) => !!s.resetting[wt.wtKey]);
-  const toggleWorktree = useStore((s) => s.toggleWorktree);
-  const resetDb = useStore((s) => s.resetDb);
+/** branch name: the `owner/` prefix recedes; the tail truncates at its HEAD */
+function BranchName({ branch, q }: { branch: string; q: string }) {
+  const i = branch.indexOf("/");
+  const seg = i < 0 ? "" : branch.slice(0, i + 1);
+  const tail = i < 0 ? branch : branch.slice(i + 1);
+  return (
+    <span className="branch" title={branch}>
+      {seg && <span className="seg">{hl(seg, q)}</span>}
+      <span className="bn">
+        <span>{hl(tail, q)}</span>
+      </span>
+    </span>
+  );
+}
+
+function RowMeta({ wt, vis }: { wt: WorktreeNode; vis: Vis }) {
+  if (vis === "boot") return <span className="meta">starting…</span>;
+  if (vis === "off") {
+    const ahead = wt.git?.ahead ?? 0;
+    return <span className="meta">{ahead ? `${ahead} ahead` : "idle"}</span>;
+  }
+  const svc = primary(wt);
+  const errs = wt.services.filter((s) => s.status === "error").length;
+  const up = fmtUptime(getUptimeSec(svc?.svcKey ?? ""));
+  return (
+    <span className="meta">
+      {errs > 0 && (
+        <span className="warnct">
+          <Alert size={11} />
+          {errs}
+        </span>
+      )}
+      {svc?.port != null && <span className="port">:{svc.port}</span>}
+      {up !== "—" && <span className="up">{up}</span>}
+    </span>
+  );
+}
+
+function RowActions({ wt, vis }: { wt: WorktreeNode; vis: Vis }) {
+  const startAll = useStore((s) => s.startAll);
+  const stopAll = useStore((s) => s.stopAll);
   const openWorktree = useStore((s) => s.openWorktree);
   const openPort = useStore((s) => s.openPort);
-
-  const status = aggStatus(wt);
-  const busy = status === "starting" || status === "stopping";
-  const running = isLive(status) && !busy;
-  const label = busy ? (status === "starting" ? "Starting" : "Stopping") : running ? "Stop" : "Start";
-
-  // the web/client service (frontend) to open in the browser
-  const webSvc = wt.services.find((s) => s.kind === "web" && s.port != null) ?? wt.services.find((s) => s.port != null);
-  const canOpenClient = !!webSvc?.port && isLive(webSvc.status);
-
+  const resetDb = useStore((s) => s.resetDb);
+  const resetting = useStore((s) => !!s.resetting[wt.wtKey]);
+  const stop = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    stopAll(wt.wtKey);
+  };
+  // Reset this worktree's database (store guards against concurrent resets and
+  // surfaces progress/completion via the toast).
+  const db = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!resetting) resetDb(wt.wtKey);
+  };
+  const DbButton = () => (
+    <button className="ib" title="Reset database" onClick={db} disabled={resetting}>
+      {resetting ? <Spinner size={13} className="cx-spin" /> : <Database size={13} />}
+    </button>
+  );
+  const term = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    openWorktree(wt.wtKey, "terminal");
+  };
+  if (vis === "boot") {
+    return (
+      <span className="acts">
+        <button className="ib" title="Terminal" onClick={term}>
+          <Terminal size={13} />
+        </button>
+        <DbButton />
+        <button className="ib danger" title="Cancel start" onClick={stop}>
+          <Stop size={12} />
+        </button>
+      </span>
+    );
+  }
+  if (vis === "off") {
+    return (
+      <span className="acts">
+        <button className="ib" title="Open in editor" onClick={(e) => { e.stopPropagation(); openWorktree(wt.wtKey, "editor"); }}>
+          <Editor size={13} />
+        </button>
+        <button className="ib" title="Terminal" onClick={term}>
+          <Terminal size={13} />
+        </button>
+        <button className="ib play" title="Start" onClick={(e) => { e.stopPropagation(); startAll(wt.wtKey); }}>
+          <Play size={12} />
+        </button>
+      </span>
+    );
+  }
+  const svc = primary(wt);
   return (
-    <div className="wm-wt">
-      <div className="wm-wt-top">
-        <span className="wm-wt-branch">{wt.branch}</span>
-        <div className="wm-acts">
-          <button
-            className="wm-act"
-            title={canOpenClient ? `Open client (localhost:${webSvc!.port})` : "Start the worktree to open the client"}
-            onClick={() => canOpenClient && openPort(webSvc!.port!)}
-            disabled={!canOpenClient}
-          >
-            <Globe size={15} />
-          </button>
-          <button className="wm-act" title="Open worktree" onClick={() => openWorktree(wt.wtKey, "editor")}>
-            <External size={15} />
-          </button>
-          <button
-            className={"wm-act" + (resetting ? " wm-act--busy" : "")}
-            title="Reset database"
-            onClick={() => !resetting && resetDb(wt.wtKey)}
-            disabled={resetting}
-          >
-            {resetting ? <Spinner size={15} className="wm-spin" /> : <Database size={15} />}
-          </button>
-          <button
-            className={"wm-toggle" + (busy ? " is-busy" : "")}
-            onClick={() => !busy && toggleWorktree(wt.wtKey)}
-            disabled={busy}
-          >
-            {label}
-          </button>
-        </div>
-      </div>
-      <div className="wm-svcs">
-        {wt.services.map((s) => (
-          <span className="wm-svc" key={s.svcKey}>
-            <span className={"wm-svc-dot s-" + s.status} />
-            {s.name}
-          </span>
-        ))}
-      </div>
+    <span className="acts">
+      <button
+        className="ib"
+        title={svc?.port != null ? "Open in browser" : "No port to open"}
+        onClick={(e) => { e.stopPropagation(); if (svc?.port != null) openPort(svc.port); }}
+      >
+        <External size={13} />
+      </button>
+      <button className="ib" title="Terminal" onClick={term}>
+        <Terminal size={13} />
+      </button>
+      <DbButton />
+      <button className="ib danger" title="Stop" onClick={stop}>
+        <Stop size={12} />
+      </button>
+    </span>
+  );
+}
+
+function Row({ wt, vis, q, selected, onHover, onFocusWt }: {
+  wt: WorktreeNode;
+  vis: Vis;
+  q: string;
+  selected: boolean;
+  onHover: () => void;
+  onFocusWt: () => void;
+}) {
+  const dot = vis === "run" ? "run" : vis === "err" ? "err" : vis === "boot" ? "boot" : "idle";
+  return (
+    <div
+      className={"row" + (vis === "off" ? " off" : "") + (selected ? " sel" : "")}
+      title={wt.branch}
+      data-sel={selected ? "1" : undefined}
+      onMouseEnter={onHover}
+      onClick={onFocusWt}
+    >
+      <span className={"dot " + dot} />
+      <BranchName branch={wt.branch} q={q} />
+      <RowMeta wt={wt} vis={vis} />
+      <RowActions wt={wt} vis={vis} />
     </div>
   );
 }
 
 export default function Popover() {
   const tree = useStore((s) => s.tree);
-  const flash = useStore((s) => s.flash);
+  const toast = useStore((s) => s.toast);
+  const showToast = useStore((s) => s.showToast);
+  const select = useStore((s) => s.select);
+  const startAll = useStore((s) => s.startAll);
   const openManager = useStore((s) => s.openManager);
   const quit = useStore((s) => s.quit);
 
+  const [repoId, setRepoId] = useState<string | null>(null);
+  const [repoMenu, setRepoMenu] = useState(false);
+  const [q, setQ] = useState("");
+  const [sel, setSel] = useState(-1);
+  const [ver, setVer] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const popRef = useRef<HTMLDivElement>(null);
+
+  // keep the selected repo valid as the tree changes; default to the first
+  const repo: RepoNode | undefined = useMemo(
+    () => tree.find((r) => r.repoId === repoId) ?? tree[0],
+    [tree, repoId],
+  );
+
+  const ql = q.trim().toLowerCase();
+  // visible worktrees for this repo, ordered as they render: running → starting → idle
+  const { groups, rows } = useMemo(() => {
+    const wts = (repo?.worktrees ?? []).filter((w) => w.branch.toLowerCase().includes(ql));
+    const tagged = wts.map((wt) => ({ wt, vis: visOf(wt) }));
+    const run = tagged.filter((t) => serving(t.vis));
+    const boot = tagged.filter((t) => t.vis === "boot");
+    const idle = tagged.filter((t) => t.vis === "off");
+    return {
+      groups: [
+        { label: "Running", items: run },
+        { label: "Starting", items: boot },
+        { label: ql ? "Matches" : "Idle", items: idle },
+      ].filter((g) => g.items.length),
+      rows: [...run, ...boot, ...idle],
+    };
+  }, [repo, ql]);
+
+  const runningCount = (repo?.worktrees ?? []).filter((w) => serving(visOf(w))).length;
+  const total = repo?.worktrees.length ?? 0;
+
+  // app-wide health for the status bar — reflects real state, not a claim
+  const errCount = tree.reduce((n, r) => n + r.worktrees.filter((w) => visOf(w) === "err").length, 0);
+  const anyRunning = tree.some((r) => r.worktrees.some((w) => serving(visOf(w))));
+
+  const focusWt = (wt: WorktreeNode) => {
+    select(wt.wtKey);
+    openManager();
+  };
+
+  useEffect(() => {
+    if (hasBackend()) import("@tauri-apps/api/app").then((m) => m.getVersion().then(setVer).catch(() => setVer("")));
+  }, []);
+
+  // entry animation, matching the design's `pin`
+  useEffect(() => {
+    const el = popRef.current;
+    if (!el) return;
+    el.classList.add("is-in");
+    const done = () => el.classList.remove("is-in");
+    el.addEventListener("animationend", done, { once: true });
+    return () => el.removeEventListener("animationend", done);
+  }, []);
+
+  // reset the keyboard cursor whenever the visible set changes
+  useEffect(() => setSel(-1), [ql, repoId]);
+
+  // keep the keyboard-selected row inside the scroll port
+  useEffect(() => {
+    if (sel < 0) return;
+    listRef.current?.querySelector<HTMLElement>('.row[data-sel="1"]')?.scrollIntoView({ block: "nearest" });
+  }, [sel]);
+
+  // keyboard: arrows move the cursor, Enter acts, ⌘K focuses, Esc clears,
+  // any other typing focuses the filter. Mouse movement drops keyboard mode.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+        e.preventDefault();
+        document.body.classList.add("kb");
+        if (!rows.length) return;
+        setSel((at) => {
+          const d = e.key === "ArrowDown" ? 1 : rows.length - 1;
+          const base = at < 0 ? (e.key === "ArrowDown" ? -1 : 0) : at;
+          return (base + d + rows.length) % rows.length;
+        });
+      } else if (e.key === "Enter" && sel >= 0) {
+        const r = rows[sel];
+        if (!r) return;
+        r.vis === "off" ? startAll(r.wt.wtKey) : focusWt(r.wt);
+      } else if (e.metaKey && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        inputRef.current?.select();
+        inputRef.current?.focus();
+      } else if (e.metaKey && e.key.toLowerCase() === "n") {
+        e.preventDefault();
+        newWorktree();
+      } else if (e.key === "Escape") {
+        if (q) setQ("");
+      } else if (e.key !== "Tab" && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        inputRef.current?.focus();
+      }
+    };
+    const onMove = () => document.body.classList.remove("kb");
+    document.addEventListener("keydown", onKey);
+    addEventListener("mousemove", onMove, { passive: true });
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      removeEventListener("mousemove", onMove);
+    };
+  }, [rows, sel, q]);
+
+  // close the repo menu on outside click
+  useEffect(() => {
+    if (!repoMenu) return;
+    const d = (e: MouseEvent) => {
+      if (!(e.target as HTMLElement).closest(".repo")) setRepoMenu(false);
+    };
+    document.addEventListener("mousedown", d);
+    return () => document.removeEventListener("mousedown", d);
+  }, [repoMenu]);
+
+  // The new-worktree modal and the overview live in the main window. Show that
+  // window (openManager) and emit a command it listens for (App.tsx). In a plain
+  // browser (no backend) there's nothing to emit to, so fall back to a toast.
+  const command = (name: string, fallback: string) => {
+    openManager();
+    if (hasBackend()) import("@tauri-apps/api/event").then((m) => m.emit(name)).catch(() => {});
+    else showToast(fallback);
+  };
+  const newWorktree = () => command("tray:new-worktree", "Create a worktree in the manager");
+  const openManagerOverview = () => command("tray:overview", "Opening all worktrees");
+  const openSettings = () => {
+    openManager();
+    showToast("Settings — opening the manager");
+  };
+
   return (
-    <div className="wm-pop">
-      <button className={"wm-item" + (flash === "manager" ? " wm-item--flash" : "")} onClick={openManager}>
-        <span className="wm-item-ic">
-          <WindowIcon size={16} />
-        </span>
-        Open Manager
-      </button>
-      <button className={"wm-item" + (flash === "quit" ? " wm-item--flash" : "")} onClick={quit}>
-        <span className="wm-item-ic">
-          <Power size={16} />
-        </span>
-        Quit
-      </button>
-      <div className="wm-sep" />
-      <div className="wm-groups">
-        {tree.map((repo, ri) => (
-          <div className={"wm-grp" + (ri ? " wm-grp--div" : "")} key={repo.repoId}>
-            <RepoHeader repo={repo} />
-            {repo.worktrees.map((wt) => (
-              <WorktreeRow key={wt.wtKey} wt={wt} />
-            ))}
-          </div>
-        ))}
+    <div className="pop" ref={popRef}>
+      <div className="ph">
+        <div className="repo">
+          <button onClick={() => setRepoMenu((o) => !o)} disabled={tree.length < 2} aria-haspopup="listbox" aria-expanded={repoMenu}>
+            <Fork size={13} nodeColor="var(--teal)" />
+            <span className="nm">{repo?.name ?? "No repository"}</span>
+            {tree.length > 1 && <Chevron size={10} />}
+          </button>
+          <span className="sum">
+            {runningCount > 0 ? (
+              <>
+                <span className="dot run" />
+                <b>{runningCount} running</b> · {total} total
+              </>
+            ) : (
+              `${total} ${total === 1 ? "worktree" : "worktrees"}`
+            )}
+          </span>
+          <button className="gear" title="Settings… ⌘," onClick={openSettings}>
+            <Settings size={14} />
+          </button>
+          {repoMenu && (
+            <div className="repomenu" role="listbox">
+              {tree.map((r) => (
+                <button
+                  key={r.repoId}
+                  className={r.repoId === (repo?.repoId ?? "") ? "on" : ""}
+                  role="option"
+                  aria-selected={r.repoId === repo?.repoId}
+                  onClick={() => { setRepoId(r.repoId); setRepoMenu(false); }}
+                >
+                  <Fork size={13} nodeColor="var(--teal)" />
+                  {r.name}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+        <label className="search">
+          <Search size={13} />
+          <input
+            ref={inputRef}
+            value={q}
+            placeholder="Filter worktrees"
+            spellCheck={false}
+            autoComplete="off"
+            onChange={(e) => setQ(e.target.value)}
+          />
+          <kbd>⌘K</kbd>
+        </label>
       </div>
+
+      <div className="list" ref={listRef}>
+        {rows.length ? (
+          groups.map((g) => {
+            const startIdx = rows.findIndex((r) => r === g.items[0]);
+            return (
+              <div key={g.label}>
+                <div className="glabel">
+                  {g.label}
+                  <span className="ct">{g.items.length}</span>
+                  <span className="rule" />
+                </div>
+                {g.items.map((t, j) => (
+                  <Row
+                    key={t.wt.wtKey}
+                    wt={t.wt}
+                    vis={t.vis}
+                    q={ql}
+                    selected={sel === startIdx + j}
+                    onHover={() => setSel(startIdx + j)}
+                    onFocusWt={() => focusWt(t.wt)}
+                  />
+                ))}
+              </div>
+            );
+          })
+        ) : (
+          <div className="empty">
+            {ql ? (
+              <>
+                No worktree matches <code>{q}</code>
+              </>
+            ) : (
+              "No worktrees yet"
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="pf">
+        <div className="pfrow">
+          <button className="mi" title="New worktree… ⌘N" onClick={newWorktree}>
+            <Plus size={13} />
+            New worktree
+          </button>
+          <span className="vr" />
+          <button className="mi" title="Open Manager ⌘⇧C" onClick={openManagerOverview}>
+            <WindowIcon size={13} />
+            Open Manager
+          </button>
+          <span className="vr" />
+          <button className="mi" title="Quit Canopy ⌘Q" onClick={quit}>
+            <Power size={13} />
+            Quit
+          </button>
+        </div>
+        <div className="pstat">
+          <span className="hlth" style={{ color: errCount > 0 ? "var(--amber)" : "var(--green)", display: "inline-flex" }}>
+            {errCount > 0 ? <Alert size={13} /> : <Check size={13} />}
+          </span>
+          <span>
+            {errCount > 0
+              ? `${errCount} service${errCount > 1 ? "s" : ""} stopped unexpectedly`
+              : anyRunning
+                ? "Canopy is running smoothly"
+                : "No services running"}
+          </span>
+          {ver && <span className="ver">v{ver}</span>}
+        </div>
+      </div>
+
+      {toast && <div className="toast">{toast}</div>}
     </div>
   );
 }

--- a/src/styles/canopy-shell.css
+++ b/src/styles/canopy-shell.css
@@ -365,6 +365,87 @@
 .cxs-sfilter input {
   font-size: var(--fs-body);
 }
+/* repo filter — a dropdown that narrows the list to one repository */
+.cxs-repobar {
+  position: relative;
+  flex: none;
+  margin: 0 var(--sp-3) var(--sp-tight) var(--sp-4);
+}
+.cxs-repobtn {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  width: 100%;
+  height: var(--h-control-xs);
+  padding: 0 var(--sp-3);
+  border: 1px solid var(--divider);
+  background: var(--surface-well);
+  color: var(--text-secondary);
+  border-radius: var(--r-md);
+  font: var(--fs-small) var(--sans);
+  cursor: pointer;
+  transition: border-color var(--dur), color var(--dur);
+}
+.cxs-repobtn:hover {
+  border-color: var(--border-pop);
+  color: var(--text-primary);
+}
+.cxs-repobtn > svg:first-child {
+  color: var(--action-primary);
+  flex: none;
+}
+.cxs-repobtn .nm {
+  flex: 1;
+  min-width: 0;
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cxs-repomenu {
+  position: absolute;
+  top: calc(100% + 3px);
+  left: 0;
+  right: 0;
+  z-index: 30;
+  background: var(--surface-float);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  box-shadow: var(--shadow-menu);
+  padding: var(--sp-1);
+  max-height: 260px;
+  overflow-y: auto;
+}
+.cxs-repoitem {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  width: 100%;
+  padding: var(--sp-2) var(--sp-3);
+  border: 0;
+  background: none;
+  color: var(--text-primary);
+  font: var(--fs-body) var(--sans);
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  text-align: left;
+}
+.cxs-repoitem:hover {
+  background: var(--raised-hi);
+}
+.cxs-repoitem.is-on {
+  color: var(--action-primary);
+}
+.cxs-repoitem > svg {
+  flex: none;
+}
+.cxs-repoitem .nm {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .cxs-slist {
   flex: 1;
   overflow-y: auto;

--- a/src/styles/onboarding.css
+++ b/src/styles/onboarding.css
@@ -1,930 +1,993 @@
-/* First-run onboarding wizard — ported from the v0.4 design handoff
-   (Worktree Manager Onboarding.html). All selectors are scoped under .ob-root
-   so nothing here leaks into the main window / Settings palette. Colors use the
-   shared tokens (tokens.css); --field is a local alias for the sunken input bg. */
+/* First-run onboarding — ported from the redesign handoff (Canopy
+   Onboarding.html / cxo-onboard.jsx). The shipped 5-step wizard (Repository →
+   Stack → Services → Commands → Review) collapses into ONE adaptive screen:
+   paste or drop a repo, see what Canopy found and what it will do, adjust
+   anything inline, one action. Plus the empty state, provisioning narration and
+   a "ready" screen that ends on the next action.
+
+   Every selector is scoped under .ob-root so nothing leaks into the main window
+   or Settings. Colours resolve from the shared token layer (tokens.css); the
+   design's own token names (--surface-*, --action-*, --r-*, --fs-*) are the
+   semantic aliases declared there, so this sheet declares none of its own. */
 .ob-root {
-  --field: var(--panel-2);
   position: fixed;
   inset: 0;
   z-index: 80;
-  background: var(--bg);
-  color: var(--text);
+  background: var(--surface-app);
+  color: var(--text-primary);
   display: flex;
   flex-direction: column;
   font-family: var(--sans);
   user-select: none;
+  /* the screen keys its one responsive break off its own width, not the window */
+  container-type: inline-size;
+  container-name: obwin;
 }
 
-/* titlebar */
+/* ── titlebar — the real, draggable window chrome ─────────────────── */
 .ob-root .ob-tb {
   height: 44px;
   flex: none;
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 0 12px; /* non-macOS: native titlebar, no traffic-light inset */
-  background: var(--titlebar);
-  border-bottom: 1px solid var(--border-soft);
+  gap: var(--sp-4);
+  padding: 0 var(--sp-5);
+  background: var(--surface-float);
+  border-bottom: 1px solid var(--divider);
 }
-/* macOS traffic-light inset (see app.css) */
+/* macOS overlay titlebar: clear the traffic lights (see app.css) */
 .mac .ob-root .ob-tb {
   padding-left: 80px;
 }
 .ob-root .ob-tb-title {
   display: flex;
   align-items: center;
-  gap: 8px;
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--dim);
+  gap: var(--sp-3);
+  font: var(--fw-semi) var(--fs-body) var(--sans);
+  letter-spacing: var(--tracking-tight);
+  color: var(--text-primary);
 }
 .ob-root .ob-tb-title .fork {
-  color: var(--accent);
+  color: var(--action-primary);
   display: inline-flex;
 }
 .ob-root .ob-tb .sp {
   flex: 1;
   align-self: stretch;
 }
-.ob-root .ob-skip {
-  background: none;
+.ob-root .ob-ib {
+  height: 26px;
+  min-width: 26px;
+  padding: 0 var(--sp-tight);
   border: 0;
-  color: var(--faint);
-  font-family: var(--sans);
-  font-size: 12.5px;
   cursor: pointer;
-  padding: 6px 10px;
-  border-radius: 7px;
-  transition: background 0.1s, color 0.1s;
+  background: none;
+  color: var(--text-secondary);
+  border-radius: var(--r-md);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--sp-tight);
+  font: var(--fs-body) var(--sans);
+  flex: none;
+  transition: background var(--dur-fast), color var(--dur-fast);
+}
+.ob-root .ob-ib:hover {
+  background: var(--btn);
+  color: var(--text-primary);
+}
+.ob-root .ob-skip {
+  height: 24px;
+  padding: 0 var(--sp-4);
+  border: 0;
+  background: none;
+  color: var(--text-tertiary);
+  font: var(--fs-small) var(--sans);
+  cursor: pointer;
+  border-radius: var(--r-md);
 }
 .ob-root .ob-skip:hover {
   background: var(--btn);
-  color: var(--text);
+  color: var(--text-primary);
 }
 
-.ob-root .ob-body {
-  flex: 1;
-  display: flex;
-  min-height: 0;
-}
-
-/* stepper rail */
-.ob-root .rail {
-  width: 248px;
-  flex: none;
-  background: var(--sidebar);
-  border-right: 1px solid var(--border-soft);
-  padding: 22px 16px;
-  display: flex;
-  flex-direction: column;
-}
-.ob-root .rail-brand {
-  display: flex;
-  align-items: center;
-  gap: 11px;
-  padding: 4px 8px 20px;
-}
-.ob-root .fork-badge {
-  width: 34px;
-  height: 34px;
-  border-radius: 10px;
-  flex: none;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--accent-dim);
-  color: var(--accent);
-}
-.ob-root .rail-brand h2 {
-  font-size: 14px;
-  font-weight: 640;
-  margin: 0;
-  letter-spacing: -0.01em;
-}
-.ob-root .rail-brand p {
-  font-size: 11px;
-  color: var(--faint);
-  margin: 1px 0 0;
-}
-.ob-root .steps {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-.ob-root .step-item {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 9px 8px;
-  border-radius: 8px;
-  text-align: left;
-  border: 0;
-  background: none;
-  width: 100%;
-}
-.ob-root .step-num {
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
-  flex: none;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 12px;
-  font-weight: 600;
-  font-family: var(--mono);
-  border: 1.5px solid var(--border);
-  color: var(--faint);
-  background: var(--field);
-  transition: all 0.18s;
-}
-.ob-root .step-lbl {
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-  min-width: 0;
-}
-.ob-root .step-lbl .t {
-  font-size: 13px;
-  font-weight: 550;
-  color: var(--dim);
-  transition: color 0.18s;
-}
-.ob-root .step-lbl .s {
-  font-size: 11px;
-  color: var(--faint);
-}
-.ob-root .step-item.done .step-num {
-  border-color: var(--accent);
-  background: var(--accent-dim);
-  color: var(--accent);
-}
-.ob-root .step-item.active {
-  background: var(--accent-dim);
-}
-.ob-root .step-item.active .step-num {
-  border-color: var(--accent);
-  background: var(--accent);
-  color: #08171a;
-}
-.ob-root .step-item.active .step-lbl .t {
-  color: var(--text);
-}
-.ob-root .rail-foot {
-  margin-top: auto;
-  padding: 12px 8px 0;
-  font-size: 11px;
-  color: var(--faint);
-  line-height: 1.5;
-}
-
-/* main content */
-.ob-root .ob-main {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-  min-height: 0;
-}
-.ob-root .ob-scroll {
-  flex: 1;
-  overflow-y: auto;
-  min-height: 0;
-}
-.ob-root .ob-content {
-  max-width: 620px;
-  margin: 0 auto;
-  padding: 40px 40px 32px;
-}
-.ob-root .step-head {
-  margin-bottom: 26px;
-}
-.ob-root .step-head .kicker {
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: var(--accent);
-  margin: 0 0 8px;
-}
-.ob-root .step-head h1 {
-  font-size: 22px;
-  font-weight: 640;
-  letter-spacing: -0.02em;
-  margin: 0;
-}
-.ob-root .step-head p {
-  font-size: 13.5px;
-  color: var(--dim);
-  margin: 8px 0 0;
-  line-height: 1.55;
-}
-
-/* footer nav */
-.ob-root .ob-foot {
-  flex: none;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 14px 40px;
-  border-top: 1px solid var(--border-soft);
-  background: var(--bg);
-}
-.ob-root .ob-foot .dots {
-  display: flex;
-  gap: 6px;
-}
-.ob-root .ob-foot .dots i {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--border);
-  display: block;
-  transition: background 0.2s, width 0.2s;
-}
-.ob-root .ob-foot .dots i.on {
-  background: var(--accent);
-  width: 16px;
-  border-radius: 3px;
-}
-.ob-root .ob-foot .grow {
-  flex: 1;
-}
+/* ── shared controls ──────────────────────────────────────────────── */
 .ob-root .btn {
-  height: 36px;
-  padding: 0 16px;
-  border: 0;
+  height: 29px;
+  padding: 0 var(--sp-5);
+  border-radius: var(--r-lg);
+  border: 1px solid var(--divider);
+  background: var(--btn);
+  color: var(--text-secondary);
+  font: var(--fw-medium) var(--fs-body) var(--sans);
   cursor: pointer;
-  border-radius: 8px;
-  font-family: var(--sans);
-  font-size: 13px;
-  font-weight: 550;
   display: inline-flex;
   align-items: center;
-  gap: 7px;
-  transition: background 0.12s, color 0.12s, opacity 0.12s;
+  gap: var(--sp-3);
+  flex: none;
+  white-space: nowrap;
+  transition: background var(--dur-fast), color var(--dur-fast), border-color var(--dur-fast);
 }
-.ob-root .btn.ghost {
-  background: var(--btn);
-  color: var(--dim);
-}
-.ob-root .btn.ghost:hover {
+.ob-root .btn:hover {
   background: var(--btn-hover);
-  color: var(--text);
+  color: var(--text-primary);
+  border-color: var(--border-pop);
 }
-.ob-root .btn.primary {
-  background: var(--accent);
-  color: #08171a;
-  font-weight: 600;
-}
-.ob-root .btn.primary:hover {
-  filter: brightness(1.08);
-}
-.ob-root .btn.primary:disabled {
+.ob-root .btn:disabled {
   opacity: 0.4;
   cursor: default;
+}
+.ob-root .btn:disabled:hover {
+  background: var(--btn);
+  color: var(--text-secondary);
+  border-color: var(--divider);
+}
+.ob-root .btn.pri {
+  background: var(--action-primary);
+  border-color: var(--action-primary);
+  color: var(--action-primary-ink);
+  font-weight: var(--fw-semi);
+}
+.ob-root .btn.pri:hover {
+  filter: brightness(1.09);
+  background: var(--action-primary);
+  color: var(--action-primary-ink);
+}
+.ob-root .btn.pri:disabled:hover {
   filter: none;
 }
-
-/* inputs */
-.ob-root .fld-label {
-  font-size: 10.5px;
-  font-weight: 600;
-  letter-spacing: 0.07em;
-  text-transform: uppercase;
-  color: var(--faint);
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
+.ob-root .btn.gh {
+  background: none;
+  border-color: transparent;
+  color: var(--text-tertiary);
 }
-.ob-root .field-col {
-  display: flex;
-  flex-direction: column;
-  gap: 7px;
+.ob-root .btn.gh:hover {
+  background: var(--btn);
+  color: var(--text-primary);
+  border-color: transparent;
 }
-.ob-root .input {
-  width: 100%;
-  height: 36px;
-  padding: 0 12px;
-  border-radius: 8px;
-  background: var(--field);
-  border: 1px solid var(--border-soft);
-  color: var(--text);
-  font-family: var(--sans);
-  font-size: 13px;
+.ob-root .btn.lg {
+  height: 34px;
+  padding: 0 var(--sp-6);
+  font-size: var(--fs-body);
+}
+.ob-root .btn.sm {
+  height: 24px;
+  padding: 0 var(--sp-4);
+  font-size: var(--fs-small);
+}
+.ob-root .btn:focus-visible,
+.ob-root .ob-skip:focus-visible,
+.ob-root .ob-ib:focus-visible,
+.ob-root .rr:focus-visible,
+.ob-root .stackchip:focus-visible,
+.ob-root .smi:focus-visible {
+  outline: 2px solid var(--action-primary);
+  outline-offset: -2px;
+}
+.ob-root .btn .k {
+  font: 500 var(--fs-micro) var(--mono);
+  opacity: 0.6;
+}
+.ob-root .inp {
+  height: 30px;
+  padding: 0 var(--sp-pop);
+  border-radius: var(--r-lg);
+  border: 1px solid var(--divider);
+  background: var(--surface-well);
+  color: var(--text-primary);
+  font: var(--fs-body) var(--sans);
   outline: none;
-  transition: border-color 0.12s, box-shadow 0.12s, background 0.12s;
+  min-width: 0;
+  transition: border-color var(--dur), box-shadow var(--dur);
 }
-.ob-root .input.mono {
+.ob-root .inp:focus {
+  border-color: var(--action-primary);
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+.ob-root .inp::placeholder {
+  color: var(--text-tertiary);
+}
+.ob-root .inp.mono {
   font-family: var(--mono);
-  font-size: 12.5px;
+  font-size: var(--fs-small);
 }
-.ob-root .input::placeholder {
-  color: var(--faint);
+/* toggle — a control, so it floats: full-round track + knob */
+.ob-root .tgl {
+  position: relative;
+  width: 30px;
+  height: 17px;
+  border-radius: var(--r-xl);
+  background: var(--btn-hover);
+  border: 0;
+  cursor: pointer;
+  flex: none;
+  transition: background 0.14s;
 }
-.ob-root .input:hover {
-  border-color: var(--border);
+.ob-root .tgl.on {
+  background: var(--action-primary);
 }
-.ob-root .input:focus {
-  border-color: var(--accent);
-  box-shadow: 0 0 0 3px var(--accent-dim);
+.ob-root .tgl i {
+  position: absolute;
+  top: 2.5px;
+  left: 2.5px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #d5d7dc;
+  transition: transform 0.14s, background 0.14s;
+  display: block;
 }
-.ob-root .input-row {
+.ob-root .tgl.on i {
+  transform: translateX(13px);
+  background: var(--action-primary-ink);
+}
+.ob-root .tgl:focus-visible {
+  outline: 2px solid var(--action-primary);
+  outline-offset: 2px;
+}
+/* uppercase section label with a trailing hairline */
+.ob-root .slab {
   display: flex;
-  gap: 8px;
+  align-items: center;
+  gap: var(--sp-row);
+  font: var(--fw-bold) var(--fs-label) var(--sans);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  margin-bottom: var(--sp-row);
 }
-.ob-root .input-row .input {
+.ob-root .slab .n {
+  letter-spacing: 0;
+  text-transform: none;
+  font-weight: var(--fw-regular);
+  font-size: var(--fs-micro);
+}
+.ob-root .slab .ln {
   flex: 1;
+  height: 1px;
+  background: var(--divider);
 }
 
-/* detected repo confirmation card */
-.ob-root .detect-card {
-  margin-top: 18px;
-  background: var(--panel);
-  border: 1px solid var(--border-soft);
-  border-radius: 11px;
-  padding: 16px 18px;
+/* ── A · empty state — first launch used to say nothing ───────────── */
+.ob-root .emptywrap {
+  flex: 1;
   display: flex;
   align-items: flex-start;
-  gap: 14px;
-  opacity: 0;
-  transform: translateY(6px);
-  animation: ob-rise 0.35s ease forwards;
+  justify-content: center;
+  padding: var(--sp-empty-lg);
+  min-height: 0;
+  overflow-y: auto;
+}
+.ob-root .emptycard {
+  width: 100%;
+  max-width: 540px;
+  text-align: center;
+  margin: auto 0;
+}
+.ob-root .emptyring {
+  width: 60px;
+  height: 60px;
+  border-radius: var(--r-2xl);
+  margin: 0 auto var(--sp-7);
+  display: grid;
+  place-items: center;
+  background: var(--accent-dim);
+  color: var(--action-primary);
+  border: 1px solid var(--teal-border);
+}
+.ob-root .emptycard h1 {
+  font-size: var(--fs-xl);
+  font-weight: var(--fw-semi);
+  letter-spacing: -0.02em;
+  margin: 0 0 var(--sp-row);
+}
+.ob-root .emptycard > p {
+  font-size: var(--fs-md);
+  color: var(--text-secondary);
+  line-height: 1.6;
+  margin: 0 auto 20px;
+  max-width: 430px;
+  text-wrap: pretty;
+}
+.ob-root .emptyacts {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--sp-4);
+  margin-bottom: var(--sp-empty);
+}
+.ob-root .whatnext {
+  border-top: 1px solid var(--divider);
+  padding-top: var(--sp-7);
+  text-align: left;
+}
+.ob-root .wn {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--sp-pop-lg);
+  padding: var(--sp-3) 0;
+}
+.ob-root .wn .n {
+  width: 18px;
+  height: 18px;
+  border-radius: var(--r-sm);
+  flex: none;
+  display: grid;
+  place-items: center;
+  font: var(--fw-bold) var(--fs-label) var(--sans);
+  background: var(--btn);
+  color: var(--text-tertiary);
+  margin-top: 1px;
+}
+.ob-root .wn .t {
+  min-width: 0;
+}
+.ob-root .wn .t b {
+  display: block;
+  font-size: var(--fs-body);
+  font-weight: var(--fw-medium);
+  color: var(--text-primary);
+}
+.ob-root .wn .t span {
+  display: block;
+  font-size: var(--fs-small);
+  color: var(--text-tertiary);
+  line-height: 1.45;
+  margin-top: 2px;
+}
+
+/* ── B · one adaptive add screen ──────────────────────────────────── */
+.ob-root .obody {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+.ob-root .obinner {
+  max-width: 756px;
+  margin: 0 auto;
+  padding: var(--sp-8) var(--sp-8) 34px;
+}
+.ob-root .ohead h1 {
+  font-size: var(--fs-xl);
+  font-weight: var(--fw-semi);
+  letter-spacing: -0.02em;
+  margin: 0 0 var(--sp-tight);
+}
+.ob-root .ohead > p {
+  font-size: var(--fs-body);
+  color: var(--text-tertiary);
+  line-height: 1.55;
+  margin: 0 0 var(--sp-7);
+  max-width: 520px;
+  text-wrap: pretty;
+}
+
+/* the drop target doubles as the path field */
+.ob-root .drop {
+  border: 1px dashed var(--border);
+  border-radius: var(--r-xl);
+  background: var(--surface-well);
+  padding: var(--sp-7);
+  transition: border-color 0.14s, background 0.14s;
+}
+.ob-root .drop.over {
+  border-color: var(--action-primary);
+  background: var(--accent-dim);
+}
+.ob-root .drop.filled {
+  border-style: solid;
+  padding: var(--sp-5);
+}
+.ob-root .droprow {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-4);
+}
+.ob-root .droprow .ic {
+  color: var(--text-tertiary);
+  display: inline-flex;
+  flex: none;
+}
+.ob-root .drophint {
+  text-align: center;
+  padding: var(--sp-row) 0 2px;
+  font-size: var(--fs-small);
+  color: var(--text-tertiary);
+}
+.ob-root .drophint b {
+  color: var(--text-secondary);
+  font-weight: var(--fw-medium);
+}
+
+/* detection result — the stack becomes a chip here, not a whole step */
+.ob-root .detect {
+  margin-top: var(--sp-6);
+  border: 1px solid var(--divider);
+  border-radius: var(--r-xl);
+  overflow: visible;
+  animation: ob-rise 0.18s ease;
 }
 @keyframes ob-rise {
+  from {
+    opacity: 0;
+    transform: translateY(7px);
+  }
   to {
     opacity: 1;
     transform: none;
   }
 }
-.ob-root .detect-card .fork-badge {
-  width: 38px;
-  height: 38px;
-}
-.ob-root .detect-card .info {
-  flex: 1;
-  min-width: 0;
-}
-.ob-root .detect-card .info h3 {
-  font-size: 15px;
-  font-weight: 620;
-  margin: 0;
-}
-.ob-root .detect-card .meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px 16px;
-  margin-top: 8px;
-  font-size: 12px;
-  color: var(--dim);
-  font-family: var(--mono);
-}
-.ob-root .detect-card .meta .k {
-  color: var(--faint);
-}
-.ob-root .git-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 12px;
-  font-weight: 550;
-  color: var(--run);
-  background: var(--green-dim);
-  padding: 4px 10px;
-  border-radius: 999px;
-  font-family: var(--sans);
-  flex: none;
-}
-
-/* recent list */
-.ob-root .recent {
-  margin-top: 14px;
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
-}
-.ob-root .recent-item {
+.ob-root .dtop {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 8px 10px;
-  border-radius: 8px;
-  background: none;
-  border: 1px solid transparent;
-  cursor: pointer;
-  color: var(--dim);
-  font-family: var(--mono);
-  font-size: 12px;
-  text-align: left;
-  transition: background 0.1s, border-color 0.1s;
+  gap: var(--sp-pop-lg);
+  padding: var(--sp-5) var(--sp-pop-lg);
+  background: var(--surface-card);
+  border-radius: var(--r-xl) var(--r-xl) 0 0;
 }
-.ob-root .recent-item:hover {
-  background: var(--row-hover);
-  border-color: var(--border-soft);
-  color: var(--text);
-}
-.ob-root .recent-item .ic {
-  color: var(--faint);
-  display: inline-flex;
-  flex: none;
-}
-
-/* stack grid */
-.ob-root .stack-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 10px;
-}
-.ob-root .stack-card {
-  position: relative;
-  text-align: left;
-  background: var(--panel);
-  border: 1.5px solid var(--border-soft);
-  border-radius: 11px;
-  padding: 15px 15px 14px;
-  cursor: pointer;
-  transition: border-color 0.12s, background 0.12s;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-.ob-root .stack-card:hover {
-  border-color: var(--border);
-}
-.ob-root .stack-card.sel {
-  border-color: var(--accent);
-  background: color-mix(in srgb, var(--accent) 8%, var(--panel));
-}
-.ob-root .stack-mono {
+.ob-root .dtop .badge {
   width: 34px;
   height: 34px;
-  border-radius: 9px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-family: var(--mono);
-  font-size: 13px;
-  font-weight: 600;
-  background: var(--field);
-  border: 1px solid var(--border-soft);
-  color: var(--dim);
-}
-.ob-root .stack-card.sel .stack-mono {
-  background: var(--accent-dim);
-  color: var(--accent);
-  border-color: transparent;
-}
-.ob-root .stack-card h3 {
-  font-size: 13.5px;
-  font-weight: 600;
-  margin: 0;
-}
-.ob-root .stack-card p {
-  font-size: 11.5px;
-  color: var(--faint);
-  margin: 2px 0 0;
-}
-.ob-root .stack-badge {
-  position: absolute;
-  top: 11px;
-  right: 11px;
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: var(--accent);
-  background: var(--accent-dim);
-  padding: 3px 8px;
-  border-radius: 999px;
-}
-.ob-root .stack-check {
-  position: absolute;
-  top: 11px;
-  right: 11px;
-  color: var(--accent);
-  display: inline-flex;
-}
-
-/* scan / package.json peek */
-.ob-root .scan {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 26px 4px;
-  color: var(--dim);
-  font-size: 13px;
-}
-.ob-root .scan .sp {
-  color: var(--accent);
-  display: inline-flex;
-}
-.ob-root .pkg-peek {
-  background: var(--panel-2);
-  border: 1px solid var(--border-soft);
-  border-radius: 10px;
-  overflow: hidden;
-  margin-bottom: 20px;
-}
-.ob-root .pkg-peek .bar {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 9px 13px;
-  border-bottom: 1px solid var(--border-soft);
-  font-family: var(--mono);
-  font-size: 11.5px;
-  color: var(--faint);
-}
-.ob-root .pkg-peek .bar .ic {
-  color: var(--accent);
-  display: inline-flex;
-}
-.ob-root .pkg-body {
-  padding: 11px 15px;
-  font-family: var(--mono);
-  font-size: 12px;
-  line-height: 1.75;
-  color: #c6c8cc;
-  max-height: 168px;
-  overflow-y: auto;
-}
-.ob-root .pkg-body .ln {
-  white-space: pre;
-}
-.ob-root .pkg-body .key {
-  color: var(--accent);
-}
-.ob-root .pkg-body .str {
-  color: #c6c8cc;
-}
-.ob-root .pkg-body .pun {
-  color: var(--faint);
-}
-.ob-root .pkg-body .hit {
-  background: var(--accent-dim);
-  border-radius: 4px;
-  padding: 0 3px;
-  margin: 0 -3px;
-}
-
-/* suggestion rows */
-.ob-root .sug-head {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  margin: 0 0 12px;
-}
-.ob-root .sug-head h3 {
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--dim);
-  margin: 0;
-}
-.ob-root .sug-head .desc {
-  font-size: 11.5px;
-  color: var(--faint);
-}
-.ob-root .sug-head .line {
-  flex: 1;
-  height: 1px;
-  background: var(--border-soft);
-}
-.ob-root .sug-head .add-action {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  cursor: pointer;
-  background: none;
-  border: 0;
-  color: var(--accent);
-  font-family: var(--sans);
-  font-size: 12.5px;
-  font-weight: 550;
-  padding: 3px 6px;
-  border-radius: 6px;
-  transition: background 0.1s;
-}
-.ob-root .sug-head .add-action:hover {
-  background: var(--accent-dim);
-}
-.ob-root .sug-list {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-.ob-root .sug {
-  display: flex;
-  align-items: center;
-  gap: 13px;
-  padding: 12px 14px;
-  background: var(--panel);
-  border: 1px solid var(--border-soft);
-  border-radius: 10px;
-  transition: border-color 0.12s, opacity 0.12s;
-}
-.ob-root .sug.off {
-  opacity: 0.5;
-}
-.ob-root .sug.on {
-  border-color: color-mix(in srgb, var(--accent) 45%, var(--border-soft));
-}
-.ob-root .sug .kind-ic {
-  width: 30px;
-  height: 30px;
-  border-radius: 8px;
+  border-radius: var(--r-xl);
   flex: none;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--field);
-  color: var(--dim);
-  border: 1px solid var(--border-soft);
+  display: grid;
+  place-items: center;
+  background: var(--accent-dim);
+  color: var(--action-primary);
 }
-.ob-root .sug .body {
-  flex: 1;
+.ob-root .dtop .info {
   min-width: 0;
-}
-.ob-root .sug .row1 {
-  display: flex;
-  align-items: center;
-  gap: 9px;
-}
-.ob-root .sug .name {
-  font-size: 14px;
-  font-weight: 560;
-}
-.ob-root .sug .tag {
-  font-size: 10.5px;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: var(--faint);
-  background: var(--field);
-  border: 1px solid var(--border-soft);
-  padding: 1.5px 7px;
-  border-radius: 5px;
-}
-.ob-root .sug .cmd {
-  font-family: var(--mono);
-  font-size: 11.5px;
-  color: var(--faint);
-  margin-top: 4px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.ob-root .sug .cmd b {
-  color: var(--dim);
-  font-weight: 400;
-}
-.ob-root .sug .port {
-  flex: none;
-  font-family: var(--mono);
-  font-size: 12px;
-  color: var(--accent);
-  background: var(--accent-dim);
-  padding: 3px 9px;
-  border-radius: 6px;
-}
-.ob-root .sug .port.none {
-  color: var(--faint);
-  background: var(--btn);
-}
-
-/* toggle switch */
-.ob-root .sw {
-  width: 38px;
-  height: 22px;
-  border-radius: 999px;
-  border: 0;
-  background: var(--border);
-  position: relative;
-  cursor: pointer;
-  flex: none;
-  transition: background 0.16s;
-  padding: 0;
-}
-.ob-root .sw::after {
-  content: "";
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  background: #e8e8ea;
-  transition: transform 0.16s;
-}
-.ob-root .sw.on {
-  background: var(--accent);
-}
-.ob-root .sw.on::after {
-  transform: translateX(16px);
-  background: #08171a;
-}
-
-/* grouped config sub-sections (step 4) */
-.ob-root .cfg-group {
-  margin-bottom: 22px;
-}
-.ob-root .cfg-two {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 12px;
-}
-.ob-root .kv-line {
-  display: grid;
-  grid-template-columns: 1fr 20px 1.5fr auto;
-  gap: 8px;
-  align-items: center;
-}
-.ob-root .kv-line + .kv-line {
-  margin-top: 7px;
-}
-.ob-root .kv-eq {
-  text-align: center;
-  color: var(--faint);
-  font-family: var(--mono);
-}
-.ob-root .step-line {
-  display: grid;
-  grid-template-columns: 22px 1fr auto;
-  gap: 9px;
-  align-items: center;
-}
-.ob-root .step-line + .step-line {
-  margin-top: 7px;
-}
-.ob-root .step-num2 {
-  width: 20px;
-  height: 20px;
-  border-radius: 6px;
-  background: var(--field);
-  border: 1px solid var(--border-soft);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-family: var(--mono);
-  font-size: 11px;
-  color: var(--faint);
-}
-
-/* review */
-.ob-root .rev-card {
-  background: var(--panel);
-  border: 1px solid var(--border-soft);
-  border-radius: 12px;
-  overflow: hidden;
-}
-.ob-root .rev-top {
-  display: flex;
-  align-items: center;
-  gap: 13px;
-  padding: 16px 18px;
-  border-bottom: 1px solid var(--border-soft);
-}
-.ob-root .rev-top .fork-badge {
-  width: 36px;
-  height: 36px;
-}
-.ob-root .rev-top h3 {
-  font-size: 15px;
-  font-weight: 620;
-  margin: 0;
-}
-.ob-root .rev-top .path {
-  font-family: var(--mono);
-  font-size: 11.5px;
-  color: var(--faint);
-  margin-top: 3px;
-}
-.ob-root .rev-top .sp {
   flex: 1;
 }
-.ob-root .rev-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-}
-.ob-root .rev-cell {
-  padding: 14px 18px;
-  border-top: 1px solid var(--border-soft);
-}
-.ob-root .rev-cell:nth-child(even) {
-  border-left: 1px solid var(--border-soft);
-}
-.ob-root .rev-cell .lbl {
-  font-size: 10.5px;
-  font-weight: 600;
-  letter-spacing: 0.07em;
-  text-transform: uppercase;
-  color: var(--faint);
-}
-.ob-root .rev-cell .val {
-  font-size: 13.5px;
-  margin-top: 6px;
-  color: var(--text);
-}
-.ob-root .rev-cell .val .mono {
-  font-family: var(--mono);
-  font-size: 12px;
-  color: var(--dim);
-}
-.ob-root .rev-list {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  margin-top: 6px;
-}
-.ob-root .rev-list .r {
+.ob-root .dtop h3 {
+  font-size: var(--fs-md);
+  font-weight: var(--fw-semi);
+  margin: 0;
   display: flex;
   align-items: center;
-  gap: 7px;
-  font-size: 12.5px;
-  color: var(--dim);
+  gap: var(--sp-row);
 }
-.ob-root .rev-list .r .d {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--accent);
+.ob-root .dtop .meta {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-pop);
+  margin-top: 3px;
+  font: var(--fs-micro) var(--mono);
+  color: var(--text-tertiary);
+  flex-wrap: wrap;
+}
+.ob-root .dtop .meta .k {
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  font-family: var(--sans);
+  font-weight: var(--fw-bold);
+  font-size: var(--fs-label);
+  letter-spacing: 0.08em;
+}
+.ob-root .okchip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  height: 21px;
+  padding: 0 var(--sp-row);
+  border-radius: var(--r-sm);
+  background: var(--green-dim);
+  color: var(--state-running);
+  font: var(--fw-semi) var(--fs-micro) var(--sans);
   flex: none;
 }
-
-/* success overlay */
-.ob-root .done-veil {
-  position: absolute;
-  inset: 0;
-  background: rgba(20, 21, 24, 0.72);
-  backdrop-filter: blur(3px);
-  display: flex;
+/* stack: detected, shown, changeable in one click — was step 2 of 5 */
+.ob-root .stackwrap {
+  position: relative;
+  flex: none;
+}
+.ob-root .stackchip {
+  display: inline-flex;
   align-items: center;
-  justify-content: center;
+  gap: var(--sp-3);
+  height: 24px;
+  padding: 0 var(--sp-3) 0 var(--sp-row);
+  border-radius: var(--r-md);
+  background: var(--surface-well);
+  border: 1px solid var(--divider);
+  color: var(--text-secondary);
+  font: var(--fs-small) var(--sans);
+  cursor: pointer;
+  transition: border-color var(--dur), color var(--dur);
+}
+.ob-root .stackchip:hover {
+  border-color: var(--border);
+  color: var(--text-primary);
+}
+.ob-root .stackchip .mn {
+  font: var(--fw-bold) var(--fs-label) var(--mono);
+  color: var(--action-primary);
+}
+.ob-root .stackmenu {
+  position: absolute;
+  top: calc(100% + 5px);
+  right: 0;
   z-index: 20;
-  animation: ob-fadein 0.25s ease;
-}
-@keyframes ob-fadein {
-  from {
-    opacity: 0;
-  }
-}
-.ob-root .done-card {
-  width: 380px;
-  background: var(--panel);
+  width: 232px;
+  max-height: 246px;
+  overflow-y: auto;
+  background: var(--surface-float);
   border: 1px solid var(--border);
-  border-radius: 16px;
-  padding: 30px 28px 26px;
-  text-align: center;
-  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.5);
-  animation: ob-pop 0.3s cubic-bezier(0.2, 0.8, 0.3, 1.2);
+  border-radius: var(--r-xl);
+  box-shadow: var(--shadow-pop);
+  padding: var(--sp-xs);
+  animation: ob-pop 0.12s var(--ease-pop);
 }
 @keyframes ob-pop {
   from {
     opacity: 0;
-    transform: scale(0.94) translateY(8px);
+    transform: translateY(-4px) scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: none;
   }
 }
-.ob-root .done-ring {
-  width: 60px;
-  height: 60px;
+.ob-root .smi {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-4);
+  width: 100%;
+  padding: var(--sp-tight) var(--sp-row);
+  border: 0;
+  border-radius: var(--r-md);
+  background: none;
+  cursor: pointer;
+  text-align: left;
+  color: var(--text-primary);
+  font-family: var(--sans);
+}
+.ob-root .smi:hover {
+  background: var(--raised-hi);
+}
+.ob-root .smi.on {
+  background: var(--accent-dim);
+  color: var(--action-primary);
+}
+.ob-root .smi .mn {
+  width: 22px;
+  font: var(--fw-bold) var(--fs-label) var(--mono);
+  color: var(--text-tertiary);
+  flex: none;
+}
+.ob-root .smi.on .mn {
+  color: var(--action-primary);
+}
+.ob-root .smi .nm {
+  font-size: var(--fs-body);
+  flex: 1;
+  min-width: 0;
+}
+.ob-root .smi .ds {
+  font: var(--fs-micro) var(--mono);
+  color: var(--text-tertiary);
+  flex: none;
+}
+.ob-root .smi .det {
+  font: var(--fw-bold) var(--fs-label) var(--sans);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--action-primary);
+  background: var(--accent-dim);
+  padding: 1px 5px;
+  border-radius: var(--r-xs);
+  flex: none;
+}
+
+/* what Canopy found — grouped, toggleable, the real payload */
+.ob-root .dsec {
+  border-top: 1px solid var(--divider);
+  padding: var(--sp-pop-lg) var(--sp-pop-lg);
+}
+.ob-root .scanning {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-4);
+  padding: var(--sp-6) var(--sp-pop-lg);
+  border-top: 1px solid var(--divider);
+  font-size: var(--fs-body);
+  color: var(--text-tertiary);
+}
+.ob-root .scanning .sp2 {
+  color: var(--action-primary);
+  display: inline-flex;
+}
+.ob-root .svcrow {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-pop);
+  padding: var(--sp-3) 0;
+}
+.ob-root .svcrow + .svcrow {
+  border-top: 1px solid var(--divider);
+}
+.ob-root .svcrow .kic {
+  width: 24px;
+  height: 24px;
+  border-radius: var(--r-md);
+  flex: none;
+  display: grid;
+  place-items: center;
+  background: var(--surface-well);
+  color: var(--text-tertiary);
+}
+.ob-root .svcrow.on .kic {
+  color: var(--action-primary);
+  background: var(--accent-dim);
+}
+.ob-root .svcrow .bd {
+  min-width: 0;
+  flex: 1;
+}
+.ob-root .svcrow .r1 {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+}
+.ob-root .svcrow .nm {
+  font-size: var(--fs-body);
+  font-weight: var(--fw-medium);
+  color: var(--text-primary);
+}
+.ob-root .svcrow.off .nm {
+  color: var(--text-tertiary);
+}
+.ob-root .svcrow .tag {
+  font: var(--fw-bold) var(--fs-label) var(--sans);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  background: var(--btn);
+  padding: 2px var(--sp-tight);
+  border-radius: var(--r-xs);
+  flex: none;
+}
+.ob-root .svcrow .cmd {
+  font: var(--fs-micro) var(--mono);
+  color: var(--text-tertiary);
+  margin-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ob-root .svcrow .cmd b {
+  color: var(--text-tertiary);
+  font-weight: var(--fw-regular);
+}
+.ob-root .svcrow .port {
+  font: var(--fs-small) var(--mono);
+  color: var(--action-primary);
+  flex: none;
+}
+.ob-root .svcrow.off .port,
+.ob-root .svcrow .port.none {
+  color: var(--text-tertiary);
+}
+.ob-root .svcrow .pin {
+  width: 62px;
+  height: 24px;
+  text-align: right;
+  padding: 0 var(--sp-3);
+}
+
+/* the derivation made visible — why these services */
+.ob-root .peek {
+  margin-top: var(--sp-4);
+  border: 1px solid var(--divider);
+  border-radius: var(--r-xl);
+  overflow: hidden;
+  background: var(--surface-well);
+}
+.ob-root .peek .bar {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  padding: var(--sp-tight) var(--sp-4);
+  border-bottom: 1px solid var(--divider);
+  font: var(--fs-micro) var(--mono);
+  color: var(--text-tertiary);
+}
+.ob-root .peek .bd {
+  padding: var(--sp-3) 0;
+  font: var(--fs-micro) / 1.62 var(--mono);
+  max-height: 150px;
+  overflow: auto;
+  user-select: text;
+}
+.ob-root .peek .ln {
+  padding: 0 var(--sp-pop);
+  white-space: pre;
+}
+.ob-root .peek .key {
+  color: var(--teal-text);
+}
+.ob-root .peek .key.hit {
+  color: var(--action-primary);
+  font-weight: var(--fw-semi);
+  background: var(--accent-dim);
+  border-radius: var(--r-xs);
+  padding: 0 3px;
+}
+.ob-root .peek .str {
+  color: #c3a6e8;
+}
+.ob-root .peek .pun {
+  color: var(--text-tertiary);
+}
+
+.ob-root .kv {
+  display: grid;
+  grid-template-columns: minmax(80px, 1fr) 10px minmax(110px, 1.5fr) auto;
+  gap: 5px 7px;
+  align-items: center;
+}
+.ob-root .kv .eq {
+  color: var(--text-tertiary);
+  font: var(--fs-small) var(--mono);
+  text-align: center;
+}
+.ob-root .stepline {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-4);
+  padding: var(--sp-xs) 0;
+}
+.ob-root .stepline .n2 {
+  width: 17px;
+  height: 17px;
+  border-radius: var(--r-sm);
+  flex: none;
+  display: grid;
+  place-items: center;
+  font: var(--fw-bold) var(--fs-label) var(--sans);
+  background: var(--btn);
+  color: var(--text-tertiary);
+}
+.ob-root .adv {
+  border-top: 1px solid var(--divider);
+}
+.ob-root .adv > summary {
+  list-style: none;
+  cursor: pointer;
+  padding: var(--sp-pop) var(--sp-pop-lg);
+  font: var(--fw-medium) var(--fs-small) var(--sans);
+  color: var(--text-tertiary);
+  display: flex;
+  align-items: center;
+  gap: var(--sp-row);
+}
+.ob-root .adv > summary::-webkit-details-marker {
+  display: none;
+}
+.ob-root .adv > summary:hover {
+  color: var(--text-primary);
+}
+.ob-root .adv > summary .cv {
+  display: inline-flex;
+  transition: transform 0.15s;
+}
+.ob-root .adv[open] > summary .cv {
+  transform: rotate(90deg);
+}
+.ob-root .adv > summary .n {
+  margin-left: auto;
+  font-size: var(--fs-micro);
+  font-weight: var(--fw-regular);
+}
+.ob-root .advb {
+  padding: 0 var(--sp-pop-lg) var(--sp-pop-lg);
+}
+.ob-root .hint {
+  font-size: var(--fs-micro);
+  color: var(--text-tertiary);
+  line-height: 1.5;
+  margin-top: var(--sp-tight);
+}
+.ob-root .hint code {
+  font-family: var(--mono);
+  color: var(--teal-text);
+}
+.ob-root .hint a {
+  color: var(--teal-text);
+  cursor: pointer;
+}
+.ob-root .hint a:hover {
+  color: var(--action-primary);
+}
+
+/* footer: one primary action, no step dots to count */
+.ob-root .ofoot {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-4);
+  padding: 0 var(--sp-6);
+  height: 50px;
+  border-top: 1px solid var(--divider);
+  background: var(--surface-float);
+}
+.ob-root .ofoot .sp {
+  flex: 1;
+}
+.ob-root .ofoot .sum {
+  font-size: var(--fs-small);
+  color: var(--text-tertiary);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ob-root .ofoot .sum b {
+  color: var(--text-primary);
+  font-weight: var(--fw-semi);
+}
+
+/* ── C · provisioning ─────────────────────────────────────────────── */
+.ob-root .runwrap {
+  flex: 1;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: var(--sp-empty-lg);
+  min-height: 0;
+  overflow-y: auto;
+}
+.ob-root .runcard {
+  width: 100%;
+  max-width: 436px;
+  margin: auto 0;
+}
+.ob-root .runcard h2 {
+  font-size: var(--fs-lg);
+  font-weight: var(--fw-semi);
+  margin: 0 0 var(--sp-xs);
+  text-align: center;
+}
+.ob-root .runcard > p {
+  font-size: var(--fs-small);
+  color: var(--text-tertiary);
+  margin: 0 0 var(--sp-7);
+  text-align: center;
+}
+.ob-root .stp {
+  display: flex;
+  align-items: baseline;
+  gap: var(--sp-pop);
+  padding: var(--sp-2) 0;
+  font: var(--fs-small) var(--mono);
+}
+.ob-root .stp .bl {
+  width: 14px;
+  flex: none;
+  text-align: center;
+  color: var(--text-tertiary);
+}
+.ob-root .stp.done .bl {
+  color: var(--state-running);
+}
+.ob-root .stp.act .bl {
+  color: var(--action-primary);
+}
+.ob-root .stp .tx {
+  flex: 1;
+  min-width: 0;
+  color: var(--text-secondary);
+}
+.ob-root .stp.done .tx {
+  color: var(--text-primary);
+}
+.ob-root .stp.pend .tx {
+  color: var(--text-tertiary);
+}
+.ob-root .stp .mt {
+  font-size: var(--fs-micro);
+  color: var(--text-tertiary);
+  flex: none;
+}
+.ob-root .runcancel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--sp-3);
+  margin-top: 20px;
+  padding-top: var(--sp-7);
+  border-top: 1px solid var(--divider);
+}
+.ob-root .runcancel > span {
+  font-size: var(--fs-micro);
+  color: var(--text-tertiary);
+}
+
+/* ── D · ready ────────────────────────────────────────────────────── */
+.ob-root .donering {
+  width: 56px;
+  height: 56px;
   border-radius: 50%;
-  margin: 0 auto 16px;
+  margin: 0 auto var(--sp-6);
+  display: grid;
+  place-items: center;
+  background: var(--green-dim);
+  color: var(--state-running);
+  border: 1px solid var(--green-border);
+}
+.ob-root .doneacts {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--green-dim);
-  color: var(--run);
+  gap: var(--sp-4);
+  margin-top: 20px;
 }
-.ob-root .done-card h2 {
-  font-size: 18px;
-  font-weight: 640;
-  margin: 0;
+.ob-root .donefacts {
+  margin-top: 22px;
+  border-top: 1px solid var(--divider);
+  padding-top: var(--sp-6);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--sp-4) var(--sp-7);
+  text-align: left;
 }
-.ob-root .done-card p {
-  font-size: 13px;
-  color: var(--dim);
-  margin: 8px 0 22px;
-  line-height: 1.5;
+.ob-root .df .l {
+  font: var(--fw-bold) var(--fs-label) var(--sans);
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  margin-bottom: 3px;
 }
-.ob-root .done-actions {
-  display: flex;
-  flex-direction: column;
-  gap: 9px;
+.ob-root .df .v {
+  font: var(--fs-small) var(--mono);
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
-.ob-root .done-actions .btn {
-  width: 100%;
-  justify-content: center;
+.ob-root .df .v em {
+  font-style: normal;
+  color: var(--action-primary);
 }
 
-.ob-root .ob-scroll::-webkit-scrollbar,
-.ob-root .pkg-body::-webkit-scrollbar {
-  width: 10px;
+/* ── toast ────────────────────────────────────────────────────────── */
+.ob-root .toast {
+  position: absolute;
+  bottom: 62px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--toast-bg);
+  color: var(--text-primary);
+  padding: var(--sp-row) var(--sp-toast-x);
+  border-radius: var(--r-xl);
+  font-size: var(--fs-body);
+  box-shadow: var(--shadow-toast);
+  border: 1px solid var(--border);
+  z-index: 80;
 }
-.ob-root .ob-scroll::-webkit-scrollbar-thumb,
-.ob-root .pkg-body::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.08);
-  border-radius: 6px;
-  border: 3px solid transparent;
-  background-clip: padding-box;
+.ob-root .spin {
+  animation: ob-spin 0.8s linear infinite;
+  transform-origin: 50% 50%;
+}
+@keyframes ob-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@container obwin (max-width: 620px) {
+  .ob-root .donefacts {
+    grid-template-columns: 1fr;
+  }
+  .ob-root .obinner {
+    padding: 20px var(--sp-6) var(--sp-8);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ob-root .detect,
+  .ob-root .stackmenu {
+    animation: none;
+  }
 }

--- a/src/styles/onboarding.css
+++ b/src/styles/onboarding.css
@@ -1,14 +1,16 @@
 /* First-run onboarding — ported from the redesign handoff (Canopy
-   Onboarding.html / cxo-onboard.jsx). The shipped 5-step wizard (Repository →
-   Stack → Services → Commands → Review) collapses into ONE adaptive screen:
-   paste or drop a repo, see what Canopy found and what it will do, adjust
-   anything inline, one action. Plus the empty state, provisioning narration and
-   a "ready" screen that ends on the next action.
+   Onboarding.html / cxo-onboard.jsx, revised). The shipped 5-step wizard
+   (Repository → Stack → Services → Commands → Review) collapses into ONE
+   adaptive screen. The empty state makes the case for worktrees (a checkout-vs-
+   worktree comparison + highlights); the add screen detects as you type, shows
+   the derivation, and lets you edit each service inline; provisioning narrates
+   the real work; "ready" ends on the next action.
 
    Every selector is scoped under .ob-root so nothing leaks into the main window
    or Settings. Colours resolve from the shared token layer (tokens.css); the
-   design's own token names (--surface-*, --action-*, --r-*, --fs-*) are the
-   semantic aliases declared there, so this sheet declares none of its own. */
+   design's own token names are the semantic aliases declared there, so this
+   sheet declares none of its own. The design's light/dark toggle is dropped —
+   the app ships dark only. */
 .ob-root {
   position: fixed;
   inset: 0;
@@ -19,7 +21,6 @@
   flex-direction: column;
   font-family: var(--sans);
   user-select: none;
-  /* the screen keys its one responsive break off its own width, not the window */
   container-type: inline-size;
   container-name: obwin;
 }
@@ -35,7 +36,6 @@
   background: var(--surface-float);
   border-bottom: 1px solid var(--divider);
 }
-/* macOS overlay titlebar: clear the traffic lights (see app.css) */
 .mac .ob-root .ob-tb {
   padding-left: 80px;
 }
@@ -54,27 +54,6 @@
 .ob-root .ob-tb .sp {
   flex: 1;
   align-self: stretch;
-}
-.ob-root .ob-ib {
-  height: 26px;
-  min-width: 26px;
-  padding: 0 var(--sp-tight);
-  border: 0;
-  cursor: pointer;
-  background: none;
-  color: var(--text-secondary);
-  border-radius: var(--r-md);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--sp-tight);
-  font: var(--fs-body) var(--sans);
-  flex: none;
-  transition: background var(--dur-fast), color var(--dur-fast);
-}
-.ob-root .ob-ib:hover {
-  background: var(--btn);
-  color: var(--text-primary);
 }
 .ob-root .ob-skip {
   height: 24px;
@@ -156,18 +135,49 @@
   padding: 0 var(--sp-4);
   font-size: var(--fs-small);
 }
+.ob-root .btn.bad:hover {
+  background: var(--red-dim);
+  color: var(--red-text);
+  border-color: var(--red-border-hi);
+}
 .ob-root .btn:focus-visible,
 .ob-root .ob-skip:focus-visible,
-.ob-root .ob-ib:focus-visible,
 .ob-root .rr:focus-visible,
 .ob-root .stackchip:focus-visible,
-.ob-root .smi:focus-visible {
+.ob-root .smi:focus-visible,
+.ob-root .asbtn:focus-visible,
+.ob-root .cbx:focus-visible,
+.ob-root .ico:focus-visible {
   outline: 2px solid var(--action-primary);
   outline-offset: -2px;
 }
 .ob-root .btn .k {
   font: 500 var(--fs-micro) var(--mono);
   opacity: 0.6;
+}
+.ob-root .ico {
+  width: 26px;
+  height: 26px;
+  border: 1px solid var(--divider);
+  background: var(--surface-well);
+  border-radius: var(--r-md);
+  cursor: pointer;
+  color: var(--text-tertiary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+  transition: background var(--dur-fast), color var(--dur-fast), border-color var(--dur-fast);
+}
+.ob-root .ico:hover {
+  background: var(--btn);
+  color: var(--text-primary);
+  border-color: var(--border);
+}
+.ob-root .ico.bad:hover {
+  background: var(--red-dim);
+  color: var(--red-text);
+  border-color: var(--red-border-hi);
 }
 .ob-root .inp {
   height: 30px;
@@ -192,39 +202,47 @@
   font-family: var(--mono);
   font-size: var(--fs-small);
 }
-/* toggle — a control, so it floats: full-round track + knob */
-.ob-root .tgl {
-  position: relative;
-  width: 30px;
-  height: 17px;
-  border-radius: var(--r-xl);
-  background: var(--btn-hover);
-  border: 0;
+/* select styled as an input, with a chevron affordance */
+.ob-root .inp.sel {
+  appearance: none;
+  padding-right: 24px;
+  cursor: pointer;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%237c7e86' stroke-width='2.4' stroke-linecap='round' stroke-linejoin='round'><path d='M6 9l6 6l6 -6'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 9px center;
+}
+/* the on/off control is a checkbox — a value you set, not a live switch */
+.ob-root .cbx {
+  width: 16px;
+  height: 16px;
+  border-radius: var(--r-xs);
+  border: 1px solid var(--border);
+  background: var(--surface-well);
+  display: grid;
+  place-items: center;
   cursor: pointer;
   flex: none;
-  transition: background 0.14s;
+  color: var(--action-primary-ink);
+  padding: 0;
+  transition: background var(--dur), border-color var(--dur);
 }
-.ob-root .tgl.on {
+.ob-root .cbx:hover {
+  border-color: var(--border-pop);
+}
+.ob-root .cbx.on {
   background: var(--action-primary);
+  border-color: var(--action-primary);
 }
-.ob-root .tgl i {
-  position: absolute;
-  top: 2.5px;
-  left: 2.5px;
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  background: #d5d7dc;
-  transition: transform 0.14s, background 0.14s;
-  display: block;
+.ob-root .impline {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-pop);
+  padding: var(--sp-4) 0 var(--sp-xs);
+  font-size: var(--fs-micro);
+  color: var(--text-tertiary);
 }
-.ob-root .tgl.on i {
-  transform: translateX(13px);
-  background: var(--action-primary-ink);
-}
-.ob-root .tgl:focus-visible {
-  outline: 2px solid var(--action-primary);
-  outline-offset: 2px;
+.ob-root .impline > span {
+  flex: 1;
 }
 /* uppercase section label with a trailing hairline */
 .ob-root .slab {
@@ -249,45 +267,207 @@
   background: var(--divider);
 }
 
-/* ── A · empty state — first launch used to say nothing ───────────── */
-.ob-root .emptywrap {
+/* ── A · empty state — the ask on the left, the case on the right ─── */
+.ob-root .hero {
   flex: 1;
-  display: flex;
-  align-items: flex-start;
-  justify-content: center;
-  padding: var(--sp-empty-lg);
   min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.02fr);
   overflow-y: auto;
 }
-.ob-root .emptycard {
-  width: 100%;
-  max-width: 540px;
-  text-align: center;
-  margin: auto 0;
+.ob-root .heroL {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 36px 26px 40px 40px;
 }
-.ob-root .emptyring {
-  width: 60px;
-  height: 60px;
-  border-radius: var(--r-2xl);
-  margin: 0 auto var(--sp-7);
-  display: grid;
-  place-items: center;
-  background: var(--accent-dim);
-  color: var(--action-primary);
-  border: 1px solid var(--teal-border);
-}
-.ob-root .emptycard h1 {
-  font-size: var(--fs-xl);
-  font-weight: var(--fw-semi);
+.ob-root .heromark {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-4);
+  font: var(--fw-semi) var(--fs-lg) var(--sans);
   letter-spacing: -0.02em;
-  margin: 0 0 var(--sp-row);
+  margin-bottom: var(--sp-8);
 }
-.ob-root .emptycard > p {
+.ob-root .heromark .fk {
+  color: var(--action-primary);
+  display: inline-flex;
+}
+.ob-root .hero h1 {
+  font-size: 26px;
+  font-weight: 640;
+  letter-spacing: -0.025em;
+  margin: 0 0 10px;
+  line-height: 1.15;
+}
+.ob-root .heroL > p {
   font-size: var(--fs-md);
   color: var(--text-secondary);
   line-height: 1.6;
-  margin: 0 auto 20px;
-  max-width: 430px;
+  margin: 0 0 22px;
+  max-width: 400px;
+  text-wrap: pretty;
+}
+.ob-root .heroL > p.herohint {
+  font-size: var(--fs-micro);
+  color: var(--text-tertiary);
+  margin: 0;
+  max-width: none;
+}
+.ob-root .hero .emptyacts {
+  justify-content: flex-start;
+  margin-bottom: var(--sp-6);
+}
+.ob-root .heroR {
+  margin: var(--sp-6) var(--sp-6) var(--sp-6) 0;
+  padding: 20px;
+  border-radius: var(--r-2xl);
+  border: 1px solid var(--divider);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: var(--sp-7);
+  background: radial-gradient(110% 80% at 12% -12%, var(--accent-dim) 0%, transparent 62%), linear-gradient(168deg, var(--surface-float) 0%, var(--surface-app) 100%);
+}
+/* the point of a worktree is the comparison, so draw both sides */
+.ob-root .cmp {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-5);
+}
+.ob-root .cmp-card {
+  border: 1px solid var(--divider);
+  border-radius: var(--r-lg);
+  padding: 13px 14px;
+}
+.ob-root .cmp-card.was {
+  background: var(--surface-well);
+}
+.ob-root .cmp-card.is {
+  background: var(--surface-card);
+  border-color: var(--border);
+  box-shadow: var(--shadow-pop);
+}
+.ob-root .cmp-h {
+  display: flex;
+  align-items: baseline;
+  gap: var(--sp-row);
+  padding-bottom: var(--sp-4);
+  margin-bottom: var(--sp-4);
+  border-bottom: 1px solid var(--divider);
+}
+.ob-root .cmp-h b {
+  font: var(--fw-medium) var(--fs-small) var(--mono);
+  letter-spacing: var(--tracking-tight);
+  color: var(--text-secondary);
+}
+.ob-root .cmp-card.is .cmp-h b {
+  color: var(--action-primary);
+}
+.ob-root .cmp-h span {
+  margin-left: auto;
+  font-size: var(--fs-micro);
+  color: var(--text-tertiary);
+}
+.ob-root .cmp-row {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-row);
+  padding: var(--sp-2) 0;
+  min-width: 0;
+}
+.ob-root .cmp-row .fd {
+  width: 14px;
+  flex: none;
+  display: inline-flex;
+  color: var(--text-tertiary);
+  align-self: flex-start;
+  margin-top: 2px;
+}
+.ob-root .cmp-row .bd {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.ob-root .cmp-row .p {
+  font: var(--fs-micro) var(--mono);
+  color: var(--text-tertiary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.ob-root .cmp-row .b {
+  font: var(--fw-medium) var(--fs-micro) var(--mono);
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.ob-root .cmp-row .s {
+  font: var(--fs-micro) var(--mono);
+  color: var(--action-primary);
+  flex: none;
+}
+.ob-root .cmp-row.off {
+  opacity: 0.55;
+}
+.ob-root .cmp-row.off .b {
+  color: var(--text-tertiary);
+  text-decoration: line-through;
+  text-decoration-color: var(--divider);
+}
+.ob-root .cmp-row.off .s {
+  font-family: var(--sans);
+  color: var(--text-tertiary);
+}
+.ob-root .cmp-n {
+  margin: var(--sp-4) 0 0;
+  font-size: var(--fs-micro);
+  color: var(--text-tertiary);
+  line-height: 1.5;
+  text-wrap: pretty;
+}
+.ob-root .cmp-card.is .cmp-n {
+  color: var(--text-secondary);
+}
+.ob-root .hilites {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+  margin-bottom: var(--sp-6);
+}
+.ob-root .hi {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--sp-pop-lg);
+}
+.ob-root .hi .t {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--r-md);
+  flex: none;
+  display: grid;
+  place-items: center;
+  background: var(--surface-well);
+  border: 1px solid var(--divider);
+  color: var(--action-primary);
+}
+.ob-root .hi .bd {
+  min-width: 0;
+}
+.ob-root .hi h3 {
+  margin: 0;
+  font-size: var(--fs-body);
+  font-weight: var(--fw-semi);
+  letter-spacing: -0.01em;
+}
+.ob-root .hi p {
+  margin: 3px 0 0;
+  font-size: var(--fs-small);
+  color: var(--text-secondary);
+  line-height: 1.5;
   text-wrap: pretty;
 }
 .ob-root .emptyacts {
@@ -296,45 +476,6 @@
   justify-content: center;
   gap: var(--sp-4);
   margin-bottom: var(--sp-empty);
-}
-.ob-root .whatnext {
-  border-top: 1px solid var(--divider);
-  padding-top: var(--sp-7);
-  text-align: left;
-}
-.ob-root .wn {
-  display: flex;
-  align-items: flex-start;
-  gap: var(--sp-pop-lg);
-  padding: var(--sp-3) 0;
-}
-.ob-root .wn .n {
-  width: 18px;
-  height: 18px;
-  border-radius: var(--r-sm);
-  flex: none;
-  display: grid;
-  place-items: center;
-  font: var(--fw-bold) var(--fs-label) var(--sans);
-  background: var(--btn);
-  color: var(--text-tertiary);
-  margin-top: 1px;
-}
-.ob-root .wn .t {
-  min-width: 0;
-}
-.ob-root .wn .t b {
-  display: block;
-  font-size: var(--fs-body);
-  font-weight: var(--fw-medium);
-  color: var(--text-primary);
-}
-.ob-root .wn .t span {
-  display: block;
-  font-size: var(--fs-small);
-  color: var(--text-tertiary);
-  line-height: 1.45;
-  margin-top: 2px;
 }
 
 /* ── B · one adaptive add screen ──────────────────────────────────── */
@@ -580,7 +721,7 @@
   flex: none;
 }
 
-/* what Canopy found — grouped, toggleable, the real payload */
+/* what Canopy found — grouped, editable, the real payload */
 .ob-root .dsec {
   border-top: 1px solid var(--divider);
   padding: var(--sp-pop-lg) var(--sp-pop-lg);
@@ -604,7 +745,7 @@
   gap: var(--sp-pop);
   padding: var(--sp-3) 0;
 }
-.ob-root .svcrow + .svcrow {
+.ob-root .svcitem + .svcitem {
   border-top: 1px solid var(--divider);
 }
 .ob-root .svcrow .kic {
@@ -625,10 +766,27 @@
   min-width: 0;
   flex: 1;
 }
+/* the row body is a button that opens the inline editor */
+.ob-root .svcrow .asbtn {
+  all: unset;
+  display: block;
+  cursor: pointer;
+  min-width: 0;
+  flex: 1;
+}
 .ob-root .svcrow .r1 {
   display: flex;
   align-items: center;
   gap: var(--sp-3);
+}
+.ob-root .svcrow .cv {
+  display: inline-flex;
+  color: var(--text-tertiary);
+  transition: transform var(--dur);
+}
+.ob-root .svcitem.open .cv {
+  transform: rotate(90deg);
+  color: var(--action-primary);
 }
 .ob-root .svcrow .nm {
   font-size: var(--fs-body);
@@ -675,6 +833,43 @@
   text-align: right;
   padding: 0 var(--sp-3);
 }
+/* the inline service editor */
+.ob-root .svcedit {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--sp-4);
+  padding: var(--sp-xs) 0 var(--sp-5) 34px;
+}
+.ob-root .fld {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-xs);
+  min-width: 0;
+}
+.ob-root .fld.wide {
+  grid-column: 1 / -1;
+}
+.ob-root .fld > span {
+  font: var(--fw-bold) var(--fs-label) var(--sans);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+.ob-root .fld .inp {
+  height: 28px;
+  width: 100%;
+  box-sizing: border-box;
+}
+.ob-root .svcedit-f {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-row);
+  margin-top: 2px;
+}
+.ob-root .svcedit-f .sp {
+  flex: 1;
+}
 
 /* the derivation made visible — why these services */
 .ob-root .peek {
@@ -715,7 +910,7 @@
   padding: 0 3px;
 }
 .ob-root .peek .str {
-  color: #c3a6e8;
+  color: var(--syntax-str, #c3a6e8);
 }
 .ob-root .peek .pun {
   color: var(--text-tertiary);
@@ -905,6 +1100,26 @@
 }
 
 /* ── D · ready ────────────────────────────────────────────────────── */
+.ob-root .emptycard {
+  width: 100%;
+  max-width: 540px;
+  text-align: center;
+  margin: auto 0;
+}
+.ob-root .emptycard h1 {
+  font-size: var(--fs-xl);
+  font-weight: var(--fw-semi);
+  letter-spacing: -0.02em;
+  margin: 0 0 var(--sp-row);
+}
+.ob-root .emptycard > p {
+  font-size: var(--fs-md);
+  color: var(--text-secondary);
+  line-height: 1.6;
+  margin: 0 auto 20px;
+  max-width: 430px;
+  text-wrap: pretty;
+}
 .ob-root .donering {
   width: 56px;
   height: 56px;
@@ -976,8 +1191,21 @@
   }
 }
 
+/* narrow window: drop the showcase, stack the facts, tighten padding */
+@container obwin (max-width: 760px) {
+  .ob-root .hero {
+    grid-template-columns: 1fr;
+  }
+  .ob-root .heroR {
+    display: none;
+  }
+  .ob-root .heroL {
+    padding: 30px 26px;
+  }
+}
 @container obwin (max-width: 620px) {
-  .ob-root .donefacts {
+  .ob-root .donefacts,
+  .ob-root .svcedit {
     grid-template-columns: 1fr;
   }
   .ob-root .obinner {

--- a/src/styles/popover.css
+++ b/src/styles/popover.css
@@ -1,262 +1,490 @@
-/* Popover styles — ported 1:1 from "Worktree Manager Popover.html" (.wm-*) */
+/* Menu-bar tray — ported 1:1 from the design system's "Canopy Tray.html".
+   The design's presentation scaffolding (fake desktop + menu bar) is dropped:
+   the frameless window IS the popover card, so `.pop` fills the window and the
+   body is transparent. Every other rule is the design's verbatim, token-driven.
+   This sheet loads only in the popover window (with tokens.css). */
 
+html,
 body {
-  /* transparent window: the .wm-pop draws its own chrome inside a shadow gutter */
+  margin: 0;
+  height: 100%;
+}
+body {
+  /* transparent window: the card draws its own chrome (radius + shadow) */
   background: transparent;
-}
-
-/* hide scrollbars in the popover window — trackpad/wheel scroll still works.
-   (Scoped: popover.css only loads in the popover window.) */
-html {
-  scrollbar-width: none; /* Firefox/standards */
-}
-::-webkit-scrollbar {
-  width: 0;
-  height: 0;
-  background: transparent;
-}
-
-.pop-gutter {
-  /* window hugs the card — no shadow gutter */
-  padding: 0;
-}
-
-.wm-pop {
-  width: 284px;
-  /* cap to the window height so the list scrolls inside rather than the window
-     clipping; JS caps the window at the available screen height */
-  max-height: 100vh;
-  background: var(--bg);
-  border: 1px solid var(--border-pop);
-  border-radius: 11px;
-  padding: 5px 0;
-  color: var(--text);
   font-family: var(--sans);
+  -webkit-font-smoothing: antialiased;
+  color: var(--text);
   user-select: none;
-  overflow: hidden;
+}
+.pop-gutter {
+  height: 100%;
+}
+.pop-gutter > div {
+  height: 100%;
+}
+
+/* ── the popover card — fills the frameless window ─────────────── */
+.pop {
+  width: 100%;
+  height: 100%;
+  background: var(--titlebar);
+  border: var(--border-w) solid var(--border);
+  border-radius: var(--r-xl);
+  box-shadow: var(--shadow-pop);
   display: flex;
   flex-direction: column;
+  max-height: 100vh;
+  overflow: hidden;
+}
+.pop.is-in {
+  animation: pin var(--dur-panel) var(--ease-pop);
+}
+@keyframes pin {
+  from {
+    opacity: 0;
+    transform: translateY(-4px) scale(0.985);
+  }
 }
 
-.wm-item {
+.ph {
+  padding: var(--sp-4) var(--sp-5) var(--sp-3);
   display: flex;
-  align-items: center;
-  gap: 10px;
-  width: 100%;
+  flex-direction: column;
+  gap: var(--sp-3);
   flex: none;
-  background: none;
-  border: 0;
-  cursor: pointer;
-  font-family: inherit;
-  font-size: 14px;
-  color: var(--text);
-  text-align: left;
-  padding: 6px 14px;
-  border-radius: 7px;
-  margin: 0;
-  transition: background 0.09s ease;
 }
-.wm-item:hover {
-  background: var(--hover);
-}
-.wm-item:focus {
-  outline: none;
-}
-.wm-item:focus-visible {
-  background: var(--hover);
-}
-.wm-item-ic {
-  display: inline-flex;
-  color: var(--dim);
-}
-.wm-item--flash {
-  background: var(--accent) !important;
-  color: #07181a;
-}
-.wm-item--flash .wm-item-ic {
-  color: #07181a;
-}
-
-.wm-sep {
-  height: 1px;
-  flex: none;
-  background: var(--border-pop);
-  margin: 6px 12px;
-}
-
-/* the worktree list — scrolls inside the popover when it hits the height cap */
-.wm-groups {
-  flex: 1 1 auto;
-  min-height: 0;
-  overflow-y: auto;
-}
-
-.wm-grp {
-  padding: 0;
-}
-.wm-grp--div {
-  border-top: 1px solid var(--border-pop);
-  margin-top: 5px;
-  padding-top: 5px;
-}
-
-.wm-group {
+.repo {
   display: flex;
   align-items: center;
-  gap: 6px;
-  font-size: 11.5px;
-  color: var(--faint);
-  padding: 8px 14px 3px;
-  letter-spacing: 0.01em;
-  line-height: 1;
-}
-.wm-fork {
-  display: inline-flex;
-  color: var(--accent);
-}
-.wm-mid {
-  color: var(--border-pop);
-  padding: 0 1px;
-}
-
-/* worktree row — branch + actions, then service chips */
-.wm-wt {
-  padding: 5px 10px 7px 14px;
-  border-radius: 7px;
-  margin: 1px 0;
-  transition: background 0.09s ease;
-}
-.wm-wt:hover {
-  background: var(--hover);
-}
-.wm-wt-top {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-.wm-wt-branch {
-  flex: 1 1 auto;
+  gap: var(--sp-3);
   min-width: 0;
-  font-size: 14px;
-  font-weight: 550;
+  position: relative;
+}
+.repo > button {
+  all: unset;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  height: var(--h-control-sm);
+  padding: 0 var(--sp-2) 0 var(--sp-1);
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  min-width: 0;
+  transition: background var(--dur-fast);
+}
+.repo > button:hover {
+  background: var(--hover);
+}
+.repo .nm {
+  font-size: var(--fs-body);
+  font-weight: var(--fw-semi);
+  letter-spacing: var(--tracking-tight);
+}
+.gear {
+  all: unset;
+  width: 24px;
+  height: 24px;
+  border-radius: var(--r-md);
+  display: grid;
+  place-items: center;
+  color: var(--muted);
+  cursor: pointer;
+  transition: background var(--dur-fast), color var(--dur-fast);
+}
+.gear:hover {
+  background: var(--btn-hover);
   color: var(--text);
-  letter-spacing: -0.005em;
+}
+.repo .sum {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  font-size: var(--fs-micro);
+  color: var(--faint);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.repo .sum b {
+  color: var(--green);
+  font-weight: var(--fw-medium);
+}
+
+/* repo switcher menu */
+.repomenu {
+  position: absolute;
+  z-index: 6;
+  top: calc(var(--h-control-sm) + var(--sp-1));
+  left: 0;
+  min-width: 200px;
+  max-width: 280px;
+  background: var(--raised);
+  border: var(--border-w) solid var(--border);
+  border-radius: var(--r-lg);
+  box-shadow: var(--shadow-menu);
+  padding: var(--sp-2);
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-hair);
+}
+.repomenu button {
+  all: unset;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  padding: var(--sp-2) var(--sp-3);
+  border-radius: var(--r-md);
+  cursor: pointer;
+  font-size: var(--fs-body);
+  color: var(--text);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.wm-acts {
-  flex: none;
-  display: flex;
-  align-items: center;
-  gap: 2px;
+.repomenu button:hover {
+  background: var(--raised-hi);
 }
-.wm-act {
-  flex: none;
-  width: 26px;
-  height: 24px;
-  border: 0;
-  cursor: pointer;
-  background: none;
-  color: var(--dim);
-  border-radius: 6px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  transition: background 0.1s ease, color 0.1s ease;
-}
-.wm-act:hover {
-  background: var(--btn);
-  color: var(--text);
-}
-.wm-act--busy {
-  color: var(--accent);
-  cursor: default;
-}
-.wm-act:disabled {
-  opacity: 0.35;
-  cursor: default;
-}
-.wm-act:disabled:hover {
-  background: none;
-  color: var(--dim);
-}
-.wm-toggle {
-  flex: none;
-  min-width: 52px;
-  margin-left: 3px;
-  border: 0;
-  cursor: pointer;
-  background: var(--btn);
-  color: var(--text);
-  font-family: inherit;
-  font-size: 12.5px;
-  font-weight: 500;
-  padding: 4px 12px;
-  border-radius: 6px;
-  line-height: 1.3;
-  transition: background 0.1s ease, opacity 0.1s ease;
-}
-.wm-toggle:hover {
-  background: var(--btn-hover);
-}
-.wm-toggle:active {
-  transform: translateY(0.5px);
-}
-.wm-toggle.is-busy {
-  opacity: 0.5;
-  cursor: default;
-  color: var(--dim);
+.repomenu button.on {
+  color: var(--teal-text);
 }
 
-.wm-svcs {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 4px 14px;
-  margin-top: 3px;
-  padding-left: 1px;
-}
-.wm-svc {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 12px;
-  color: var(--dim);
-}
-.wm-svc-dot {
+.dot {
   width: 6px;
   height: 6px;
   border-radius: 50%;
   flex: none;
-  background: var(--faint);
 }
-.wm-svc-dot.s-running {
-  background: var(--run);
+.dot.run {
+  background: var(--green);
+  box-shadow: var(--halo) var(--green-dim);
 }
-.wm-svc-dot.s-stopped {
-  background: var(--faint);
+.dot.idle {
+  background: var(--off);
 }
-.wm-svc-dot.s-error {
-  background: var(--stop);
+.dot.err {
+  background: var(--red);
+  box-shadow: var(--halo) var(--red-dim);
 }
-.wm-svc-dot.s-starting,
-.wm-svc-dot.s-stopping {
-  background: var(--accent);
-  animation: wm-pulse 0.9s ease-in-out infinite;
+.dot.boot {
+  background: var(--amber);
+  box-shadow: var(--halo) var(--warn-dim);
+  animation: bp 1s ease-in-out infinite;
 }
-@keyframes wm-pulse {
+@keyframes bp {
   50% {
     opacity: 0.35;
   }
 }
 
-.wm-spin {
-  animation: wm-spin 0.8s linear infinite;
-  transform-origin: 50% 50%;
+.search {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  height: var(--h-control);
+  padding: 0 var(--sp-4);
+  background: var(--panel-2);
+  border: var(--border-w) solid var(--border-soft);
+  border-radius: var(--r-lg);
+  transition: border-color var(--dur);
 }
-@keyframes wm-spin {
-  to {
-    transform: rotate(360deg);
-  }
+.search:focus-within {
+  border-color: var(--teal);
+}
+.search > svg {
+  color: var(--faint);
+  flex: none;
+}
+.search input {
+  all: unset;
+  flex: 1;
+  min-width: 0;
+  font: var(--fw-regular) var(--fs-body) var(--mono);
+  color: var(--text);
+  letter-spacing: var(--tracking-tight);
+}
+.search input::placeholder {
+  color: var(--faint);
+  font-family: var(--sans);
+  letter-spacing: 0;
+}
+.search kbd {
+  font: var(--fw-medium) var(--fs-micro) var(--sans);
+  color: var(--faint);
+  background: var(--btn);
+  border-radius: var(--r-xs);
+  padding: 1px 4px;
+}
+
+.list {
+  position: relative;
+  overflow-y: auto;
+  padding-bottom: var(--sp-2);
+  scrollbar-width: none;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+.list::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+}
+.glabel {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  padding: var(--sp-4) var(--sp-5) var(--sp-2);
+  background: var(--titlebar);
+  font: var(--fw-bold) var(--fs-label) var(--sans);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--faint);
+}
+.glabel .ct {
+  color: var(--meta-faint);
+  font-weight: var(--fw-medium);
+  letter-spacing: 0.04em;
+}
+.glabel .rule {
+  flex: 1;
+  height: var(--border-w);
+  background: var(--border-soft);
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  height: 32px;
+  margin: 0 var(--sp-2);
+  padding: 0 var(--sp-3);
+  border-radius: var(--r-md);
+  cursor: default;
+  position: relative;
+  transition: background var(--dur-fast), padding-right 0.22s var(--ease-pop);
+}
+body.kb .row.sel {
+  background: var(--raised);
+}
+.row:hover {
+  background: var(--raised-hi);
+}
+/* On hover the actions slide in over the right edge; reserve room so a long
+   branch ellipsises instead of running under them. Idle rows carry one fewer
+   action (no browser button), so they need a little less. */
+.row:hover,
+body.kb .row.sel {
+  padding-right: 104px;
+}
+.row.off:hover,
+body.kb .row.off.sel {
+  padding-right: 82px;
+}
+.branch {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  gap: 0;
+  font: var(--fw-medium) var(--fs-body) var(--mono);
+  letter-spacing: var(--tracking-tight);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--text);
+}
+.row.off .branch {
+  color: var(--muted);
+}
+.branch .seg {
+  color: var(--faint);
+}
+.meta {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  font-size: var(--fs-micro);
+  color: var(--faint);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  flex: none;
+  transition: opacity 0.16s var(--ease-pop), transform 0.22s var(--ease-pop);
+}
+.mk {
+  background: var(--teal-dim);
+  color: var(--teal-text);
+  border-radius: 2px;
+  padding: 0 1px;
+}
+/* long names truncate at the HEAD — the distinguishing part of a branch is its tail */
+.bn {
+  direction: rtl;
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+.bn > span {
+  direction: ltr;
+  unicode-bidi: embed;
+}
+.port {
+  font-family: var(--mono);
+  color: var(--teal);
+}
+.warnct {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  color: var(--amber);
+}
+.acts {
+  position: absolute;
+  right: var(--sp-3);
+  top: 50%;
+  display: flex;
+  align-items: center;
+  gap: 1px;
+  opacity: 0;
+  transform: translateX(14px);
+  transition: opacity 0.22s var(--ease-pop), transform 0.22s var(--ease-pop);
+  pointer-events: none;
+  margin-top: -11px;
+}
+.row:hover .acts,
+body.kb .row.sel .acts {
+  opacity: 1;
+  transform: translateX(0);
+  pointer-events: auto;
+}
+.row:hover .meta,
+body.kb .row.sel .meta {
+  display: none;
+}
+.ib {
+  all: unset;
+  width: 22px;
+  height: 22px;
+  border-radius: var(--r-md);
+  display: grid;
+  place-items: center;
+  color: var(--faint);
+  cursor: pointer;
+  transition: background var(--dur-fast), color var(--dur-fast);
+}
+.row:hover .ib,
+body.kb .row.sel .ib {
+  color: var(--muted);
+}
+.ib:hover {
+  background: var(--btn-hover);
+  color: var(--text);
+}
+.ib.danger:hover {
+  background: var(--red-dim);
+  color: var(--red-text);
+}
+/* Start mirrors Stop exactly: icon-only, muted by default (inherits .ib),
+   colour + a soft teal wash only when the button itself is hovered — the
+   teal-dim parallel of .ib.danger's red-dim. */
+.ib.play:hover {
+  background: var(--teal-dim);
+  color: var(--teal-text);
+}
+.empty {
+  padding: var(--sp-8) var(--sp-5);
+  text-align: center;
+  color: var(--faint);
+  font-size: var(--fs-small);
+}
+.empty code {
+  font-family: var(--mono);
+  color: var(--muted);
+}
+
+.pf {
+  border-top: var(--border-w) solid var(--border-soft);
+  background: var(--titlebar);
+  flex: none;
+}
+.pfrow {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-1);
+  padding: var(--sp-2);
+}
+.vr {
+  width: var(--border-w);
+  height: 16px;
+  background: var(--border-soft);
+  flex: none;
+}
+.mi {
+  all: unset;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--sp-2);
+  height: 26px;
+  border-radius: var(--r-md);
+  color: var(--text);
+  cursor: pointer;
+  transition: background var(--dur-fast);
+  white-space: nowrap;
+  padding: 0 var(--sp-3);
+  min-width: 0;
+  font-size: var(--fs-small);
+  flex: 1 1 0;
+}
+.mi:hover {
+  background: var(--raised-hi);
+}
+.mi svg {
+  color: var(--muted);
+  flex: none;
+}
+.mi kbd {
+  font: var(--fw-medium) var(--fs-micro) var(--sans);
+  color: var(--meta-faint);
+  background: var(--btn);
+  border-radius: var(--r-xs);
+  padding: 1px 3px;
+}
+.pstat {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  padding: var(--sp-3) var(--sp-5);
+  border-top: var(--border-w) solid var(--border-soft);
+  font-size: var(--fs-micro);
+  color: var(--faint);
+}
+.pstat .ver {
+  margin-left: auto;
+  font-family: var(--mono);
+}
+.toast {
+  position: fixed;
+  z-index: 9;
+  bottom: 18px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  padding: var(--sp-3) var(--sp-5);
+  background: var(--toast-bg);
+  border: var(--border-w) solid var(--border);
+  border-radius: var(--r-lg);
+  box-shadow: var(--shadow-toast);
+  font-size: var(--fs-small);
+  color: var(--text);
+  max-width: calc(100% - var(--sp-8));
+}
+.toast b {
+  font-family: var(--mono);
+  font-weight: var(--fw-medium);
+  color: var(--teal-text);
 }


### PR DESCRIPTION
Fixes: #51 
## What

First-run onboarding was the only screen still on the old v0.4 five-step wizard (Repository → Stack → Services → Commands → Review). This ports it to the redesign's **one adaptive screen**, rebuilt from the handoff (`Canopy Onboarding.html` / `cxo-onboard.jsx`) and wired to real IPC.

Four states, all rendered and measured (screenshots below):

- **Empty** — "No repositories yet" + what-happens-next. *This screen never existed; the app opened silent.*
- **Add** — detection runs **as you type** (debounced, not on-blur), the stack is a one-click **chip** (was step 2 of 5), services are derived from `package.json` scripts with the **derivation shown** (the JSON peek), provisioning/env/db pre-filled and collapsed.
- **Provisioning** — narrates the real work, escapable.
- **Ready** — ends on "Create first worktree", not a dead end.

Both `src/onboarding/Onboarding.tsx` and `src/styles/onboarding.css` rewritten. The stylesheet is scoped under `.ob-root` and declares **no tokens of its own** — all 64 `var()` references resolve from the shared token layer.

## Handoff contradictions resolved

| Conflict | Resolved | Why |
|---|---|---|
| Handoff/readme say env templates should use `${WT_SERVICE_PORT}` / `${INT_DB_NAME}` "to match SettingsView" | **source** — kept `${WT_SERVER_PORT}` / `${WT_DB_NAME}` | The Rust setup runner only interpolates `WT_DB_NAME` (`state.rs:142`) and `WT_<SERVICEID>_PORT` (`setup.rs`). `INT_DB_NAME` / `WT_SERVICE_PORT` appear nowhere in the backend and would land in `.env` as dead literals. SettingsView's defaults look like the actual bug. |
| Design titlebar `.tbar` 36px | **screen** — 44px | The real window uses an overlay titlebar; 44px + a `.mac` inset clears the traffic lights. |
| `.detect` card `overflow: hidden` | **changed to `visible`** | The stack dropdown lives inside `.detect`; `hidden` would clip it (no z-index escapes a clip). |

## Deliberately left out / backend gaps

- **Recently opened repos** — the design's empty-state list has no backing store (no MRU anywhere in `src-tauri`). Omitted rather than wired to fabricated paths; `TODO` left at the call site. *Needs a follow-up issue to persist opened-repo history.*

## Verification

- `tsc --noEmit` clean; `vite build` succeeds.
- **Token audit** — all 64 `var(--…)` in `onboarding.css` resolve in `tokens.css` (0 unresolved).
- **Rendered + measured in a headless browser** across all four states (real component, mocked IPC). Geometry matches design values: lg button 34px / base 29px, r7; empty ring 60×60 r12; stack chip 24px r6; toggle 30×17; footer 50px; done ring 56px circle. Colours resolve to the exact palette hexes (teal `#5cc7cd`, ink `#0d1113`, green `#4cc266`). Provisioning shows real metas (`Saving 2 services — ports 3000, 3010`).
- **Not covered:** measurement was against a browser render with a mocked IPC surface, not the packaged Tauri build; drag-drop was exercised for wiring/graceful-degradation, not a real OS drop.

---

## Also in this PR — menu-bar tray (`3a69877`)

Closes #94

Rebuilds the menu-bar popover (`src/popover/*`) from the design system's **`Canopy Tray.html`** (imported live via the claude.ai/design MCP). A per-repo, status-grouped worktree list (**Running / Starting / Idle**) with search + ⌘K, keyboard navigation, hover row-actions, a footer menu and a health status bar. Window sized to 348×≤472; built entirely on the shared tokens (self-contained sheet, 0 tokens redeclared).

Wired to the real store, with tray→main-window signals (`emit` → `App.tsx` `listen`) for surfaces the tray can't own:

- **Reset database** per worktree (spinner + toast).
- **New worktree** and **Open Manager** show the main window and open the New Worktree modal / the all-worktrees overview.
- **Start** mirrors **Stop** (icon-only, muted, teal wash only on hover); long branch names ellipsise clear of the hover actions with a full-name tooltip; proper Settings gear glyph.

Backend gaps degraded honestly (open the manager rather than fabricate): the Settings gear, and the updater "Up to date" pill (dropped — no updater backend exists).

**Verification:** `tsc` / `vite build` clean; rendered + measured headless against the design reference — geometry identical (`.pop` r9 / `#212327`, `.row` 32px·6px·7px, `.glabel` 9.5px sticky, mono branch 12.5/550, `.search` 28px / `#191a1d`, `.ib` 22px, dot 6px+halo, teal port); **0 unresolved tokens**; hover-actions + ⌘K filter/highlight confirmed. *Not covered:* the tray→main `emit`/`listen` round-trip only runs in the packaged Tauri app, not the browser render.

## Also — onboarding follow-ups (`b310f89`)

- **Hero empty state** — value props beside a side-by-side "git checkout vs git worktree" comparison mockup; refined add-repository flow (service derivation, env keys, a proper checkbox affordance, focus-visible states).
- **Sidebar repository filter** (`.cxs-repobar` / `.cxs-repomenu`) to scope the worktree list to one repo.
- **Name-based port env vars** — `worktree_vars` now also exposes each service port under its human name slug (e.g. `WT_SERVER_PORT`) alongside the id-based var, additively (`or_insert` never clobbers). This directly backs the "keep `${WT_SERVER_PORT}`" decision above: a `.env` template authored *by name* now resolves without depending on the internal service id.

