### PR TITLE
Backend hardening: correctness, stability, performance, and a safeguard test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       - run: npm run build
       - run: cargo check --locked
         working-directory: src-tauri
+      # warnings are errors in CI — the branch is clippy-clean; keep it that way
+      - run: cargo clippy --all-targets --features devtools --locked -- -D warnings
+        working-directory: src-tauri
       - run: cargo test --locked
         working-directory: src-tauri
 
@@ -52,6 +55,9 @@ jobs:
       - run: npm run build
       - run: cargo check --locked
         working-directory: src-tauri
+      # warnings are errors in CI — the branch is clippy-clean; keep it that way
+      - run: cargo clippy --all-targets --features devtools --locked -- -D warnings
+        working-directory: src-tauri
       - run: cargo test --locked
         working-directory: src-tauri
 
@@ -69,6 +75,9 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: cargo check --locked
+        working-directory: src-tauri
+      # warnings are errors in CI — the branch is clippy-clean; keep it that way
+      - run: cargo clippy --all-targets --features devtools --locked -- -D warnings
         working-directory: src-tauri
       - run: cargo test --locked
         working-directory: src-tauri

--- a/docs/backend-architecture.md
+++ b/docs/backend-architecture.md
@@ -1,0 +1,106 @@
+# Backend architecture notes
+
+Decisions made during the 2026-08 hardening pass (`backend-hardening` branch),
+plus the seams to use when the backend needs to scale further. Read this before
+adding a subsystem — most of the rules below exist because their absence was a
+shipped bug.
+
+## Layering
+
+```
+commands.rs      the IPC boundary: 47 #[tauri::command]s, all Result<T, CanopyError>
+  error.rs       { code, message } — the frontend branches on `code`, never on text
+  state.rs       tree model, port allocation, OpLease, tree-query API
+  services.rs    dev-service process table + log rings + on-disk log sink
+  terminal.rs    PTY sessions (agent lane)
+  proc.rs        the ONLY place OS process control lives (pgid / Job Object)
+  git.rs/db.rs/  wrappers over external CLIs; they return String errors and the
+  setup.rs       command layer stamps the domain code
+```
+
+Rules that keep this sound:
+
+- **Locks**: `parking_lot` everywhere; no poisoning. Never hold a lock across
+  an `.await`. The `AppState` tree-query API (`wt_context`, `service_context`,
+  `wt_service_keys`, `repo_path_by_id`) exists so callers get owned data from a
+  brief read lock — don't hand-roll tree traversals in new code.
+- **Mutating per-worktree work takes an `OpLease`** (`state::try_lease`).
+  One create/setup/remove/migrate/snapshot/restore/switch per worktree at a
+  time; the lease is RAII so panics and early returns release it.
+- **Every external process has a timeout** (git 300s / network git 900s /
+  Postgres 900s / setup steps 60min) and `kill_on_drop`, so a hung tool can't
+  wedge a command forever.
+- **Persistence is atomic**: `settings::save_json` writes temp + fsync +
+  rename, skips unchanged content, and `load_json` quarantines corrupt files
+  to `*.json.corrupt` instead of silently defaulting.
+- **Events**: high-volume events (`terminal:data`, `service:log`,
+  `service:stats`) are `emit_filter`ed to the windows that render them;
+  frontend listeners are window-scoped (`getCurrentWebviewWindow().listen`).
+  `tree:changed` is diffed before emitting. Anything new and chatty should
+  follow the same pattern.
+- **Background loops pause while no window is visible** (git refresh, stats).
+  A tray-resident app spends most of its life invisible; work nobody can see
+  is the default thing to cut. `show_main_window` / the tray toggle kick a
+  catch-up refresh.
+
+## Memory model (bounded by construction)
+
+Every unbounded-growth path found in review now has a cap or a reclaim:
+
+| Resource | Bound |
+|---|---|
+| service log ring | 160 lines in memory; full stream on disk, 2MB + one roll |
+| PTY scrollback | 256KB per session |
+| exited-session buffers | 24 most recent |
+| idle shell sessions | swept after 1h (agents exempt) |
+| port indices / overrides / statuses / log rings | released on worktree & repo removal |
+
+When adding retained state, name its cap in a comment next to the constant.
+
+## Scaling expectations
+
+Current design comfortably handles ~10 repos × ~10 worktrees × a few services
+each. The known next bottlenecks, in order:
+
+1. **Git refresh fan-out** — parallel (chunks of 6) but still 2 spawns per
+   worktree per tick. Past ~50 worktrees, move to one `git for-each-ref` per
+   repo plus `core.fsmonitor`, or a filesystem watcher instead of polling.
+2. **Stats** — sysinfo refreshes the whole process table per tick. If service
+   counts grow, walk only tracked pgids' descendants or lengthen the poll.
+3. **Tree broadcast** — the diff gate stops no-op emits, but the payload is
+   still the whole tree. If it grows large, emit per-repo or per-worktree
+   deltas (the frontend store already reconciles per-key events).
+
+## Container/runtime backend (future)
+
+`proc.rs` is deliberately the only file that knows how a "service" becomes an
+OS process, and `services.rs` only consumes its five-function API
+(`prepare_group_command` / `attach_group` / `terminate_group` / `kill_group` /
+`group_key`). To add container-backed services (Docker/Podman/OrbStack):
+
+- introduce a `Runner` trait with the same five verbs plus `spawn`, implement
+  `LocalProcessRunner` (today's proc.rs) and `ContainerRunner`
+  (`docker run --rm --label canopy.svc=<key>`, teardown =
+  `docker rm -f $(docker ps -q --filter label=…)`);
+- the orphan sweep maps to label-filtered container cleanup — simpler and more
+  reliable than pgids, since the daemon owns lifecycle;
+- port mapping already flows through one place (`state::effective_port` and
+  the `WT_*_PORT` env derivation) — container port publishing plugs in there;
+- log pumps read from `docker logs --follow` instead of pipes; the ring/disk
+  sink in `services.rs` is transport-agnostic already.
+
+Keep `ServiceCfg` the single source of truth and add a `runtime: "process" |
+"container"` field there when the time comes; nothing in the UI layer should
+know the difference.
+
+## Testing & CI
+
+- `cargo test` covers the pure cores: porcelain parsers, dotenv/JSON/YAML
+  upserts, port allocation, path containment, shell quoting, settings
+  round-trip/quarantine, PID-recycling guard.
+- The end-to-end harness (`suite.rs`, `WTM_SUITE=<repoId>`) is compiled only
+  with `--features devtools`; release binaries carry none of it.
+- CI (3 OS) runs `cargo check`, `cargo clippy --all-targets --features
+  devtools -- -D warnings` (the tree is warning-free — keep it that way), and
+  `cargo test`. The Linux/Windows jobs exist to compile the `cfg` branches a
+  macOS build never sees.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1060,7 +1060,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 [[package]]
 name = "fix-path-env"
 version = "0.0.0"
-source = "git+https://github.com/tauri-apps/fix-path-env-rs#c4c45d503ea115a839aae718d02f79e7c7f0f673"
+source = "git+https://github.com/tauri-apps/fix-path-env-rs?rev=c4c45d503ea115a839aae718d02f79e7c7f0f673#c4c45d503ea115a839aae718d02f79e7c7f0f673"
 dependencies = [
  "home",
  "strip-ansi-escapes",
@@ -3759,7 +3759,7 @@ dependencies = [
 [[package]]
 name = "tauri-nspanel"
 version = "2.1.0"
-source = "git+https://github.com/ahkohd/tauri-nspanel?branch=v2.1#a3122e894383aa068ec5365a42994e3ac94ba1b6"
+source = "git+https://github.com/ahkohd/tauri-nspanel?rev=a3122e894383aa068ec5365a42994e3ac94ba1b6#a3122e894383aa068ec5365a42994e3ac94ba1b6"
 dependencies = [
  "objc2",
  "objc2-app-kit",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -33,6 +33,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_log-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
+
+[[package]]
+name = "android_logger"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb4e440d04be07da1f1bf44fb4495ebd58669372fe0cffa6e48595ac5bd88a3"
+dependencies = [
+ "android_log-sys",
+ "env_filter",
+ "log",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,6 +413,7 @@ dependencies = [
  "base64 0.23.0",
  "fix-path-env",
  "libc",
+ "log",
  "portable-pty",
  "serde",
  "serde_json",
@@ -404,6 +422,7 @@ dependencies = [
  "tauri-build",
  "tauri-nspanel",
  "tauri-plugin-dialog",
+ "tauri-plugin-log",
  "tauri-plugin-opener",
  "tauri-plugin-positioner",
  "tokio",
@@ -928,6 +947,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -988,6 +1017,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "fern"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4316185f709b23713e41e3195f90edef7fb00c3ed4adc79769cf09cc762a3b29"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -2217,6 +2255,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -3778,6 +3825,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-log"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6792296e6f389268016c77db21ebae1fc0568f2fccf88b1ec7e2ea71330afb4c"
+dependencies = [
+ "android_logger",
+ "fern",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "swift-rs",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3985,7 +4053,9 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -426,6 +426,7 @@ dependencies = [
  "tauri-plugin-log",
  "tauri-plugin-opener",
  "tauri-plugin-positioner",
+ "tauri-plugin-single-instance",
  "tokio",
  "windows 0.62.2",
 ]
@@ -3881,6 +3882,22 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3214becf9ef5783c0ae99a3bb25adf5353a7a16ebf53e74b909e29205735c6c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -414,6 +414,7 @@ dependencies = [
  "fix-path-env",
  "libc",
  "log",
+ "parking_lot",
  "portable-pty",
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,6 +36,9 @@ serde_json = { version = "1", features = ["preserve_order"] }
 tokio = { version = "1", features = ["process", "io-util", "sync", "time", "macros", "rt-multi-thread"] }
 fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs" }
 sysinfo = "0.39.3"
+# non-poisoning locks: with std, one panic while holding a lock poisons it and
+# every later .unwrap() panics forever — the app survives as a zombie window.
+parking_lot = "0.12"
 # embedded per-worktree terminals: a real PTY per session (the agent lane runs
 # the coding-agent CLI inside one). portable-pty is cross-platform (helps Linux).
 portable-pty = "0.9"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,6 +16,10 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = ["tray-icon", "image-png", "macos-private-api"] }
 tauri-plugin-opener = "2"
+# rolling file log in the app log dir — the thing a bug report can attach.
+# `log` macros everywhere; eprintln! is reserved for the headless test harness.
+log = "0.4"
+tauri-plugin-log = "2"
 tauri-plugin-positioner = { version = "2", features = ["tray-icon"] }
 tauri-plugin-dialog = "2"
 serde = { version = "1", features = ["derive"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,7 +34,9 @@ serde = { version = "1", features = ["derive"] }
 # order the user wrote them instead of being alphabetized
 serde_json = { version = "1", features = ["preserve_order"] }
 tokio = { version = "1", features = ["process", "io-util", "sync", "time", "macros", "rt-multi-thread"] }
-fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs" }
+# rev-pinned: an unpinned git dependency isn't reproducible and a force-push
+# upstream would silently change what we ship
+fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs", rev = "c4c45d503ea115a839aae718d02f79e7c7f0f673" }
 sysinfo = "0.39.3"
 # non-poisoning locks: with std, one panic while holding a lock poisons it and
 # every later .unwrap() panics forever — the app survives as a zombie window.
@@ -68,4 +70,4 @@ windows = { version = "0.62", features = [
 # macOS-only: the tray popover is a non-activating NSPanel. Other platforms fall
 # back to a plain borderless window (see src/tray.rs).
 [target.'cfg(target_os = "macos")'.dependencies]
-tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", branch = "v2.1", version = "2.1.0" }
+tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", rev = "a3122e894383aa068ec5365a42994e3ac94ba1b6", version = "2.1.0" }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -10,6 +10,13 @@ edition = "2021"
 name = "canopy_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
+[features]
+default = []
+# Headless test harness (WTM_SUITE / WTM_SELFTEST / WTM_SELFTEST_CREATE).
+# Excluded from release builds: it ships ~400 lines of env-var-triggered code
+# that can create/remove worktrees and panics on malformed input.
+devtools = []
+
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -39,6 +39,9 @@ sysinfo = "0.39.3"
 # non-poisoning locks: with std, one panic while holding a lock poisons it and
 # every later .unwrap() panics forever — the app survives as a zombie window.
 parking_lot = "0.12"
+# two Canopy instances would sweep each other's live pgids as "orphans" and
+# race on settings/state writes — a second launch focuses the first instead.
+tauri-plugin-single-instance = "2"
 # embedded per-worktree terminals: a real PTY per session (the agent lane runs
 # the coding-agent CLI inside one). portable-pty is cross-platform (helps Linux).
 portable-pty = "0.9"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -259,8 +259,12 @@ pub fn get_logs(table: State<'_, ProcTable>, svc_key: String) -> Vec<LogLine> {
 
 // ── embedded terminals (agent lane) ──
 
+// async so they run on the runtime thread pool: open does openpty + spawn,
+// get_buffer base64-encodes up to 256KB, and write can block on a stalled
+// child — none of that belongs on the main (UI) thread.
+
 #[tauri::command]
-pub fn terminal_open(
+pub async fn terminal_open(
     app: AppHandle,
     table: State<'_, TermTable>,
     id: String,
@@ -273,23 +277,24 @@ pub fn terminal_open(
 }
 
 #[tauri::command]
-pub fn terminal_write(table: State<'_, TermTable>, id: String, data: String) -> Result<(), CanopyError> {
+pub async fn terminal_write(table: State<'_, TermTable>, id: String, data: String) -> Result<(), CanopyError> {
     terminal::write(&table, &id, &data).map_err(CanopyError::terminal)
 }
 
 #[tauri::command]
-pub fn terminal_resize(table: State<'_, TermTable>, id: String, cols: u16, rows: u16) -> Result<(), CanopyError> {
+pub async fn terminal_resize(table: State<'_, TermTable>, id: String, cols: u16, rows: u16) -> Result<(), CanopyError> {
     terminal::resize(&table, &id, cols, rows).map_err(CanopyError::terminal)
 }
 
 #[tauri::command]
-pub fn terminal_get_buffer(table: State<'_, TermTable>, id: String) -> Option<terminal::BufferSnapshot> {
-    terminal::get_buffer(&table, &id)
+pub async fn terminal_get_buffer(table: State<'_, TermTable>, id: String) -> Result<Option<terminal::BufferSnapshot>, CanopyError> {
+    Ok(terminal::get_buffer(&table, &id))
 }
 
 #[tauri::command]
-pub fn terminal_close(app: AppHandle, table: State<'_, TermTable>, id: String) {
+pub async fn terminal_close(app: AppHandle, table: State<'_, TermTable>, id: String) -> Result<(), CanopyError> {
     terminal::close_and_persist(&app, &table, &id);
+    Ok(())
 }
 
 /// Ensure a worktree's `.canopy/` exists with a self-ignoring `.gitignore`, then

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -657,11 +657,7 @@ pub async fn show_main_window(app: AppHandle) -> Result<(), CanopyError> {
         let _ = pop.hide();
     }
     // the background refresh pauses while every window is hidden — catch up now
-    let app2 = app.clone();
-    tauri::async_runtime::spawn(async move {
-        let _ = refresh_tree(&app2).await;
-        refresh_all_git_meta(&app2).await;
-    });
+    crate::tray::catch_up_refresh(&app);
     Ok(())
 }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -380,6 +380,7 @@ pub async fn worktree_stop_all(app: AppHandle, wt_key: String) -> Result<(), Can
 
 #[tauri::command]
 pub async fn reset_db(app: AppHandle, wt_key: String) -> Result<(), CanopyError> {
+    let _lease = crate::state::try_lease(&app, &wt_key, "reset db")?;
     services::reset_db(&app, &wt_key).await.map_err(CanopyError::db)
 }
 
@@ -387,6 +388,7 @@ pub async fn reset_db(app: AppHandle, wt_key: String) -> Result<(), CanopyError>
 #[tauri::command]
 pub async fn run_migration(app: AppHandle, wt_key: String) -> Result<(), CanopyError> {
     let (repo_path, repo_id) = repo_for_wt(&app, &wt_key)?;
+    let _lease = crate::state::try_lease(&app, &wt_key, "migrate")?;
     // prefer the Settings "Migrate cmd"; fall back to .worktreemanager.json `migrate`
     let settings_cmd = {
         let state = app.state::<AppState>();
@@ -428,6 +430,7 @@ pub async fn run_custom_command(app: AppHandle, wt_key: String, command: String)
         return Err(CanopyError::invalid_input("Empty command"));
     }
     let (repo_path, repo_id) = repo_for_wt(&app, &wt_key)?;
+    let _lease = crate::state::try_lease(&app, &wt_key, "command")?;
     let vars = crate::state::worktree_vars(&app, &repo_id, &wt_key, false);
     let app2 = app.clone();
     let wt2 = wt_key.clone();
@@ -664,6 +667,8 @@ pub async fn create_worktree(
         return Err(CanopyError::conflict(format!("Path already exists: {wt_path}")));
     }
 
+    let _lease = crate::state::try_lease(&app, &wt_path, "create")?;
+
     emit_op(&app, &wt_path, "create", "progress", format!("creating worktree for {branch}…"));
 
     // Refresh remote-tracking refs (and submodule objects) BEFORE `git worktree
@@ -732,6 +737,7 @@ pub async fn run_worktree_setup(app: AppHandle, wt_key: String) -> Result<(), Ca
             "Nothing to run — add provisioned files or setup commands in .worktreemanager.json",
         ));
     }
+    let _lease = crate::state::try_lease(&app, &wt_key, "setup")?;
     let vars = crate::state::worktree_vars(&app, &repo_id, &wt_key, is_main);
     let app3 = app.clone();
     let wt3 = wt_key.clone();
@@ -768,6 +774,7 @@ pub async fn remove_worktree(app: AppHandle, wt_key: String, delete_branch: bool
     if is_main {
         return Err(CanopyError::invalid_input("Refusing to remove the main checkout"));
     }
+    let _lease = crate::state::try_lease(&app, &wt_key, "remove")?;
 
     // stop its services first
     for key in services::worktree_svc_keys(&app, &wt_key) {
@@ -838,6 +845,7 @@ pub async fn snapshot_database(app: AppHandle, wt_key: String, name: String) -> 
     if name.is_empty() {
         return Err(CanopyError::invalid_input("Snapshot name is required"));
     }
+    let _lease = crate::state::try_lease(&app, &wt_key, "snapshot")?;
     let app2 = app.clone();
     let wt2 = wt_key.clone();
     crate::db::clone_database(&wt_key, &name, move |line| emit_op(&app2, &wt2, "snapshot", "progress", line))
@@ -849,6 +857,7 @@ pub async fn snapshot_database(app: AppHandle, wt_key: String, name: String) -> 
 
 #[tauri::command]
 pub async fn export_database(app: AppHandle, wt_key: String, file_path: String) -> Result<(), CanopyError> {
+    let _lease = crate::state::try_lease(&app, &wt_key, "export")?;
     let app2 = app.clone();
     let wt2 = wt_key.clone();
     crate::db::export_database(&wt_key, &file_path, move |line| emit_op(&app2, &wt2, "snapshot", "progress", line))
@@ -860,6 +869,7 @@ pub async fn export_database(app: AppHandle, wt_key: String, file_path: String) 
 
 #[tauri::command]
 pub async fn restore_database(app: AppHandle, wt_key: String, file_path: String) -> Result<(), CanopyError> {
+    let _lease = crate::state::try_lease(&app, &wt_key, "restore")?;
     // quiesce: a live connection pool holds locks against --clean drops and
     // can observe (or block) a half-restored schema. Stop the worktree's
     // running services, restore, then bring the same ones back.
@@ -901,6 +911,7 @@ pub async fn restore_database(app: AppHandle, wt_key: String, file_path: String)
 #[tauri::command]
 pub async fn switch_database(app: AppHandle, wt_key: String, db_name: String) -> Result<(), CanopyError> {
     let (repo_path, _repo_id) = repo_for_wt(&app, &wt_key)?;
+    let _lease = crate::state::try_lease(&app, &wt_key, "switch database")?;
     // repoint PG_DB in the worktree's root .env AND in any provisioned dotenv
     // file (e.g. server/.env) that declares it
     let pairs = [("PG_DB".to_string(), db_name.clone())];

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -749,8 +749,8 @@ pub async fn run_worktree_setup(app: AppHandle, wt_key: String) -> Result<(), Ca
 }
 
 #[tauri::command]
-pub async fn worktree_dirty_report(wt_key: String) -> git::DirtyReport {
-    git::dirty_report(&wt_key).await
+pub async fn worktree_dirty_report(wt_key: String) -> Result<git::DirtyReport, CanopyError> {
+    git::dirty_report(&wt_key).await.map_err(CanopyError::git)
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -856,13 +856,42 @@ pub async fn export_database(app: AppHandle, wt_key: String, file_path: String) 
 
 #[tauri::command]
 pub async fn restore_database(app: AppHandle, wt_key: String, file_path: String) -> Result<(), CanopyError> {
+    // quiesce: a live connection pool holds locks against --clean drops and
+    // can observe (or block) a half-restored schema. Stop the worktree's
+    // running services, restore, then bring the same ones back.
+    let mut was_running: Vec<String> = Vec::new();
+    for key in services::worktree_svc_keys(&app, &wt_key) {
+        if is_running(&app, &key) {
+            was_running.push(key.clone());
+            let _ = services::stop_service(&app, &key).await;
+        }
+    }
     let app2 = app.clone();
     let wt2 = wt_key.clone();
-    crate::db::restore_database(&wt_key, &file_path, move |line| emit_op(&app2, &wt2, "snapshot", "progress", line))
-        .await
-        .map_err(CanopyError::db)?;
-    emit_op(&app, &wt_key, "snapshot", "done", "restore complete");
-    Ok(())
+    let restore = crate::db::restore_database(&wt_key, &file_path, move |line| {
+        emit_op(&app2, &wt2, "snapshot", "progress", line)
+    })
+    .await;
+
+    // restart what we stopped, whether or not the restore succeeded — the
+    // worktree shouldn't be left dead because a dump file was bad
+    let mut restart_errors: Vec<String> = Vec::new();
+    for key in &was_running {
+        if let Err(e) = services::restart_service(&app, key).await {
+            restart_errors.push(format!("{key}: {e}"));
+        }
+    }
+
+    restore.map_err(CanopyError::db)?;
+    if restart_errors.is_empty() {
+        emit_op(&app, &wt_key, "snapshot", "done", "restore complete");
+        Ok(())
+    } else {
+        Err(CanopyError::process(format!(
+            "restore complete, but restart failed — {}",
+            restart_errors.join("; ")
+        )))
+    }
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,3 +1,4 @@
+use crate::error::CanopyError;
 use crate::git;
 use crate::services::{self, LogLine, ProcTable};
 use crate::settings::{self, RepoCfg, Settings};
@@ -6,25 +7,25 @@ use crate::terminal::{self, TermTable};
 use tauri::{AppHandle, Manager, State};
 
 #[tauri::command]
-pub async fn get_tree(app: AppHandle) -> Result<Vec<RepoNode>, String> {
+pub async fn get_tree(app: AppHandle) -> Result<Vec<RepoNode>, CanopyError> {
     let cached = {
         let state = app.state::<AppState>();
         let tree = state.tree.read().unwrap();
         tree.clone()
     };
     if cached.is_empty() {
-        refresh_tree(&app).await
+        refresh_tree(&app).await.map_err(CanopyError::internal)
     } else {
         Ok(cached)
     }
 }
 
 #[tauri::command]
-pub async fn refresh(app: AppHandle, wt_key: Option<String>) -> Result<(), String> {
+pub async fn refresh(app: AppHandle, wt_key: Option<String>) -> Result<(), CanopyError> {
     match wt_key {
         Some(key) => refresh_git_meta(&app, &key).await,
         None => {
-            refresh_tree(&app).await?;
+            refresh_tree(&app).await.map_err(CanopyError::internal)?;
             refresh_all_git_meta(&app).await;
         }
     }
@@ -37,21 +38,21 @@ pub fn get_settings(state: State<'_, AppState>) -> Settings {
 }
 
 #[tauri::command]
-pub async fn save_settings(app: AppHandle, new_settings: Settings) -> Result<(), String> {
+pub async fn save_settings(app: AppHandle, new_settings: Settings) -> Result<(), CanopyError> {
     {
         let state = app.state::<AppState>();
         *state.settings.write().unwrap() = new_settings.clone();
     }
-    settings::save_settings(&app, &new_settings)?;
-    refresh_tree(&app).await?;
+    settings::save_settings(&app, &new_settings).map_err(CanopyError::config)?;
+    refresh_tree(&app).await.map_err(CanopyError::internal)?;
     refresh_all_git_meta(&app).await;
     Ok(())
 }
 
 /// Validate + register a repo; returns the canonical repo config that was added.
 #[tauri::command]
-pub async fn add_repo(app: AppHandle, path: String) -> Result<RepoCfg, String> {
-    let top = git::validate_repo(&path).await?;
+pub async fn add_repo(app: AppHandle, path: String) -> Result<RepoCfg, CanopyError> {
+    let top = git::validate_repo(&path).await.map_err(CanopyError::git)?;
     let name = std::path::Path::new(&top)
         .file_name()
         .map(|s| s.to_string_lossy().into_owned())
@@ -74,13 +75,25 @@ pub async fn add_repo(app: AppHandle, path: String) -> Result<RepoCfg, String> {
         let state = app.state::<AppState>();
         let mut s = state.settings.write().unwrap();
         if s.repos.iter().any(|r| r.path == repo.path) {
-            return Err("Repository already registered".into());
+            return Err(CanopyError::conflict("Repository already registered"));
+        }
+        // repo lookups key on `id`, so two different paths must never share one
+        // (e.g. ~/work/tooljet + ~/client/tooljet) — suffix until unique.
+        let mut repo = repo;
+        let base = repo.id.clone();
+        let mut n = 2;
+        while s.repos.iter().any(|r| r.id == repo.id) {
+            repo.id = format!("{base}-{n}");
+            n += 1;
         }
         s.repos.push(repo.clone());
-        s.clone()
+        let updated = s.clone();
+        drop(s);
+        (repo, updated)
     };
-    settings::save_settings(&app, &updated)?;
-    refresh_tree(&app).await?;
+    let (repo, updated) = updated;
+    settings::save_settings(&app, &updated).map_err(CanopyError::config)?;
+    refresh_tree(&app).await.map_err(CanopyError::internal)?;
     refresh_all_git_meta(&app).await;
     Ok(repo)
 }
@@ -110,8 +123,8 @@ pub struct ScriptEntry {
 /// branch/origin, guess the stack from manifest files, and list package.json
 /// scripts. Read-only — registers nothing.
 #[tauri::command]
-pub async fn detect_repo(path: String) -> Result<RepoDetection, String> {
-    let top = git::validate_repo(&path).await?;
+pub async fn detect_repo(path: String) -> Result<RepoDetection, CanopyError> {
+    let top = git::validate_repo(&path).await.map_err(CanopyError::git)?;
     let name = std::path::Path::new(&top)
         .file_name()
         .map(|s| s.to_string_lossy().into_owned())
@@ -167,21 +180,21 @@ pub async fn detect_repo(path: String) -> Result<RepoDetection, String> {
 }
 
 #[tauri::command]
-pub async fn remove_repo(app: AppHandle, repo_id: String) -> Result<(), String> {
+pub async fn remove_repo(app: AppHandle, repo_id: String) -> Result<(), CanopyError> {
     let updated = {
         let state = app.state::<AppState>();
         let mut s = state.settings.write().unwrap();
         s.repos.retain(|r| r.id != repo_id);
         s.clone()
     };
-    settings::save_settings(&app, &updated)?;
-    refresh_tree(&app).await?;
+    settings::save_settings(&app, &updated).map_err(CanopyError::config)?;
+    refresh_tree(&app).await.map_err(CanopyError::internal)?;
     Ok(())
 }
 
 #[tauri::command]
-pub async fn git_pull(app: AppHandle, wt_key: String) -> Result<String, String> {
-    let summary = git::pull(&wt_key).await?;
+pub async fn git_pull(app: AppHandle, wt_key: String) -> Result<String, CanopyError> {
+    let summary = git::pull(&wt_key).await.map_err(CanopyError::git)?;
     refresh_git_meta(&app, &wt_key).await;
     Ok(summary)
 }
@@ -189,31 +202,31 @@ pub async fn git_pull(app: AppHandle, wt_key: String) -> Result<String, String> 
 // ── submodules ──
 
 #[tauri::command]
-pub async fn submodule_status(wt_key: String) -> Result<Vec<git::SubmoduleStatus>, String> {
+pub async fn submodule_status(wt_key: String) -> Result<Vec<git::SubmoduleStatus>, CanopyError> {
     Ok(git::submodule_status(&wt_key).await)
 }
 
 #[tauri::command]
-pub async fn pull_submodule(app: AppHandle, wt_key: String, path: String) -> Result<String, String> {
-    let summary = git::pull_submodule(&wt_key, &path).await?;
+pub async fn pull_submodule(app: AppHandle, wt_key: String, path: String) -> Result<String, CanopyError> {
+    let summary = git::pull_submodule(&wt_key, &path).await.map_err(CanopyError::git)?;
     refresh_git_meta(&app, &wt_key).await;
     Ok(summary)
 }
 
 #[tauri::command]
-pub async fn switch_submodule_branch(app: AppHandle, wt_key: String, path: String, branch: String) -> Result<(), String> {
-    git::switch_submodule_branch(&wt_key, &path, &branch).await?;
+pub async fn switch_submodule_branch(app: AppHandle, wt_key: String, path: String, branch: String) -> Result<(), CanopyError> {
+    git::switch_submodule_branch(&wt_key, &path, &branch).await.map_err(CanopyError::git)?;
     refresh_git_meta(&app, &wt_key).await;
     Ok(())
 }
 
 #[tauri::command]
-pub async fn list_submodule_branches(wt_key: String, path: String) -> Result<git::Branches, String> {
-    git::list_submodule_branches(&wt_key, &path).await
+pub async fn list_submodule_branches(wt_key: String, path: String) -> Result<git::Branches, CanopyError> {
+    git::list_submodule_branches(&wt_key, &path).await.map_err(CanopyError::git)
 }
 
 #[tauri::command]
-pub async fn fetch_submodules(wt_key: String) -> Result<usize, String> {
+pub async fn fetch_submodules(wt_key: String) -> Result<usize, CanopyError> {
     Ok(git::fetch_submodules(&wt_key).await)
 }
 
@@ -225,8 +238,8 @@ pub async fn switch_worktree_branch(
     branch: String,
     create: bool,
     base: Option<String>,
-) -> Result<(), String> {
-    git::switch_branch(&wt_key, &branch, create, base.as_deref()).await?;
+) -> Result<(), CanopyError> {
+    git::switch_branch(&wt_key, &branch, create, base.as_deref()).await.map_err(CanopyError::git)?;
     let _ = refresh_tree(&app).await;
     refresh_git_meta(&app, &wt_key).await;
     Ok(())
@@ -256,18 +269,18 @@ pub fn terminal_open(
     cols: u16,
     rows: u16,
     command: Option<String>,
-) -> Result<(), String> {
-    terminal::open(&app, &table, &id, &cwd, cols, rows, command)
+) -> Result<(), CanopyError> {
+    terminal::open(&app, &table, &id, &cwd, cols, rows, command).map_err(CanopyError::terminal)
 }
 
 #[tauri::command]
-pub fn terminal_write(table: State<'_, TermTable>, id: String, data: String) -> Result<(), String> {
-    terminal::write(&table, &id, &data)
+pub fn terminal_write(table: State<'_, TermTable>, id: String, data: String) -> Result<(), CanopyError> {
+    terminal::write(&table, &id, &data).map_err(CanopyError::terminal)
 }
 
 #[tauri::command]
-pub fn terminal_resize(table: State<'_, TermTable>, id: String, cols: u16, rows: u16) -> Result<(), String> {
-    terminal::resize(&table, &id, cols, rows)
+pub fn terminal_resize(table: State<'_, TermTable>, id: String, cols: u16, rows: u16) -> Result<(), CanopyError> {
+    terminal::resize(&table, &id, cols, rows).map_err(CanopyError::terminal)
 }
 
 #[tauri::command]
@@ -283,15 +296,15 @@ pub fn terminal_close(app: AppHandle, table: State<'_, TermTable>, id: String) {
 /// Ensure a worktree's `.canopy/` exists with a self-ignoring `.gitignore`, then
 /// write `context.md`. Never truncates an existing `.gitignore`.
 #[tauri::command]
-pub fn write_worktree_context(wt_path: String, contents: String) -> Result<(), String> {
+pub fn write_worktree_context(wt_path: String, contents: String) -> Result<(), CanopyError> {
     let dir = std::path::Path::new(&wt_path).join(".canopy");
-    std::fs::create_dir_all(&dir).map_err(|e| format!("mkdir {}: {e}", dir.display()))?;
+    std::fs::create_dir_all(&dir).map_err(|e| CanopyError::setup(format!("mkdir {}: {e}", dir.display())))?;
     let ignore = dir.join(".gitignore");
     if !ignore.exists() {
-        std::fs::write(&ignore, "*\n").map_err(|e| format!("write {}: {e}", ignore.display()))?;
+        std::fs::write(&ignore, "*\n").map_err(|e| CanopyError::setup(format!("write {}: {e}", ignore.display())))?;
     }
     let file = dir.join("context.md");
-    std::fs::write(&file, contents).map_err(|e| format!("write {}: {e}", file.display()))
+    std::fs::write(&file, contents).map_err(|e| CanopyError::setup(format!("write {}: {e}", file.display())))
 }
 
 /// The agent CLI to run for a worktree: the repo's configured `agentCommand`,
@@ -320,44 +333,60 @@ pub fn resolve_agent_command(state: State<'_, AppState>, wt_key: String) -> Stri
 }
 
 #[tauri::command]
-pub async fn service_start(app: AppHandle, svc_key: String) -> Result<(), String> {
-    services::start_service(&app, &svc_key).await
+pub async fn service_start(app: AppHandle, svc_key: String) -> Result<(), CanopyError> {
+    services::start_service(&app, &svc_key).await.map_err(CanopyError::process)
 }
 
 #[tauri::command]
-pub async fn service_stop(app: AppHandle, svc_key: String) -> Result<(), String> {
-    services::stop_service(&app, &svc_key).await
+pub async fn service_stop(app: AppHandle, svc_key: String) -> Result<(), CanopyError> {
+    services::stop_service(&app, &svc_key).await.map_err(CanopyError::process)
 }
 
 #[tauri::command]
-pub async fn service_restart(app: AppHandle, svc_key: String) -> Result<(), String> {
-    services::restart_service(&app, &svc_key).await
+pub async fn service_restart(app: AppHandle, svc_key: String) -> Result<(), CanopyError> {
+    services::restart_service(&app, &svc_key).await.map_err(CanopyError::process)
 }
 
 #[tauri::command]
-pub async fn worktree_start_all(app: AppHandle, wt_key: String) -> Result<(), String> {
+pub async fn worktree_start_all(app: AppHandle, wt_key: String) -> Result<(), CanopyError> {
+    // start every service, collecting failures — one bad service must not
+    // silently prevent its siblings from starting
+    let mut errors: Vec<String> = Vec::new();
     for key in services::worktree_svc_keys(&app, &wt_key) {
-        services::start_service(&app, &key).await?;
+        if let Err(e) = services::start_service(&app, &key).await {
+            errors.push(format!("{key}: {e}"));
+        }
     }
-    Ok(())
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(CanopyError::process(format!("some services failed to start — {}", errors.join("; "))))
+    }
 }
 
 #[tauri::command]
-pub async fn worktree_stop_all(app: AppHandle, wt_key: String) -> Result<(), String> {
+pub async fn worktree_stop_all(app: AppHandle, wt_key: String) -> Result<(), CanopyError> {
+    let mut errors: Vec<String> = Vec::new();
     for key in services::worktree_svc_keys(&app, &wt_key) {
-        services::stop_service(&app, &key).await?;
+        if let Err(e) = services::stop_service(&app, &key).await {
+            errors.push(format!("{key}: {e}"));
+        }
     }
-    Ok(())
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(CanopyError::process(format!("some services failed to stop — {}", errors.join("; "))))
+    }
 }
 
 #[tauri::command]
-pub async fn reset_db(app: AppHandle, wt_key: String) -> Result<(), String> {
-    services::reset_db(&app, &wt_key).await
+pub async fn reset_db(app: AppHandle, wt_key: String) -> Result<(), CanopyError> {
+    services::reset_db(&app, &wt_key).await.map_err(CanopyError::db)
 }
 
 /// Run the worktree's configured DB migration (`migrate` in .worktreemanager.json).
 #[tauri::command]
-pub async fn run_migration(app: AppHandle, wt_key: String) -> Result<(), String> {
+pub async fn run_migration(app: AppHandle, wt_key: String) -> Result<(), CanopyError> {
     let (repo_path, repo_id) = repo_for_wt(&app, &wt_key)?;
     // prefer the Settings "Migrate cmd"; fall back to .worktreemanager.json `migrate`
     let settings_cmd = {
@@ -387,7 +416,7 @@ pub async fn run_migration(app: AppHandle, wt_key: String) -> Result<(), String>
         }
         Err(e) => {
             emit_op(&app, &wt_key, "migrate", "error", e.clone());
-            Err(e)
+            Err(CanopyError::setup(e))
         }
     }
 }
@@ -395,9 +424,9 @@ pub async fn run_migration(app: AppHandle, wt_key: String) -> Result<(), String>
 /// Run a repo-defined custom command in the worktree root, on the pinned Node,
 /// streaming progress via `worktree:op` (op="custom") — same model as migrate.
 #[tauri::command]
-pub async fn run_custom_command(app: AppHandle, wt_key: String, command: String) -> Result<(), String> {
+pub async fn run_custom_command(app: AppHandle, wt_key: String, command: String) -> Result<(), CanopyError> {
     if command.trim().is_empty() {
-        return Err("Empty command".into());
+        return Err(CanopyError::invalid_input("Empty command"));
     }
     let (repo_path, repo_id) = repo_for_wt(&app, &wt_key)?;
     let vars = crate::state::worktree_vars(&app, &repo_id, &wt_key, false);
@@ -415,7 +444,7 @@ pub async fn run_custom_command(app: AppHandle, wt_key: String, command: String)
         }
         Err(e) => {
             emit_op(&app, &wt_key, "custom", "error", e.clone());
-            Err(e)
+            Err(CanopyError::setup(e))
         }
     }
 }
@@ -423,7 +452,7 @@ pub async fn run_custom_command(app: AppHandle, wt_key: String, command: String)
 // ── open things ──
 
 #[tauri::command]
-pub async fn open_in_editor(app: AppHandle, wt_key: String) -> Result<(), String> {
+pub async fn open_in_editor(app: AppHandle, wt_key: String) -> Result<(), CanopyError> {
     let editor = {
         let state = app.state::<AppState>();
         let s = state.settings.read().unwrap();
@@ -434,7 +463,7 @@ pub async fn open_in_editor(app: AppHandle, wt_key: String) -> Result<(), String
     tokio::process::Command::new(shell)
         .args(&shargs)
         .spawn()
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| CanopyError::process(e.to_string()))?;
     Ok(())
 }
 
@@ -442,13 +471,13 @@ pub async fn open_in_editor(app: AppHandle, wt_key: String) -> Result<(), String
 /// resolved from the worktree root; canonicalization rejects traversal and
 /// symlinks that leave it before any shell command is launched.
 #[tauri::command]
-pub async fn open_file_in_editor(app: AppHandle, wt_key: String, path: String) -> Result<(), String> {
-    let root = std::fs::canonicalize(&wt_key).map_err(|e| format!("worktree path: {e}"))?;
+pub async fn open_file_in_editor(app: AppHandle, wt_key: String, path: String) -> Result<(), CanopyError> {
+    let root = std::fs::canonicalize(&wt_key).map_err(|e| CanopyError::invalid_input(format!("worktree path: {e}")))?;
     let requested = std::path::PathBuf::from(&path);
     let candidate = if requested.is_absolute() { requested } else { root.join(requested) };
-    let file = std::fs::canonicalize(&candidate).map_err(|e| format!("file path: {e}"))?;
+    let file = std::fs::canonicalize(&candidate).map_err(|e| CanopyError::invalid_input(format!("file path: {e}")))?;
     if !file.starts_with(&root) {
-        return Err("File must be inside the selected worktree".into());
+        return Err(CanopyError::invalid_input("File must be inside the selected worktree"));
     }
     let editor = {
         let state = app.state::<AppState>();
@@ -461,13 +490,13 @@ pub async fn open_file_in_editor(app: AppHandle, wt_key: String, path: String) -
     tokio::process::Command::new(shell)
         .args(&shargs)
         .spawn()
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| CanopyError::process(e.to_string()))?;
     Ok(())
 }
 
 /// Reveal a path in the OS file manager (Finder / Files / Explorer).
 #[tauri::command]
-pub fn reveal_in_finder(wt_key: String) -> Result<(), String> {
+pub fn reveal_in_finder(wt_key: String) -> Result<(), CanopyError> {
     #[cfg(target_os = "macos")]
     let mut cmd = {
         let mut c = std::process::Command::new("open");
@@ -491,14 +520,14 @@ pub fn reveal_in_finder(wt_key: String) -> Result<(), String> {
         c.arg(dir);
         c
     };
-    cmd.spawn().map_err(|e| e.to_string())?;
+    cmd.spawn().map_err(|e| CanopyError::process(e.to_string()))?;
     Ok(())
 }
 
 /// Open a terminal at the worktree root. macOS uses the configured terminal app;
 /// Linux tries the user's preference then common emulators.
 #[tauri::command]
-pub fn open_terminal(app: AppHandle, wt_key: String) -> Result<(), String> {
+pub fn open_terminal(app: AppHandle, wt_key: String) -> Result<(), CanopyError> {
     let term = {
         let state = app.state::<AppState>();
         let s = state.settings.read().unwrap();
@@ -511,7 +540,7 @@ pub fn open_terminal(app: AppHandle, wt_key: String) -> Result<(), String> {
         std::process::Command::new("open")
             .args(["-a", &term, &wt_key])
             .spawn()
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| CanopyError::process(e.to_string()))?;
         return Ok(());
     }
 
@@ -539,7 +568,7 @@ pub fn open_terminal(app: AppHandle, wt_key: String) -> Result<(), String> {
                 return Ok(());
             }
         }
-        return Err("No terminal emulator found — set one in Settings".into());
+        return Err(CanopyError::process("No terminal emulator found — set one in Settings"));
     }
 
     #[cfg(target_os = "windows")]
@@ -548,20 +577,20 @@ pub fn open_terminal(app: AppHandle, wt_key: String) -> Result<(), String> {
         std::process::Command::new("cmd")
             .args(["/C", "start", "cmd", "/K", "cd", "/D", &wt_key])
             .spawn()
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| CanopyError::process(e.to_string()))?;
         Ok(())
     }
 }
 
 #[tauri::command]
-pub fn open_port(app: AppHandle, port: u32) -> Result<(), String> {
+pub fn open_port(app: AppHandle, port: u32) -> Result<(), CanopyError> {
     tauri_plugin_opener::OpenerExt::opener(&app)
         .open_url(format!("http://localhost:{port}"), None::<String>)
-        .map_err(|e| e.to_string())
+        .map_err(|e| CanopyError::process(e.to_string()))
 }
 
 #[tauri::command]
-pub async fn show_main_window(app: AppHandle) -> Result<(), String> {
+pub async fn show_main_window(app: AppHandle) -> Result<(), CanopyError> {
     // macOS: return to the Dock when a real window is on screen
     #[cfg(target_os = "macos")]
     let _ = app.set_activation_policy(tauri::ActivationPolicy::Regular);
@@ -577,7 +606,7 @@ pub async fn show_main_window(app: AppHandle) -> Result<(), String> {
 }
 
 #[tauri::command]
-pub async fn quit_app(app: AppHandle) -> Result<(), String> {
+pub async fn quit_app(app: AppHandle) -> Result<(), CanopyError> {
     services::stop_all(&app).await;
     app.exit(0);
     Ok(())
@@ -602,7 +631,7 @@ fn emit_op(app: &AppHandle, wt_key: &str, op: &'static str, state: &'static str,
     );
 }
 
-fn sanitize_branch(branch: &str) -> String {
+pub(crate) fn sanitize_branch(branch: &str) -> String {
     branch
         .chars()
         .map(|c| if c.is_alphanumeric() || c == '-' || c == '.' { c } else { '_' })
@@ -616,11 +645,15 @@ pub async fn create_worktree(
     branch: String,
     base: Option<String>,
     create_branch: bool,
-) -> Result<String, String> {
+) -> Result<String, CanopyError> {
     let repo = {
         let state = app.state::<AppState>();
         let s = state.settings.read().unwrap();
-        s.repos.iter().find(|r| r.id == repo_id).cloned().ok_or("unknown repo")?
+        s.repos
+            .iter()
+            .find(|r| r.id == repo_id)
+            .cloned()
+            .ok_or_else(|| CanopyError::not_found("unknown repo"))?
     };
     let wt_dir = if repo.worktree_dir.trim().is_empty() {
         format!("{}-worktrees", repo.path)
@@ -629,7 +662,7 @@ pub async fn create_worktree(
     };
     let wt_path = format!("{wt_dir}/{}", sanitize_branch(&branch));
     if std::path::Path::new(&wt_path).exists() {
-        return Err(format!("Path already exists: {wt_path}"));
+        return Err(CanopyError::conflict(format!("Path already exists: {wt_path}")));
     }
 
     emit_op(&app, &wt_path, "create", "progress", format!("creating worktree for {branch}…"));
@@ -657,7 +690,7 @@ pub async fn create_worktree(
 
     if let Err(e) = result {
         emit_op(&app, &wt_path, "create", "error", e.clone());
-        return Err(e);
+        return Err(CanopyError::git(e));
     }
 
     // post-create provisioning (env overrides + setup commands) — see setup.rs.
@@ -671,7 +704,7 @@ pub async fn create_worktree(
     })
     .await;
 
-    refresh_tree(&app).await?;
+    refresh_tree(&app).await.map_err(CanopyError::internal)?;
     refresh_git_meta(&app, &wt_path).await;
 
     match setup_result {
@@ -681,7 +714,7 @@ pub async fn create_worktree(
         }
         Err(e) => {
             emit_op(&app, &wt_path, "create", "error", format!("worktree created, but {e}"));
-            Err(format!("Worktree created, but setup failed:\n{e}"))
+            Err(CanopyError::setup(format!("Worktree created, but setup failed:\n{e}")))
         }
     }
 }
@@ -689,19 +722,21 @@ pub async fn create_worktree(
 /// Manually (re)run a worktree's setup commands — for worktrees created before
 /// setup was configured, or to retry after a failure.
 #[tauri::command]
-pub async fn run_worktree_setup(app: AppHandle, wt_key: String) -> Result<(), String> {
+pub async fn run_worktree_setup(app: AppHandle, wt_key: String) -> Result<(), CanopyError> {
     let (repo_path, repo_id, is_main) = {
         let state = app.state::<AppState>();
         let tree = state.tree.read().unwrap();
         let r = tree
             .iter()
             .find(|r| r.worktrees.iter().any(|w| w.wt_key == wt_key))
-            .ok_or("unknown worktree")?;
+            .ok_or_else(|| CanopyError::not_found("unknown worktree"))?;
         let is_main = r.worktrees.iter().find(|w| w.wt_key == wt_key).map(|w| w.is_main).unwrap_or(false);
         (r.path.clone(), r.repo_id.clone(), is_main)
     };
     if !crate::setup::has_config(&wt_key, &repo_path) {
-        return Err("Nothing to run — add provisioned files or setup commands in .worktreemanager.json".into());
+        return Err(CanopyError::invalid_input(
+            "Nothing to run — add provisioned files or setup commands in .worktreemanager.json",
+        ));
     }
     let vars = crate::state::worktree_vars(&app, &repo_id, &wt_key, is_main);
     let app3 = app.clone();
@@ -718,7 +753,7 @@ pub async fn run_worktree_setup(app: AppHandle, wt_key: String) -> Result<(), St
         }
         Err(e) => {
             emit_op(&app, &wt_key, "create", "error", e.clone());
-            Err(e)
+            Err(CanopyError::setup(e))
         }
     }
 }
@@ -729,7 +764,7 @@ pub async fn worktree_dirty_report(wt_key: String) -> git::DirtyReport {
 }
 
 #[tauri::command]
-pub async fn remove_worktree(app: AppHandle, wt_key: String, delete_branch: bool, drop_db: bool) -> Result<(), String> {
+pub async fn remove_worktree(app: AppHandle, wt_key: String, delete_branch: bool, drop_db: bool) -> Result<(), CanopyError> {
     // never remove a main checkout; find owning repo + branch
     let (repo_path, repo_id, branch, is_main) = {
         let state = app.state::<AppState>();
@@ -742,10 +777,10 @@ pub async fn remove_worktree(app: AppHandle, wt_key: String, delete_branch: bool
                 }
             }
         }
-        found.ok_or("unknown worktree")?
+        found.ok_or_else(|| CanopyError::not_found("unknown worktree"))?
     };
     if is_main {
-        return Err("Refusing to remove the main checkout".into());
+        return Err(CanopyError::invalid_input("Refusing to remove the main checkout"));
     }
 
     // stop its services first
@@ -775,12 +810,12 @@ pub async fn remove_worktree(app: AppHandle, wt_key: String, delete_branch: bool
     match git::remove_worktree(&repo_path, &wt_key, Some(&branch), delete_branch).await {
         Ok(()) => {
             emit_op(&app, &wt_key, "remove", "done", "worktree removed");
-            refresh_tree(&app).await?;
+            refresh_tree(&app).await.map_err(CanopyError::internal)?;
             Ok(())
         }
         Err(e) => {
             emit_op(&app, &wt_key, "remove", "error", e.clone());
-            Err(e)
+            Err(CanopyError::git(e))
         }
     }
 }
@@ -794,18 +829,18 @@ fn is_running(app: &AppHandle, key: &str) -> bool {
 // ── database: list / snapshot / export / switch ──
 
 /// repo path + repo_id for a worktree key.
-fn repo_for_wt(app: &AppHandle, wt_key: &str) -> Result<(String, String), String> {
+fn repo_for_wt(app: &AppHandle, wt_key: &str) -> Result<(String, String), CanopyError> {
     let state = app.state::<AppState>();
     let tree = state.tree.read().unwrap();
     tree.iter()
         .find(|r| r.worktrees.iter().any(|w| w.wt_key == wt_key))
         .map(|r| (r.path.clone(), r.repo_id.clone()))
-        .ok_or_else(|| "unknown worktree".to_string())
+        .ok_or_else(|| CanopyError::not_found("unknown worktree"))
 }
 
 #[tauri::command]
-pub async fn list_databases(wt_key: String) -> Result<Vec<String>, String> {
-    crate::db::list_databases(&wt_key).await
+pub async fn list_databases(wt_key: String) -> Result<Vec<String>, CanopyError> {
+    crate::db::list_databases(&wt_key).await.map_err(CanopyError::db)
 }
 
 #[tauri::command]
@@ -814,61 +849,77 @@ pub fn current_database(wt_key: String) -> Option<String> {
 }
 
 #[tauri::command]
-pub async fn snapshot_database(app: AppHandle, wt_key: String, name: String) -> Result<(), String> {
+pub async fn snapshot_database(app: AppHandle, wt_key: String, name: String) -> Result<(), CanopyError> {
     let name = name.trim().to_string();
     if name.is_empty() {
-        return Err("Snapshot name is required".into());
+        return Err(CanopyError::invalid_input("Snapshot name is required"));
     }
     let app2 = app.clone();
     let wt2 = wt_key.clone();
-    crate::db::clone_database(&wt_key, &name, move |line| emit_op(&app2, &wt2, "snapshot", "progress", line)).await?;
+    crate::db::clone_database(&wt_key, &name, move |line| emit_op(&app2, &wt2, "snapshot", "progress", line))
+        .await
+        .map_err(CanopyError::db)?;
     emit_op(&app, &wt_key, "snapshot", "done", format!("snapshot '{name}' created"));
     Ok(())
 }
 
 #[tauri::command]
-pub async fn export_database(app: AppHandle, wt_key: String, file_path: String) -> Result<(), String> {
+pub async fn export_database(app: AppHandle, wt_key: String, file_path: String) -> Result<(), CanopyError> {
     let app2 = app.clone();
     let wt2 = wt_key.clone();
-    crate::db::export_database(&wt_key, &file_path, move |line| emit_op(&app2, &wt2, "snapshot", "progress", line)).await?;
+    crate::db::export_database(&wt_key, &file_path, move |line| emit_op(&app2, &wt2, "snapshot", "progress", line))
+        .await
+        .map_err(CanopyError::db)?;
     emit_op(&app, &wt_key, "snapshot", "done", "exported to file");
     Ok(())
 }
 
 #[tauri::command]
-pub async fn restore_database(app: AppHandle, wt_key: String, file_path: String) -> Result<(), String> {
+pub async fn restore_database(app: AppHandle, wt_key: String, file_path: String) -> Result<(), CanopyError> {
     let app2 = app.clone();
     let wt2 = wt_key.clone();
-    crate::db::restore_database(&wt_key, &file_path, move |line| emit_op(&app2, &wt2, "snapshot", "progress", line)).await?;
+    crate::db::restore_database(&wt_key, &file_path, move |line| emit_op(&app2, &wt2, "snapshot", "progress", line))
+        .await
+        .map_err(CanopyError::db)?;
     emit_op(&app, &wt_key, "snapshot", "done", "restore complete");
     Ok(())
 }
 
 #[tauri::command]
-pub async fn switch_database(app: AppHandle, wt_key: String, db_name: String) -> Result<(), String> {
+pub async fn switch_database(app: AppHandle, wt_key: String, db_name: String) -> Result<(), CanopyError> {
     let (repo_path, _repo_id) = repo_for_wt(&app, &wt_key)?;
     // repoint PG_DB in the worktree's root .env AND in any provisioned dotenv
     // file (e.g. server/.env) that declares it
     let pairs = [("PG_DB".to_string(), db_name.clone())];
-    crate::setup::set_env_keys(&wt_key, &repo_path, &pairs)?;
-    crate::setup::set_env_keys_in_provisioned(&wt_key, &repo_path, &pairs)?;
-    refresh_tree(&app).await?;
+    crate::setup::set_env_keys(&wt_key, &repo_path, &pairs).map_err(CanopyError::setup)?;
+    crate::setup::set_env_keys_in_provisioned(&wt_key, &repo_path, &pairs).map_err(CanopyError::setup)?;
+    refresh_tree(&app).await.map_err(CanopyError::internal)?;
     // auto-restart the server so it connects to the new DB
+    let mut errors: Vec<String> = Vec::new();
     for key in services::worktree_svc_keys(&app, &wt_key) {
         if is_running(&app, &key) {
-            let _ = services::restart_service(&app, &key).await;
+            if let Err(e) = services::restart_service(&app, &key).await {
+                errors.push(format!("{key}: {e}"));
+            }
         }
     }
-    Ok(())
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(CanopyError::process(format!(
+            "database switched, but restart failed — {}",
+            errors.join("; ")
+        )))
+    }
 }
 
 /// Override a service's port. Validates range + cross-worktree conflict, updates
 /// the override, re-derives env (so dependent keys follow), and auto-restarts
 /// the worktree's running services so the change takes effect.
 #[tauri::command]
-pub async fn set_service_port(app: AppHandle, svc_key: String, port: u32) -> Result<(), String> {
+pub async fn set_service_port(app: AppHandle, svc_key: String, port: u32) -> Result<(), CanopyError> {
     if !(1024..=65535).contains(&port) {
-        return Err("Port must be between 1024 and 65535".into());
+        return Err(CanopyError::invalid_input("Port must be between 1024 and 65535"));
     }
     // locate the worktree + repo for this service, and check for conflicts
     let (wt_key, repo_id, repo_path) = {
@@ -883,12 +934,15 @@ pub async fn set_service_port(app: AppHandle, svc_key: String, port: u32) -> Res
                     }
                     // conflict: another service already uses this effective port
                     if s.svc_key != svc_key && s.port == Some(port) {
-                        return Err(format!("Port {port} is already used by {} ({})", s.name, w.branch));
+                        return Err(CanopyError::conflict(format!(
+                            "Port {port} is already used by {} ({})",
+                            s.name, w.branch
+                        )));
                     }
                 }
             }
         }
-        found.ok_or("unknown service")?
+        found.ok_or_else(|| CanopyError::not_found("unknown service"))?
     };
 
     // record the override + persist
@@ -902,31 +956,38 @@ pub async fn set_service_port(app: AppHandle, svc_key: String, port: u32) -> Res
     // re-derive .env (TOOLJET_SERVER_PORT etc.) from the declarative env block
     let vars = crate::state::worktree_vars(&app, &repo_id, &wt_key, false);
     let _ = crate::setup::reapply_provision(&wt_key, &repo_path, &vars);
-    refresh_tree(&app).await?;
+    refresh_tree(&app).await.map_err(CanopyError::internal)?;
 
     // auto-restart running services of this worktree to apply the new port(s)
+    let mut errors: Vec<String> = Vec::new();
     for key in services::worktree_svc_keys(&app, &wt_key) {
         if is_running(&app, &key) {
-            let _ = services::restart_service(&app, &key).await;
+            if let Err(e) = services::restart_service(&app, &key).await {
+                errors.push(format!("{key}: {e}"));
+            }
         }
     }
-    Ok(())
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(CanopyError::process(format!("port set, but restart failed — {}", errors.join("; "))))
+    }
 }
 
-fn repo_path(app: &AppHandle, repo_id: &str) -> Result<String, String> {
+fn repo_path(app: &AppHandle, repo_id: &str) -> Result<String, CanopyError> {
     let state = app.state::<AppState>();
     let s = state.settings.read().unwrap();
     s.repos
         .iter()
         .find(|r| r.id == repo_id)
         .map(|r| r.path.clone())
-        .ok_or_else(|| "unknown repo".to_string())
+        .ok_or_else(|| CanopyError::not_found("unknown repo"))
 }
 
 #[tauri::command]
-pub async fn list_branches(app: AppHandle, repo_id: String) -> Result<git::Branches, String> {
+pub async fn list_branches(app: AppHandle, repo_id: String) -> Result<git::Branches, CanopyError> {
     let path = repo_path(&app, &repo_id)?;
-    git::list_branches(&path).await
+    git::list_branches(&path).await.map_err(CanopyError::git)
 }
 
 /// One provisioned-file entry as exchanged with the Settings UI.
@@ -979,7 +1040,7 @@ impl From<ProvisionEntry> for crate::setup::ProvisionFile {
 
 /// Read the repo's `.worktreemanager.json` (provisioned files + setup) for the editor.
 #[tauri::command]
-pub fn get_repo_config(app: AppHandle, repo_id: String) -> Result<RepoConfig, String> {
+pub fn get_repo_config(app: AppHandle, repo_id: String) -> Result<RepoConfig, CanopyError> {
     let path = repo_path(&app, &repo_id)?;
     let c = crate::setup::read_repo_config(&path);
     Ok(RepoConfig {
@@ -994,25 +1055,37 @@ pub fn get_repo_config(app: AppHandle, repo_id: String) -> Result<RepoConfig, St
 /// Settings config Export and by the agent lane (writing `.canopy/context.md`,
 /// whose parent dir may not exist yet).
 #[tauri::command]
-pub fn save_text_file(path: String, contents: String) -> Result<(), String> {
+pub fn save_text_file(path: String, contents: String) -> Result<(), CanopyError> {
     if let Some(dir) = std::path::Path::new(&path).parent() {
-        std::fs::create_dir_all(dir).map_err(|e| format!("mkdir {}: {e}", dir.display()))?;
+        std::fs::create_dir_all(dir).map_err(|e| CanopyError::config(format!("mkdir {}: {e}", dir.display())))?;
     }
-    std::fs::write(&path, contents).map_err(|e| format!("write {path}: {e}"))
+    std::fs::write(&path, contents).map_err(|e| CanopyError::config(format!("write {path}: {e}")))
 }
 
 /// Write provisioned files + setup commands to the repo's `.worktreemanager.json`.
 #[tauri::command]
-pub fn save_repo_config(app: AppHandle, repo_id: String, provision: Vec<ProvisionEntry>, setup: Vec<String>) -> Result<(), String> {
+pub fn save_repo_config(app: AppHandle, repo_id: String, provision: Vec<ProvisionEntry>, setup: Vec<String>) -> Result<(), CanopyError> {
     let path = repo_path(&app, &repo_id)?;
     let files: Vec<crate::setup::ProvisionFile> = provision.into_iter().map(Into::into).collect();
-    crate::setup::write_repo_config(&path, &files, &setup)
+    crate::setup::write_repo_config(&path, &files, &setup).map_err(CanopyError::config)
 }
 
 /// `git fetch --all --prune` then return the refreshed branch lists.
 #[tauri::command]
-pub async fn fetch_branches(app: AppHandle, repo_id: String) -> Result<git::Branches, String> {
+pub async fn fetch_branches(app: AppHandle, repo_id: String) -> Result<git::Branches, CanopyError> {
     let path = repo_path(&app, &repo_id)?;
-    git::fetch_all(&path).await?;
-    git::list_branches(&path).await
+    git::fetch_all(&path).await.map_err(CanopyError::git)?;
+    git::list_branches(&path).await.map_err(CanopyError::git)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sanitize_branch;
+
+    #[test]
+    fn sanitize_branch_maps_separators() {
+        assert_eq!(sanitize_branch("feature/foo-bar"), "feature_foo-bar");
+        assert_eq!(sanitize_branch("v1.2.3"), "v1.2.3");
+        assert_eq!(sanitize_branch("fix db reset"), "fix_db_reset");
+    }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -6,6 +6,17 @@ use crate::state::{refresh_all_git_meta, refresh_git_meta, refresh_tree, AppStat
 use crate::terminal::{self, TermTable};
 use tauri::{AppHandle, Manager, State};
 
+/// Uniform containment: commands that act on a `wt_key` only accept keys the
+/// tree actually knows. Without this, a compromised webview could point
+/// git/db/terminal operations at arbitrary filesystem paths.
+fn ensure_known_worktree(app: &AppHandle, wt_key: &str) -> Result<(), CanopyError> {
+    if app.state::<AppState>().wt_context(wt_key).is_some() {
+        Ok(())
+    } else {
+        Err(CanopyError::not_found("unknown worktree"))
+    }
+}
+
 #[tauri::command]
 pub async fn get_tree(app: AppHandle) -> Result<Vec<RepoNode>, CanopyError> {
     let cached = {
@@ -225,6 +236,7 @@ pub async fn remove_repo(app: AppHandle, repo_id: String) -> Result<(), CanopyEr
 
 #[tauri::command]
 pub async fn git_pull(app: AppHandle, wt_key: String) -> Result<String, CanopyError> {
+    ensure_known_worktree(&app, &wt_key)?;
     let summary = git::pull(&wt_key).await.map_err(CanopyError::git)?;
     refresh_git_meta(&app, &wt_key).await;
     Ok(summary)
@@ -233,12 +245,14 @@ pub async fn git_pull(app: AppHandle, wt_key: String) -> Result<String, CanopyEr
 // ── submodules ──
 
 #[tauri::command]
-pub async fn submodule_status(wt_key: String) -> Result<Vec<git::SubmoduleStatus>, CanopyError> {
+pub async fn submodule_status(app: AppHandle, wt_key: String) -> Result<Vec<git::SubmoduleStatus>, CanopyError> {
+    ensure_known_worktree(&app, &wt_key)?;
     Ok(git::submodule_status(&wt_key).await)
 }
 
 #[tauri::command]
 pub async fn pull_submodule(app: AppHandle, wt_key: String, path: String) -> Result<String, CanopyError> {
+    ensure_known_worktree(&app, &wt_key)?;
     let summary = git::pull_submodule(&wt_key, &path).await.map_err(CanopyError::git)?;
     refresh_git_meta(&app, &wt_key).await;
     Ok(summary)
@@ -246,18 +260,21 @@ pub async fn pull_submodule(app: AppHandle, wt_key: String, path: String) -> Res
 
 #[tauri::command]
 pub async fn switch_submodule_branch(app: AppHandle, wt_key: String, path: String, branch: String) -> Result<(), CanopyError> {
+    ensure_known_worktree(&app, &wt_key)?;
     git::switch_submodule_branch(&wt_key, &path, &branch).await.map_err(CanopyError::git)?;
     refresh_git_meta(&app, &wt_key).await;
     Ok(())
 }
 
 #[tauri::command]
-pub async fn list_submodule_branches(wt_key: String, path: String) -> Result<git::Branches, CanopyError> {
+pub async fn list_submodule_branches(app: AppHandle, wt_key: String, path: String) -> Result<git::Branches, CanopyError> {
+    ensure_known_worktree(&app, &wt_key)?;
     git::list_submodule_branches(&wt_key, &path).await.map_err(CanopyError::git)
 }
 
 #[tauri::command]
-pub async fn fetch_submodules(wt_key: String) -> Result<usize, CanopyError> {
+pub async fn fetch_submodules(app: AppHandle, wt_key: String) -> Result<usize, CanopyError> {
+    ensure_known_worktree(&app, &wt_key)?;
     Ok(git::fetch_submodules(&wt_key).await)
 }
 
@@ -270,6 +287,7 @@ pub async fn switch_worktree_branch(
     create: bool,
     base: Option<String>,
 ) -> Result<(), CanopyError> {
+    ensure_known_worktree(&app, &wt_key)?;
     git::switch_branch(&wt_key, &branch, create, base.as_deref()).await.map_err(CanopyError::git)?;
     let _ = refresh_tree(&app).await;
     refresh_git_meta(&app, &wt_key).await;
@@ -304,6 +322,7 @@ pub async fn terminal_open(
     rows: u16,
     command: Option<String>,
 ) -> Result<(), CanopyError> {
+    ensure_known_worktree(&app, &cwd)?;
     terminal::open(&app, &table, &id, &cwd, cols, rows, command).map_err(CanopyError::terminal)
 }
 
@@ -331,7 +350,8 @@ pub async fn terminal_close(app: AppHandle, table: State<'_, TermTable>, id: Str
 /// Ensure a worktree's `.canopy/` exists with a self-ignoring `.gitignore`, then
 /// write `context.md`. Never truncates an existing `.gitignore`.
 #[tauri::command]
-pub fn write_worktree_context(wt_path: String, contents: String) -> Result<(), CanopyError> {
+pub fn write_worktree_context(app: AppHandle, wt_path: String, contents: String) -> Result<(), CanopyError> {
+    ensure_known_worktree(&app, &wt_path)?;
     let dir = std::path::Path::new(&wt_path).join(".canopy");
     std::fs::create_dir_all(&dir).map_err(|e| CanopyError::setup(format!("mkdir {}: {e}", dir.display())))?;
     let ignore = dir.join(".gitignore");
@@ -796,7 +816,8 @@ pub async fn run_worktree_setup(app: AppHandle, wt_key: String) -> Result<(), Ca
 }
 
 #[tauri::command]
-pub async fn worktree_dirty_report(wt_key: String) -> Result<git::DirtyReport, CanopyError> {
+pub async fn worktree_dirty_report(app: AppHandle, wt_key: String) -> Result<git::DirtyReport, CanopyError> {
+    ensure_known_worktree(&app, &wt_key)?;
     git::dirty_report(&wt_key).await.map_err(CanopyError::git)
 }
 
@@ -871,13 +892,15 @@ fn repo_for_wt(app: &AppHandle, wt_key: &str) -> Result<(String, String), Canopy
 }
 
 #[tauri::command]
-pub async fn list_databases(wt_key: String) -> Result<Vec<String>, CanopyError> {
+pub async fn list_databases(app: AppHandle, wt_key: String) -> Result<Vec<String>, CanopyError> {
+    ensure_known_worktree(&app, &wt_key)?;
     crate::db::list_databases(&wt_key).await.map_err(CanopyError::db)
 }
 
 #[tauri::command]
-pub fn current_database(wt_key: String) -> Option<String> {
-    crate::db::current_db(&wt_key)
+pub fn current_database(app: AppHandle, wt_key: String) -> Result<Option<String>, CanopyError> {
+    ensure_known_worktree(&app, &wt_key)?;
+    Ok(crate::db::current_db(&wt_key))
 }
 
 #[tauri::command]
@@ -886,6 +909,7 @@ pub async fn snapshot_database(app: AppHandle, wt_key: String, name: String) -> 
     if name.is_empty() {
         return Err(CanopyError::invalid_input("Snapshot name is required"));
     }
+    ensure_known_worktree(&app, &wt_key)?;
     let _lease = crate::state::try_lease(&app, &wt_key, "snapshot")?;
     let app2 = app.clone();
     let wt2 = wt_key.clone();
@@ -898,6 +922,7 @@ pub async fn snapshot_database(app: AppHandle, wt_key: String, name: String) -> 
 
 #[tauri::command]
 pub async fn export_database(app: AppHandle, wt_key: String, file_path: String) -> Result<(), CanopyError> {
+    ensure_known_worktree(&app, &wt_key)?;
     let _lease = crate::state::try_lease(&app, &wt_key, "export")?;
     let app2 = app.clone();
     let wt2 = wt_key.clone();
@@ -910,6 +935,7 @@ pub async fn export_database(app: AppHandle, wt_key: String, file_path: String) 
 
 #[tauri::command]
 pub async fn restore_database(app: AppHandle, wt_key: String, file_path: String) -> Result<(), CanopyError> {
+    ensure_known_worktree(&app, &wt_key)?;
     let _lease = crate::state::try_lease(&app, &wt_key, "restore")?;
     // quiesce: a live connection pool holds locks against --clean drops and
     // can observe (or block) a half-restored schema. Stop the worktree's

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -312,12 +312,7 @@ pub fn write_worktree_context(wt_path: String, contents: String) -> Result<(), C
 #[tauri::command]
 pub fn resolve_agent_command(state: State<'_, AppState>, wt_key: String) -> String {
     const DEFAULT_AGENT: &str = "claude";
-    let repo_id = {
-        let tree = state.tree.read().unwrap();
-        tree.iter()
-            .find(|r| r.worktrees.iter().any(|w| w.wt_key == wt_key))
-            .map(|r| r.repo_id.clone())
-    };
+    let repo_id = state.wt_context(&wt_key).map(|c| c.repo_id);
     let cmd = repo_id.and_then(|id| {
         let settings = state.settings.read().unwrap();
         settings
@@ -723,16 +718,11 @@ pub async fn create_worktree(
 /// setup was configured, or to retry after a failure.
 #[tauri::command]
 pub async fn run_worktree_setup(app: AppHandle, wt_key: String) -> Result<(), CanopyError> {
-    let (repo_path, repo_id, is_main) = {
-        let state = app.state::<AppState>();
-        let tree = state.tree.read().unwrap();
-        let r = tree
-            .iter()
-            .find(|r| r.worktrees.iter().any(|w| w.wt_key == wt_key))
-            .ok_or_else(|| CanopyError::not_found("unknown worktree"))?;
-        let is_main = r.worktrees.iter().find(|w| w.wt_key == wt_key).map(|w| w.is_main).unwrap_or(false);
-        (r.path.clone(), r.repo_id.clone(), is_main)
-    };
+    let ctx = app
+        .state::<AppState>()
+        .wt_context(&wt_key)
+        .ok_or_else(|| CanopyError::not_found("unknown worktree"))?;
+    let (repo_path, repo_id, is_main) = (ctx.repo_path, ctx.repo_id, ctx.is_main);
     if !crate::setup::has_config(&wt_key, &repo_path) {
         return Err(CanopyError::invalid_input(
             "Nothing to run — add provisioned files or setup commands in .worktreemanager.json",
@@ -766,19 +756,11 @@ pub async fn worktree_dirty_report(wt_key: String) -> git::DirtyReport {
 #[tauri::command]
 pub async fn remove_worktree(app: AppHandle, wt_key: String, delete_branch: bool, drop_db: bool) -> Result<(), CanopyError> {
     // never remove a main checkout; find owning repo + branch
-    let (repo_path, repo_id, branch, is_main) = {
-        let state = app.state::<AppState>();
-        let tree = state.tree.read().unwrap();
-        let mut found = None;
-        for r in tree.iter() {
-            for w in r.worktrees.iter() {
-                if w.wt_key == wt_key {
-                    found = Some((r.path.clone(), r.repo_id.clone(), w.branch.clone(), w.is_main));
-                }
-            }
-        }
-        found.ok_or_else(|| CanopyError::not_found("unknown worktree"))?
-    };
+    let ctx = app
+        .state::<AppState>()
+        .wt_context(&wt_key)
+        .ok_or_else(|| CanopyError::not_found("unknown worktree"))?;
+    let (repo_path, repo_id, branch, is_main) = (ctx.repo_path, ctx.repo_id, ctx.branch, ctx.is_main);
     if is_main {
         return Err(CanopyError::invalid_input("Refusing to remove the main checkout"));
     }
@@ -830,11 +812,9 @@ fn is_running(app: &AppHandle, key: &str) -> bool {
 
 /// repo path + repo_id for a worktree key.
 fn repo_for_wt(app: &AppHandle, wt_key: &str) -> Result<(String, String), CanopyError> {
-    let state = app.state::<AppState>();
-    let tree = state.tree.read().unwrap();
-    tree.iter()
-        .find(|r| r.worktrees.iter().any(|w| w.wt_key == wt_key))
-        .map(|r| (r.path.clone(), r.repo_id.clone()))
+    app.state::<AppState>()
+        .wt_context(wt_key)
+        .map(|c| (c.repo_path, c.repo_id))
         .ok_or_else(|| CanopyError::not_found("unknown worktree"))
 }
 
@@ -921,18 +901,13 @@ pub async fn set_service_port(app: AppHandle, svc_key: String, port: u32) -> Res
     if !(1024..=65535).contains(&port) {
         return Err(CanopyError::invalid_input("Port must be between 1024 and 65535"));
     }
-    // locate the worktree + repo for this service, and check for conflicts
-    let (wt_key, repo_id, repo_path) = {
+    // check cross-worktree conflicts: another service already on this port
+    {
         let state = app.state::<AppState>();
         let tree = state.tree.read().unwrap();
-        let mut found = None;
         for r in tree.iter() {
             for w in r.worktrees.iter() {
                 for s in w.services.iter() {
-                    if s.svc_key == svc_key {
-                        found = Some((w.wt_key.clone(), r.repo_id.clone(), r.path.clone()));
-                    }
-                    // conflict: another service already uses this effective port
                     if s.svc_key != svc_key && s.port == Some(port) {
                         return Err(CanopyError::conflict(format!(
                             "Port {port} is already used by {} ({})",
@@ -942,8 +917,11 @@ pub async fn set_service_port(app: AppHandle, svc_key: String, port: u32) -> Res
                 }
             }
         }
-        found.ok_or_else(|| CanopyError::not_found("unknown service"))?
-    };
+    }
+    let (wt_key, repo_id, repo_path) = app
+        .state::<AppState>()
+        .service_context(&svc_key)
+        .ok_or_else(|| CanopyError::not_found("unknown service"))?;
 
     // record the override + persist
     {
@@ -975,12 +953,8 @@ pub async fn set_service_port(app: AppHandle, svc_key: String, port: u32) -> Res
 }
 
 fn repo_path(app: &AppHandle, repo_id: &str) -> Result<String, CanopyError> {
-    let state = app.state::<AppState>();
-    let s = state.settings.read().unwrap();
-    s.repos
-        .iter()
-        .find(|r| r.id == repo_id)
-        .map(|r| r.path.clone())
+    app.state::<AppState>()
+        .repo_path_by_id(repo_id)
         .ok_or_else(|| CanopyError::not_found("unknown repo"))
 }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -580,6 +580,7 @@ pub fn reveal_in_finder(wt_key: String) -> Result<(), CanopyError> {
 /// Open a terminal at the worktree root. macOS uses the configured terminal app;
 /// Linux tries the user's preference then common emulators.
 #[tauri::command]
+#[allow(clippy::needless_return)] // cfg-gated per-OS tails; return keeps them uniform
 pub fn open_terminal(app: AppHandle, wt_key: String) -> Result<(), CanopyError> {
     let term = {
         let state = app.state::<AppState>();

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -10,7 +10,7 @@ use tauri::{AppHandle, Manager, State};
 pub async fn get_tree(app: AppHandle) -> Result<Vec<RepoNode>, CanopyError> {
     let cached = {
         let state = app.state::<AppState>();
-        let tree = state.tree.read().unwrap();
+        let tree = state.tree.read();
         tree.clone()
     };
     if cached.is_empty() {
@@ -34,14 +34,14 @@ pub async fn refresh(app: AppHandle, wt_key: Option<String>) -> Result<(), Canop
 
 #[tauri::command]
 pub fn get_settings(state: State<'_, AppState>) -> Settings {
-    state.settings.read().unwrap().clone()
+    state.settings.read().clone()
 }
 
 #[tauri::command]
 pub async fn save_settings(app: AppHandle, new_settings: Settings) -> Result<(), CanopyError> {
     {
         let state = app.state::<AppState>();
-        *state.settings.write().unwrap() = new_settings.clone();
+        *state.settings.write() = new_settings.clone();
     }
     settings::save_settings(&app, &new_settings).map_err(CanopyError::config)?;
     refresh_tree(&app).await.map_err(CanopyError::internal)?;
@@ -73,7 +73,7 @@ pub async fn add_repo(app: AppHandle, path: String) -> Result<RepoCfg, CanopyErr
 
     let updated = {
         let state = app.state::<AppState>();
-        let mut s = state.settings.write().unwrap();
+        let mut s = state.settings.write();
         if s.repos.iter().any(|r| r.path == repo.path) {
             return Err(CanopyError::conflict("Repository already registered"));
         }
@@ -183,7 +183,7 @@ pub async fn detect_repo(path: String) -> Result<RepoDetection, CanopyError> {
 pub async fn remove_repo(app: AppHandle, repo_id: String) -> Result<(), CanopyError> {
     let updated = {
         let state = app.state::<AppState>();
-        let mut s = state.settings.write().unwrap();
+        let mut s = state.settings.write();
         s.repos.retain(|r| r.id != repo_id);
         s.clone()
     };
@@ -252,7 +252,6 @@ pub fn get_logs(table: State<'_, ProcTable>, svc_key: String) -> Vec<LogLine> {
     table
         .logs
         .lock()
-        .unwrap()
         .get(&svc_key)
         .map(|b| b.iter().cloned().collect())
         .unwrap_or_default()
@@ -314,7 +313,7 @@ pub fn resolve_agent_command(state: State<'_, AppState>, wt_key: String) -> Stri
     const DEFAULT_AGENT: &str = "claude";
     let repo_id = state.wt_context(&wt_key).map(|c| c.repo_id);
     let cmd = repo_id.and_then(|id| {
-        let settings = state.settings.read().unwrap();
+        let settings = state.settings.read();
         settings
             .repos
             .iter()
@@ -386,7 +385,7 @@ pub async fn run_migration(app: AppHandle, wt_key: String) -> Result<(), CanopyE
     // prefer the Settings "Migrate cmd"; fall back to .worktreemanager.json `migrate`
     let settings_cmd = {
         let state = app.state::<AppState>();
-        let s = state.settings.read().unwrap();
+        let s = state.settings.read();
         s.repos.iter().find(|r| r.id == repo_id).map(|r| r.migrate_db.clone()).unwrap_or_default()
     };
     let vars = crate::state::worktree_vars(&app, &repo_id, &wt_key, false);
@@ -450,7 +449,7 @@ pub async fn run_custom_command(app: AppHandle, wt_key: String, command: String)
 pub async fn open_in_editor(app: AppHandle, wt_key: String) -> Result<(), CanopyError> {
     let editor = {
         let state = app.state::<AppState>();
-        let s = state.settings.read().unwrap();
+        let s = state.settings.read();
         s.editor.command.clone()
     };
     let editor = if editor.trim().is_empty() { "code".to_string() } else { editor };
@@ -476,7 +475,7 @@ pub async fn open_file_in_editor(app: AppHandle, wt_key: String, path: String) -
     }
     let editor = {
         let state = app.state::<AppState>();
-        let s = state.settings.read().unwrap();
+        let s = state.settings.read();
         s.editor.command.clone()
     };
     let editor = if editor.trim().is_empty() { "code".to_string() } else { editor };
@@ -525,7 +524,7 @@ pub fn reveal_in_finder(wt_key: String) -> Result<(), CanopyError> {
 pub fn open_terminal(app: AppHandle, wt_key: String) -> Result<(), CanopyError> {
     let term = {
         let state = app.state::<AppState>();
-        let s = state.settings.read().unwrap();
+        let s = state.settings.read();
         s.terminal.clone()
     };
 
@@ -643,7 +642,7 @@ pub async fn create_worktree(
 ) -> Result<String, CanopyError> {
     let repo = {
         let state = app.state::<AppState>();
-        let s = state.settings.read().unwrap();
+        let s = state.settings.read();
         s.repos
             .iter()
             .find(|r| r.id == repo_id)
@@ -804,7 +803,7 @@ pub async fn remove_worktree(app: AppHandle, wt_key: String, delete_branch: bool
 
 fn is_running(app: &AppHandle, key: &str) -> bool {
     let table = app.state::<services::ProcTable>();
-    let procs = table.procs.lock().unwrap();
+    let procs = table.procs.lock();
     procs.contains_key(key)
 }
 
@@ -933,7 +932,7 @@ pub async fn set_service_port(app: AppHandle, svc_key: String, port: u32) -> Res
     // check cross-worktree conflicts: another service already on this port
     {
         let state = app.state::<AppState>();
-        let tree = state.tree.read().unwrap();
+        let tree = state.tree.read();
         for r in tree.iter() {
             for w in r.worktrees.iter() {
                 for s in w.services.iter() {
@@ -955,8 +954,8 @@ pub async fn set_service_port(app: AppHandle, svc_key: String, port: u32) -> Res
     // record the override + persist
     {
         let state = app.state::<AppState>();
-        state.runtime.write().unwrap().port_overrides.insert(svc_key.clone(), port);
-        let rt = state.runtime.read().unwrap().clone();
+        state.runtime.write().port_overrides.insert(svc_key.clone(), port);
+        let rt = state.runtime.read().clone();
         let _ = settings::save_runtime(&app, &rt);
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -55,8 +55,13 @@ pub async fn save_settings(app: AppHandle, new_settings: Settings) -> Result<(),
         *state.settings.write() = new_settings.clone();
     }
     settings::save_settings(&app, &new_settings).map_err(CanopyError::config)?;
+    // await only the structural rebuild (the tree must reflect the new
+    // services/repos when this resolves); git meta is 2 spawns per worktree
+    // and arrives via worktree:git events — holding the Save button on it
+    // meant seconds of spinner for a millisecond write
     refresh_tree(&app).await.map_err(CanopyError::internal)?;
-    refresh_all_git_meta(&app).await;
+    let app2 = app.clone();
+    tauri::async_runtime::spawn(async move { refresh_all_git_meta(&app2).await });
     Ok(())
 }
 
@@ -105,7 +110,9 @@ pub async fn add_repo(app: AppHandle, path: String) -> Result<RepoCfg, CanopyErr
     let (repo, updated) = updated;
     settings::save_settings(&app, &updated).map_err(CanopyError::config)?;
     refresh_tree(&app).await.map_err(CanopyError::internal)?;
-    refresh_all_git_meta(&app).await;
+    // meta arrives via worktree:git events — same reasoning as save_settings
+    let app2 = app.clone();
+    tauri::async_runtime::spawn(async move { refresh_all_git_meta(&app2).await });
     Ok(repo)
 }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -635,6 +635,12 @@ pub async fn show_main_window(app: AppHandle) -> Result<(), CanopyError> {
     if let Some(pop) = app.get_webview_window("popover") {
         let _ = pop.hide();
     }
+    // the background refresh pauses while every window is hidden — catch up now
+    let app2 = app.clone();
+    tauri::async_runtime::spawn(async move {
+        let _ = refresh_tree(&app2).await;
+        refresh_all_git_meta(&app2).await;
+    });
     Ok(())
 }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -181,6 +181,23 @@ pub async fn detect_repo(path: String) -> Result<RepoDetection, CanopyError> {
 
 #[tauri::command]
 pub async fn remove_repo(app: AppHandle, repo_id: String) -> Result<(), CanopyError> {
+    // Deregistering a repo must not leave its dev servers running untracked
+    // or its runtime state (port indices/overrides, statuses, logs) behind.
+    let wt_keys: Vec<String> = {
+        let state = app.state::<AppState>();
+        let tree = state.tree.read();
+        tree.iter()
+            .filter(|r| r.repo_id == repo_id)
+            .flat_map(|r| r.worktrees.iter().map(|w| w.wt_key.clone()))
+            .collect()
+    };
+    for wt in &wt_keys {
+        for key in services::worktree_svc_keys(&app, wt) {
+            let _ = services::stop_service(&app, &key).await;
+        }
+        terminal::close_worktree(&app, &app.state::<TermTable>(), wt);
+    }
+
     let updated = {
         let state = app.state::<AppState>();
         let mut s = state.settings.write();
@@ -188,6 +205,20 @@ pub async fn remove_repo(app: AppHandle, repo_id: String) -> Result<(), CanopyEr
         s.clone()
     };
     settings::save_settings(&app, &updated).map_err(CanopyError::config)?;
+
+    for wt in &wt_keys {
+        crate::state::release_worktree_runtime(&app, &repo_id, wt);
+    }
+    // drop the repo's whole port-index map (covers worktrees no longer listed)
+    {
+        let state = app.state::<AppState>();
+        let runtime = {
+            let mut rt = state.runtime.write();
+            rt.port_indices.remove(&repo_id);
+            rt.clone()
+        };
+        let _ = settings::save_runtime(&app, &runtime);
+    }
     refresh_tree(&app).await.map_err(CanopyError::internal)?;
     Ok(())
 }
@@ -802,6 +833,10 @@ pub async fn remove_worktree(app: AppHandle, wt_key: String, delete_branch: bool
     emit_op(&app, &wt_key, "remove", "progress", "removing worktree…");
     match git::remove_worktree(&repo_path, &wt_key, Some(&branch), delete_branch).await {
         Ok(()) => {
+            // reclaim the port index + overrides + statuses + log buffers —
+            // without this, months of worktree churn leak indices and derived
+            // ports creep permanently upward
+            crate::state::release_worktree_runtime(&app, &repo_id, &wt_key);
             emit_op(&app, &wt_key, "remove", "done", "worktree removed");
             refresh_tree(&app).await.map_err(CanopyError::internal)?;
             Ok(())

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -304,6 +304,9 @@ mod tests {
         assert_eq!(tail(b""), "");
     }
 
+    /// only the Unix-gated pipe test uses this (the test spawns POSIX shell
+    /// commands, so it doesn't run on the Windows job)
+    #[cfg(unix)]
     fn test_conn() -> PgConn {
         PgConn {
             host: "h".into(),

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -156,50 +156,92 @@ pub async fn clone_database(wt_path: &str, target: &str, mut progress: impl FnMu
     progress(format!("creating database {target}…"));
     run(wt_path, &c, &format!("createdb {conn_args} {}", q(target))).await?;
     progress(format!("copying {} → {target}…", c.db));
-    // Dump to a temp file, then restore from it — deliberately NOT a shell
-    // pipeline. A pipeline's exit status is the last command's, so a failed
-    // pg_dump feeding a tolerant pg_restore reports success; and `set -o
-    // pipefail` is not a portable fix — `set` is a POSIX *special builtin*, so
+    // Dump piped straight into restore — but the pipe lives in RUST, not the
+    // shell. A shell pipeline's exit status is the last command's (a failed
+    // pg_dump feeding a tolerant pg_restore reports success), and `set -o
+    // pipefail` is not a portable fix: `set` is a POSIX *special builtin*, so
     // on dash (Debian/Ubuntu /bin/sh) an unknown option exits the shell
-    // outright, even wrapped in braces or an `|| true` list. Two explicit
-    // stages work on every shell and say which half failed.
+    // outright — braces and `|| true` do not contain it. Connecting the two
+    // children ourselves checks BOTH statuses, names the failing stage, and
+    // stages nothing on disk (a temp file would double a big DB's footprint).
     let pre = pg_path_prefix_for(server_major(wt_path, &c).await);
-    let dump = temp_dump_path(target);
-    let dump_q = q(&crate::toolchain::bash_path(&dump));
-    let dump_res = run(
+    let result = run_piped(
         wt_path,
         &c,
-        &format!("{pre}pg_dump {conn_args} -Fc {src} -f {dump_q}", src = q(&c.db)),
+        &format!("{pre}pg_dump {conn_args} -Fc {src}", src = q(&c.db)),
+        &format!("{pre}pg_restore {conn_args} --no-owner --no-acl -d {dst}", dst = q(target)),
+        &c.db,
+        target,
     )
     .await;
-    let result = match dump_res {
-        Err(e) => Err(format!("dump of {} failed: {e}", c.db)),
-        Ok(_) => run(
-            wt_path,
-            &c,
-            &format!("{pre}pg_restore {conn_args} --no-owner --no-acl -d {dst} {dump_q}", dst = q(target)),
-        )
-        .await
-        .map(|_| ())
-        .map_err(|e| format!("restore into {target} failed: {e}")),
-    };
-    let _ = std::fs::remove_file(&dump);
-    result?;
+    if let Err(e) = result {
+        // don't strand the half-filled database we just created — a retry
+        // would otherwise die on "already exists"
+        progress(format!("copy failed — dropping partially created {target}…"));
+        let _ = run(wt_path, &c, &format!("dropdb {conn_args} --if-exists {}", q(target))).await;
+        return Err(e);
+    }
     progress("snapshot ready".into());
     Ok(())
 }
 
-/// Scratch path for the intermediate dump. Includes the pid so two Canopy
-/// runs (or two snapshots) can't collide on it.
-fn temp_dump_path(target: &str) -> String {
-    let safe: String = target
-        .chars()
-        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
-        .collect();
-    std::env::temp_dir()
-        .join(format!("canopy-snap-{}-{safe}.dump", std::process::id()))
-        .to_string_lossy()
-        .into_owned()
+/// Spawn `producer | consumer` with the pipe held by us: producer's stdout
+/// feeds consumer's stdin, both run through the login shell (PATH), both exit
+/// statuses are checked, and the whole pair shares one timeout.
+async fn run_piped(
+    wt_path: &str,
+    c: &PgConn,
+    producer: &str,
+    consumer: &str,
+    src_label: &str,
+    dst_label: &str,
+) -> Result<(), String> {
+    use std::process::Stdio;
+    let spawn = |line: &str, stdin: Stdio, stdout: Stdio| {
+        let (shell, args) = crate::toolchain::shell_argv(line);
+        let mut cmd = Command::new(shell);
+        cmd.args(&args)
+            .current_dir(wt_path)
+            .kill_on_drop(true)
+            .stdin(stdin)
+            .stdout(stdout)
+            .stderr(Stdio::piped());
+        if let Some(p) = &c.pass {
+            cmd.env("PGPASSWORD", p);
+        }
+        cmd.spawn()
+    };
+    let mut prod = spawn(producer, Stdio::null(), Stdio::piped()).map_err(|e| format!("pg_dump spawn failed: {e}"))?;
+    let prod_out = prod.stdout.take().ok_or("pg_dump stdout unavailable")?;
+    let pipe: Stdio = prod_out.try_into().map_err(|e| format!("pipe setup failed: {e}"))?;
+    let cons = spawn(consumer, pipe, Stdio::null()).map_err(|e| format!("pg_restore spawn failed: {e}"))?;
+
+    // wait on both concurrently: if the consumer dies early the producer gets
+    // EPIPE and exits, and vice versa the consumer sees EOF — no deadlock.
+    let waited = tokio::time::timeout(PG_TIMEOUT, async {
+        tokio::join!(prod.wait_with_output(), cons.wait_with_output())
+    })
+    .await;
+    let (p_out, c_out) = match waited {
+        Ok(pair) => pair,
+        Err(_) => return Err(format!("copy timed out after {}s", PG_TIMEOUT.as_secs())),
+    };
+    let p_out = p_out.map_err(|e| format!("pg_dump wait failed: {e}"))?;
+    let c_out = c_out.map_err(|e| format!("pg_restore wait failed: {e}"))?;
+    if !p_out.status.success() {
+        return Err(format!("dump of {src_label} failed: {}", tail(&p_out.stderr)));
+    }
+    if !c_out.status.success() {
+        return Err(format!("restore into {dst_label} failed: {}", tail(&c_out.stderr)));
+    }
+    Ok(())
+}
+
+/// Last few stderr lines, newest-last — the actionable part of a pg error.
+fn tail(stderr: &[u8]) -> String {
+    let s = String::from_utf8_lossy(stderr);
+    let lines: Vec<&str> = s.lines().rev().take(4).collect();
+    lines.into_iter().rev().collect::<Vec<_>>().join("\n")
 }
 
 /// Dump the worktree's current DB to a custom-format file at `file_path`.

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -50,15 +50,22 @@ impl PgConn {
     }
 }
 
+/// Cap for one Postgres CLI invocation — dumps/restores of big databases take
+/// a while, but a hung server must not wedge the command forever.
+const PG_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(900);
+
 /// Run a shell command line in the worktree dir with PGPASSWORD set.
 async fn run(wt_path: &str, c: &PgConn, cmdline: &str) -> Result<String, String> {
     let (shell, shargs) = crate::toolchain::shell_argv(cmdline);
     let mut cmd = Command::new(shell);
-    cmd.args(&shargs).current_dir(wt_path);
+    cmd.args(&shargs).current_dir(wt_path).kill_on_drop(true);
     if let Some(p) = &c.pass {
         cmd.env("PGPASSWORD", p);
     }
-    let out = cmd.output().await.map_err(|e| format!("failed to run: {e}"))?;
+    let out = match tokio::time::timeout(PG_TIMEOUT, cmd.output()).await {
+        Ok(res) => res.map_err(|e| format!("failed to run: {e}"))?,
+        Err(_) => return Err(format!("database command timed out after {}s", PG_TIMEOUT.as_secs())),
+    };
     if out.status.success() {
         Ok(String::from_utf8_lossy(&out.stdout).into_owned())
     } else {

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -150,9 +150,13 @@ pub async fn clone_database(wt_path: &str, target: &str, mut progress: impl FnMu
     run(wt_path, &c, &format!("createdb {conn_args} {}", q(target))).await?;
     progress(format!("copying {} → {target}…", c.db));
     // custom-format dump piped straight into restore, using binaries matching the
-    // server version so directives/archive format stay compatible on restore
+    // server version so directives/archive format stay compatible on restore.
+    // pipefail: a pipeline's status is otherwise the LAST command's — a failed
+    // pg_dump feeding a tolerant pg_restore would report a truncated copy as ok.
+    // (`|| true` keeps plain sh/dash working, where pipefail doesn't exist —
+    // those shells just keep the old last-command semantics.)
     let line = format!(
-        "{pre}pg_dump {conn_args} -Fc {src} | pg_restore {conn_args} --no-owner --no-acl -d {dst}",
+        "{{ set -o pipefail; }} 2>/dev/null || true; {pre}pg_dump {conn_args} -Fc {src} | pg_restore {conn_args} --no-owner --no-acl -d {dst}",
         pre = pg_path_prefix_for(server_major(wt_path, &c).await),
         src = q(&c.db),
         dst = q(target),
@@ -182,7 +186,9 @@ pub async fn restore_database(wt_path: &str, file_path: &str, mut progress: impl
     let pre = pg_path_prefix_for(server_major(wt_path, &c).await);
     progress(format!("restoring {} from file…", c.db));
     let line = if file_path.to_lowercase().ends_with(".sql") {
-        format!("{pre}psql {conn_args} -d {db} -v ON_ERROR_STOP=0 -f {f}", db = q(&c.db), f = q(file_path))
+        // ON_ERROR_STOP=1: without it psql runs the whole script regardless of
+        // failures and exits 0 — a half-restored database reported as success.
+        format!("{pre}psql {conn_args} -d {db} -v ON_ERROR_STOP=1 -f {f}", db = q(&c.db), f = q(file_path))
     } else {
         format!(
             "{pre}pg_restore {conn_args} --no-owner --no-acl --clean --if-exists -d {db} {f}",

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -289,10 +289,59 @@ pub async fn restore_database(wt_path: &str, file_path: &str, mut progress: impl
 
 #[cfg(test)]
 mod tests {
-    use super::q;
+    use super::*;
+
     #[test]
     fn quotes_args_safely() {
         assert_eq!(q("tooljet_main"), "'tooljet_main'");
         assert_eq!(q("a'b"), "'a'\\''b'");
+    }
+
+    #[test]
+    fn tail_keeps_last_lines_in_order() {
+        assert_eq!(tail(b"a\nb\nc\nd\ne\nf"), "c\nd\ne\nf");
+        assert_eq!(tail(b"only"), "only");
+        assert_eq!(tail(b""), "");
+    }
+
+    fn test_conn() -> PgConn {
+        PgConn {
+            host: "h".into(),
+            port: "1".into(),
+            user: "u".into(),
+            pass: None,
+            db: "d".into(),
+        }
+    }
+
+    /// THE invariant clone_database depends on: both children's exit statuses
+    /// are checked, and the error names the failing stage. A shell pipeline
+    /// reports only the last command's status — this is the regression that
+    /// motivated the Rust-held pipe, so it gets a live process test.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn run_piped_checks_both_exit_statuses() {
+        let c = test_conn();
+        let wt = std::env::temp_dir();
+        let wt = wt.to_str().unwrap();
+
+        // happy path: bytes flow producer → consumer, both exit 0
+        run_piped(wt, &c, "printf %s data", "cat >/dev/null", "src", "dst")
+            .await
+            .expect("clean pipe");
+
+        // producer fails while the consumer exits 0 — exactly the case a
+        // shell pipeline would report as success
+        let e = run_piped(wt, &c, "printf x; echo boom >&2; exit 7", "cat >/dev/null", "srcdb", "dst")
+            .await
+            .unwrap_err();
+        assert!(e.contains("dump of srcdb failed"), "names the dump stage: {e}");
+        assert!(e.contains("boom"), "carries producer stderr: {e}");
+
+        // consumer fails after a clean producer
+        let e = run_piped(wt, &c, "printf %s data", "cat >/dev/null; exit 3", "src", "dstdb")
+            .await
+            .unwrap_err();
+        assert!(e.contains("restore into dstdb failed"), "names the restore stage: {e}");
     }
 }

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -55,10 +55,16 @@ impl PgConn {
 const PG_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(900);
 
 /// Run a shell command line in the worktree dir with PGPASSWORD set.
+/// Uses the fast non-login shell: these lines are composed by Canopy (pure
+/// POSIX, need only PATH), and a login shell's profile init cost 300ms–1s
+/// PER invocation — a snapshot chains five of them before any data moves.
 async fn run(wt_path: &str, c: &PgConn, cmdline: &str) -> Result<String, String> {
-    let (shell, shargs) = crate::toolchain::shell_argv(cmdline);
+    let (shell, shargs) = crate::toolchain::fast_shell_argv(cmdline);
     let mut cmd = Command::new(shell);
-    cmd.args(&shargs).current_dir(wt_path).kill_on_drop(true);
+    cmd.args(&shargs)
+        .current_dir(wt_path)
+        .env("PATH", crate::toolchain::effective_path())
+        .kill_on_drop(true);
     if let Some(p) = &c.pass {
         cmd.env("PGPASSWORD", p);
     }
@@ -198,10 +204,12 @@ async fn run_piped(
 ) -> Result<(), String> {
     use std::process::Stdio;
     let spawn = |line: &str, stdin: Stdio, stdout: Stdio| {
-        let (shell, args) = crate::toolchain::shell_argv(line);
+        // fast non-login shell — see `run` for why this is safe here
+        let (shell, args) = crate::toolchain::fast_shell_argv(line);
         let mut cmd = Command::new(shell);
         cmd.args(&args)
             .current_dir(wt_path)
+            .env("PATH", crate::toolchain::effective_path())
             .kill_on_drop(true)
             .stdin(stdin)
             .stdout(stdout)

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -156,21 +156,50 @@ pub async fn clone_database(wt_path: &str, target: &str, mut progress: impl FnMu
     progress(format!("creating database {target}…"));
     run(wt_path, &c, &format!("createdb {conn_args} {}", q(target))).await?;
     progress(format!("copying {} → {target}…", c.db));
-    // custom-format dump piped straight into restore, using binaries matching the
-    // server version so directives/archive format stay compatible on restore.
-    // pipefail: a pipeline's status is otherwise the LAST command's — a failed
-    // pg_dump feeding a tolerant pg_restore would report a truncated copy as ok.
-    // (`|| true` keeps plain sh/dash working, where pipefail doesn't exist —
-    // those shells just keep the old last-command semantics.)
-    let line = format!(
-        "{{ set -o pipefail; }} 2>/dev/null || true; {pre}pg_dump {conn_args} -Fc {src} | pg_restore {conn_args} --no-owner --no-acl -d {dst}",
-        pre = pg_path_prefix_for(server_major(wt_path, &c).await),
-        src = q(&c.db),
-        dst = q(target),
-    );
-    run(wt_path, &c, &line).await?;
+    // Dump to a temp file, then restore from it — deliberately NOT a shell
+    // pipeline. A pipeline's exit status is the last command's, so a failed
+    // pg_dump feeding a tolerant pg_restore reports success; and `set -o
+    // pipefail` is not a portable fix — `set` is a POSIX *special builtin*, so
+    // on dash (Debian/Ubuntu /bin/sh) an unknown option exits the shell
+    // outright, even wrapped in braces or an `|| true` list. Two explicit
+    // stages work on every shell and say which half failed.
+    let pre = pg_path_prefix_for(server_major(wt_path, &c).await);
+    let dump = temp_dump_path(target);
+    let dump_q = q(&crate::toolchain::bash_path(&dump));
+    let dump_res = run(
+        wt_path,
+        &c,
+        &format!("{pre}pg_dump {conn_args} -Fc {src} -f {dump_q}", src = q(&c.db)),
+    )
+    .await;
+    let result = match dump_res {
+        Err(e) => Err(format!("dump of {} failed: {e}", c.db)),
+        Ok(_) => run(
+            wt_path,
+            &c,
+            &format!("{pre}pg_restore {conn_args} --no-owner --no-acl -d {dst} {dump_q}", dst = q(target)),
+        )
+        .await
+        .map(|_| ())
+        .map_err(|e| format!("restore into {target} failed: {e}")),
+    };
+    let _ = std::fs::remove_file(&dump);
+    result?;
     progress("snapshot ready".into());
     Ok(())
+}
+
+/// Scratch path for the intermediate dump. Includes the pid so two Canopy
+/// runs (or two snapshots) can't collide on it.
+fn temp_dump_path(target: &str) -> String {
+    let safe: String = target
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect();
+    std::env::temp_dir()
+        .join(format!("canopy-snap-{}-{safe}.dump", std::process::id()))
+        .to_string_lossy()
+        .into_owned()
 }
 
 /// Dump the worktree's current DB to a custom-format file at `file_path`.

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -1,0 +1,117 @@
+// Structured errors crossing the IPC boundary.
+//
+// Every #[tauri::command] returns `Result<T, CanopyError>`. The error
+// serializes as `{ "code": "...", "message": "..." }` so the frontend can
+// branch on `code` (retry vs. destructive-confirm vs. plain toast) instead of
+// pattern-matching display strings. Internal modules (git.rs, db.rs, setup.rs)
+// keep returning `String` — they wrap external tools whose stderr *is* the
+// message — and the command layer stamps the domain code at the boundary.
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrorCode {
+    /// git CLI failure (pull/fetch/worktree/submodule…)
+    Git,
+    /// Postgres tooling failure (psql/pg_dump/pg_restore/createdb)
+    Db,
+    /// provisioning / setup / migrate / custom command failure
+    Setup,
+    /// dev-service process control (spawn/stop/restart)
+    Process,
+    /// embedded PTY session failure
+    Terminal,
+    /// settings / repo-config file problems
+    Config,
+    /// the referenced repo / worktree / service isn't registered
+    NotFound,
+    /// the request itself is invalid (bad port, empty name…)
+    InvalidInput,
+    /// the operation conflicts with current state (already exists / in progress)
+    Conflict,
+    /// anything unclassified — the safe default for `?` on a bare String
+    Internal,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CanopyError {
+    pub code: ErrorCode,
+    pub message: String,
+}
+
+impl CanopyError {
+    pub fn new(code: ErrorCode, message: impl Into<String>) -> Self {
+        Self { code, message: message.into() }
+    }
+    pub fn git(m: impl Into<String>) -> Self {
+        Self::new(ErrorCode::Git, m)
+    }
+    pub fn db(m: impl Into<String>) -> Self {
+        Self::new(ErrorCode::Db, m)
+    }
+    pub fn setup(m: impl Into<String>) -> Self {
+        Self::new(ErrorCode::Setup, m)
+    }
+    pub fn process(m: impl Into<String>) -> Self {
+        Self::new(ErrorCode::Process, m)
+    }
+    pub fn terminal(m: impl Into<String>) -> Self {
+        Self::new(ErrorCode::Terminal, m)
+    }
+    pub fn config(m: impl Into<String>) -> Self {
+        Self::new(ErrorCode::Config, m)
+    }
+    pub fn not_found(m: impl Into<String>) -> Self {
+        Self::new(ErrorCode::NotFound, m)
+    }
+    pub fn invalid_input(m: impl Into<String>) -> Self {
+        Self::new(ErrorCode::InvalidInput, m)
+    }
+    pub fn conflict(m: impl Into<String>) -> Self {
+        Self::new(ErrorCode::Conflict, m)
+    }
+    pub fn internal(m: impl Into<String>) -> Self {
+        Self::new(ErrorCode::Internal, m)
+    }
+}
+
+impl std::fmt::Display for CanopyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for CanopyError {}
+
+/// Bare-`?` compatibility while internal modules still return `String`.
+impl From<String> for CanopyError {
+    fn from(m: String) -> Self {
+        Self::internal(m)
+    }
+}
+
+impl From<&str> for CanopyError {
+    fn from(m: &str) -> Self {
+        Self::internal(m)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serializes_as_code_and_message() {
+        let e = CanopyError::git("pull failed");
+        let v = serde_json::to_value(&e).unwrap();
+        assert_eq!(v["code"], "git");
+        assert_eq!(v["message"], "pull failed");
+    }
+
+    #[test]
+    fn bare_string_maps_to_internal() {
+        let e: CanopyError = "boom".into();
+        assert_eq!(e.code, ErrorCode::Internal);
+        assert_eq!(e.to_string(), "boom");
+    }
+}

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -568,18 +568,23 @@ pub async fn create_worktree(
 #[serde(rename_all = "camelCase")]
 pub struct DirtyReport {
     pub dirty: bool,
+    /// first entries only (see `total` for the full count)
     pub details: Vec<String>,
+    /// total changed paths — `details` is capped for display
+    pub total: usize,
 }
 
-/// Dirty check covering the worktree AND its submodules.
-pub async fn dirty_report(wt_path: &str) -> DirtyReport {
-    let mut details = Vec::new();
-    if let Ok(out) = run_git(wt_path, &["status", "--porcelain", "--ignore-submodules=none"]).await {
-        for l in out.lines().take(10) {
-            details.push(l.to_string());
-        }
-    }
-    DirtyReport { dirty: !details.is_empty(), details }
+/// Dirty check covering the worktree AND its submodules. A failed `git status`
+/// (index.lock held, corrupt repo, permissions) is an ERROR, never "clean" —
+/// this report is what arms a `worktree remove --force`.
+pub async fn dirty_report(wt_path: &str) -> Result<DirtyReport, String> {
+    let out = run_git(wt_path, &["status", "--porcelain", "--ignore-submodules=none"]).await?;
+    let lines: Vec<&str> = out.lines().filter(|l| !l.trim().is_empty()).collect();
+    Ok(DirtyReport {
+        dirty: !lines.is_empty(),
+        details: lines.iter().take(10).map(|l| l.to_string()).collect(),
+        total: lines.len(),
+    })
 }
 
 /// Remove a worktree. `--force` is required for any worktree containing

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -677,4 +677,109 @@ mod tests {
         assert_eq!(msg, "fix: tab\tin message", "only the first tab splits");
         assert_eq!(parse_last_commit(""), (0, String::new()));
     }
+
+    // ── integration: the real git CLI against throwaway repos ──
+    //
+    // These exercise the actual plumbing (worktree add/list/remove, status,
+    // meta) on whatever git the machine has — the same binary users run.
+    // Paths are compared by count/branch, never by string equality, because
+    // git canonicalizes (macOS /var → /private/var) and Windows mixes
+    // separators.
+
+    fn unique_dir(tag: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!("canopy-git-{tag}-{}", std::process::id()))
+    }
+
+    async fn init_repo(dir: &std::path::Path) {
+        std::fs::create_dir_all(dir).unwrap();
+        let d = dir.to_str().unwrap();
+        run_git(d, &["init"]).await.unwrap();
+        // CI runners have no global identity; commits fail without one
+        run_git(d, &["config", "user.email", "canopy-test@localhost"]).await.unwrap();
+        run_git(d, &["config", "user.name", "canopy-test"]).await.unwrap();
+        run_git(d, &["config", "commit.gpgsign", "false"]).await.unwrap();
+        std::fs::write(dir.join("a.txt"), "one\n").unwrap();
+        run_git(d, &["add", "."]).await.unwrap();
+        run_git(d, &["commit", "-m", "init"]).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn worktree_lifecycle_against_a_real_repo() {
+        let repo = unique_dir("life");
+        let _ = std::fs::remove_dir_all(&repo);
+        init_repo(&repo).await;
+        let rp = repo.to_str().unwrap();
+
+        let wts = list_worktrees(rp).await.unwrap();
+        assert_eq!(wts.len(), 1, "fresh repo = one main checkout");
+        assert!(wts[0].is_main);
+
+        // meta: clean → dirty → clean
+        let m = git_meta(rp).await.unwrap();
+        assert!(!m.dirty);
+        assert_eq!(m.last_commit_msg, "init");
+        assert!(m.last_commit_ts > 0);
+        std::fs::write(repo.join("a.txt"), "two\n").unwrap();
+        assert!(git_meta(rp).await.unwrap().dirty, "edit must show as dirty");
+        run_git(rp, &["checkout", "--", "."]).await.unwrap();
+
+        // linked worktree on a new branch
+        let wt = unique_dir("life-wt");
+        let _ = std::fs::remove_dir_all(&wt);
+        let wtp_owned = wt.to_str().unwrap().to_string();
+        let wtp = wtp_owned.as_str();
+        create_worktree(rp, wtp, "feat-x", Some("HEAD"), true, |_| {}).await.unwrap();
+        assert!(wt.join("a.txt").exists(), "checkout materialized");
+        assert_eq!(list_worktrees(rp).await.unwrap().len(), 2);
+        let head = run_git(wtp, &["rev-parse", "--abbrev-ref", "HEAD"]).await.unwrap();
+        assert_eq!(head.trim(), "feat-x");
+
+        // dirty report: clean, then counts an untracked file
+        let r = dirty_report(wtp).await.unwrap();
+        assert!(!r.dirty && r.total == 0, "{r:?}");
+        std::fs::write(wt.join("b.txt"), "x").unwrap();
+        let r = dirty_report(wtp).await.unwrap();
+        assert!(r.dirty && r.total == 1, "{r:?}");
+
+        // remove (--force covers the untracked file) + branch deletion
+        remove_worktree(rp, wtp, Some("feat-x"), true).await.unwrap();
+        assert!(!wt.exists(), "worktree directory removed");
+        assert_eq!(list_worktrees(rp).await.unwrap().len(), 1);
+        let branches = run_git(rp, &["branch", "--list", "feat-x"]).await.unwrap();
+        assert!(branches.trim().is_empty(), "branch deleted: {branches:?}");
+
+        let _ = std::fs::remove_dir_all(&repo);
+    }
+
+    #[tokio::test]
+    async fn switch_branch_in_place_and_back() {
+        let repo = unique_dir("switch");
+        let _ = std::fs::remove_dir_all(&repo);
+        init_repo(&repo).await;
+        let rp = repo.to_str().unwrap();
+        let original = list_worktrees(rp).await.unwrap()[0].branch.clone();
+
+        switch_branch(rp, "feat-y", true, None).await.unwrap();
+        let head = run_git(rp, &["rev-parse", "--abbrev-ref", "HEAD"]).await.unwrap();
+        assert_eq!(head.trim(), "feat-y");
+
+        // plain checkout back (create=false path)
+        switch_branch(rp, &original, false, None).await.unwrap();
+        let head = run_git(rp, &["rev-parse", "--abbrev-ref", "HEAD"]).await.unwrap();
+        assert_eq!(head.trim(), original);
+
+        let _ = std::fs::remove_dir_all(&repo);
+    }
+
+    /// Data-loss guard: this report arms `worktree remove --force`, and a
+    /// failed probe must be an ERROR the UI fails closed on — never `clean`.
+    #[tokio::test]
+    async fn dirty_report_fails_closed_on_a_broken_repo() {
+        let missing = unique_dir("never-created");
+        let _ = std::fs::remove_dir_all(&missing);
+        assert!(
+            dirty_report(missing.to_str().unwrap()).await.is_err(),
+            "missing path must error, not report clean"
+        );
+    }
 }

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -26,14 +26,18 @@ pub struct WorktreeInfo {
 /// `git worktree list --porcelain` — first entry is the main working tree.
 pub async fn list_worktrees(repo_path: &str) -> Result<Vec<WorktreeInfo>, String> {
     let out = run_git(repo_path, &["worktree", "list", "--porcelain"]).await?;
+    Ok(parse_worktree_list(&out))
+}
 
+/// Pure parser for `git worktree list --porcelain` output.
+fn parse_worktree_list(porcelain: &str) -> Vec<WorktreeInfo> {
     struct Entry {
         path: String,
         branch: Option<String>,
         bare: bool,
     }
     let mut entries: Vec<Entry> = Vec::new();
-    for line in out.lines() {
+    for line in porcelain.lines() {
         if let Some(p) = line.strip_prefix("worktree ") {
             entries.push(Entry { path: p.to_string(), branch: None, bare: false });
         } else if let Some(e) = entries.last_mut() {
@@ -47,7 +51,7 @@ pub async fn list_worktrees(repo_path: &str) -> Result<Vec<WorktreeInfo>, String
         }
     }
 
-    Ok(entries
+    entries
         .into_iter()
         .filter(|e| !e.bare)
         .enumerate()
@@ -56,7 +60,7 @@ pub async fn list_worktrees(repo_path: &str) -> Result<Vec<WorktreeInfo>, String
             branch: e.branch.unwrap_or_else(|| "(detached)".into()),
             is_main: i == 0,
         })
-        .collect())
+        .collect()
 }
 
 #[derive(Debug, Clone, Serialize, Default, PartialEq)]
@@ -71,6 +75,17 @@ pub struct GitMeta {
 
 pub async fn git_meta(wt_path: &str) -> Result<GitMeta, String> {
     let status = run_git(wt_path, &["status", "--porcelain=v2", "--branch"]).await?;
+    let mut meta = parse_status_meta(&status);
+    if let Ok(log) = run_git(wt_path, &["log", "-1", "--format=%ct%x09%s"]).await {
+        let (ts, msg) = parse_last_commit(&log);
+        meta.last_commit_ts = ts;
+        meta.last_commit_msg = msg;
+    }
+    Ok(meta)
+}
+
+/// Pure parser for `git status --porcelain=v2 --branch`: ahead/behind + dirty.
+fn parse_status_meta(status: &str) -> GitMeta {
     let mut meta = GitMeta::default();
     for line in status.lines() {
         if let Some(ab) = line.strip_prefix("# branch.ab ") {
@@ -82,16 +97,19 @@ pub async fn git_meta(wt_path: &str) -> Result<GitMeta, String> {
                     meta.behind = b.parse().unwrap_or(0);
                 }
             }
-        } else if !line.starts_with('#') {
+        } else if !line.starts_with('#') && !line.trim().is_empty() {
             meta.dirty = true;
         }
     }
-    if let Ok(log) = run_git(wt_path, &["log", "-1", "--format=%ct%x09%s"]).await {
-        let mut it = log.trim_end().splitn(2, '\t');
-        meta.last_commit_ts = it.next().and_then(|t| t.parse().ok()).unwrap_or(0);
-        meta.last_commit_msg = it.next().unwrap_or("").to_string();
-    }
-    Ok(meta)
+    meta
+}
+
+/// Pure parser for `git log -1 --format=%ct%x09%s`.
+fn parse_last_commit(log: &str) -> (i64, String) {
+    let mut it = log.trim_end().splitn(2, '\t');
+    let ts = it.next().and_then(|t| t.trim().parse().ok()).unwrap_or(0);
+    let msg = it.next().unwrap_or("").to_string();
+    (ts, msg)
 }
 
 /// (name, path) pairs from a worktree's .gitmodules (empty if none).
@@ -581,4 +599,51 @@ pub async fn remove_worktree(
     }
     let _ = run_git(repo_path, &["worktree", "prune"]).await;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_worktree_porcelain() {
+        let out = "worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\n\
+                   worktree /repo-worktrees/feat\nHEAD def456\nbranch refs/heads/feat\n\n\
+                   worktree /repo-worktrees/det\nHEAD 987fed\ndetached\n";
+        let wts = parse_worktree_list(out);
+        assert_eq!(wts.len(), 3);
+        assert!(wts[0].is_main && wts[0].branch == "main" && wts[0].path == "/repo");
+        assert!(!wts[1].is_main && wts[1].branch == "feat");
+        assert_eq!(wts[2].branch, "(detached)");
+    }
+
+    #[test]
+    fn skips_bare_entries() {
+        let out = "worktree /repo.git\nbare\n\nworktree /wt\nHEAD abc\nbranch refs/heads/x\n";
+        let wts = parse_worktree_list(out);
+        assert_eq!(wts.len(), 1);
+        assert_eq!(wts[0].path, "/wt");
+        // NOTE: is_main is positional over the filtered list — a bare main repo
+        // promotes the first linked worktree, which matches git's ordering.
+        assert!(wts[0].is_main);
+    }
+
+    #[test]
+    fn parses_status_ahead_behind_dirty() {
+        let s = "# branch.oid abc\n# branch.head main\n# branch.upstream origin/main\n# branch.ab +3 -1\n\
+                 1 .M N... 100644 100644 100644 abc def src/x.rs\n";
+        let m = parse_status_meta(s);
+        assert_eq!((m.ahead, m.behind, m.dirty), (3, 1, true));
+        let clean = "# branch.oid abc\n# branch.head main\n# branch.ab +0 -0\n";
+        let m = parse_status_meta(clean);
+        assert_eq!((m.ahead, m.behind, m.dirty), (0, 0, false));
+    }
+
+    #[test]
+    fn parses_last_commit_line() {
+        let (ts, msg) = parse_last_commit("1722500000\tfix: tab\tin message\n");
+        assert_eq!(ts, 1722500000);
+        assert_eq!(msg, "fix: tab\tin message", "only the first tab splits");
+        assert_eq!(parse_last_commit(""), (0, String::new()));
+    }
 }

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -1,14 +1,40 @@
 use serde::Serialize;
+use std::time::Duration;
 use tokio::process::Command;
 
+/// Local git operations (status, rev-parse, checkout…). Generous — a checkout
+/// on a huge repo takes time — but bounded: an unresponsive git (dead network
+/// mount, wedged index.lock) must not hang a command forever.
+const GIT_TIMEOUT: Duration = Duration::from_secs(300);
+/// Network operations (fetch, pull, submodule clone/update) get longer.
+const GIT_NETWORK_TIMEOUT: Duration = Duration::from_secs(900);
+
 pub async fn run_git(cwd: &str, args: &[&str]) -> Result<String, String> {
-    let out = Command::new("git")
+    run_git_with_timeout(cwd, args, GIT_TIMEOUT).await
+}
+
+/// For fetch/pull/submodule-transfer calls — same semantics, longer leash.
+async fn run_git_net(cwd: &str, args: &[&str]) -> Result<String, String> {
+    run_git_with_timeout(cwd, args, GIT_NETWORK_TIMEOUT).await
+}
+
+async fn run_git_with_timeout(cwd: &str, args: &[&str], dur: Duration) -> Result<String, String> {
+    let fut = Command::new("git")
         .arg("-C")
         .arg(cwd)
         .args(args)
-        .output()
-        .await
-        .map_err(|e| format!("failed to run git: {e}"))?;
+        .kill_on_drop(true) // a timed-out git must not linger
+        .output();
+    let out = match tokio::time::timeout(dur, fut).await {
+        Ok(res) => res.map_err(|e| format!("failed to run git: {e}"))?,
+        Err(_) => {
+            return Err(format!(
+                "git {} timed out after {}s",
+                args.first().copied().unwrap_or(""),
+                dur.as_secs()
+            ))
+        }
+    };
     if out.status.success() {
         Ok(String::from_utf8_lossy(&out.stdout).into_owned())
     } else {
@@ -144,7 +170,7 @@ pub async fn pull(wt_path: &str) -> Result<String, String> {
     // Superproject fast-forward. A worktree branch with no upstream (or a
     // non-ff remote) shouldn't block pulling submodules that DO track a branch,
     // so this failure is soft — recorded, then we still update submodules.
-    let super_res = run_git(wt_path, &["pull", "--ff-only"]).await;
+    let super_res = run_git_net(wt_path, &["pull", "--ff-only"]).await;
 
     let mods = submodule_entries(wt_path).await;
     if mods.is_empty() {
@@ -171,16 +197,16 @@ pub async fn pull(wt_path: &str) -> Result<String, String> {
         // -c protocol.file.allow=always: submodules with local/relative URLs
         // would otherwise be blocked by git's file-protocol default
         let result = if on_branch {
-            run_git(&sm_path, &["pull", "--ff-only"]).await.map(|_| pulled += 1)
+            run_git_net(&sm_path, &["pull", "--ff-only"]).await.map(|_| pulled += 1)
         } else if tracks_branch {
-            run_git(
+            run_git_net(
                 wt_path,
                 &["-c", "protocol.file.allow=always", "submodule", "update", "--init", "--remote", "--recursive", "--", sm],
             )
             .await
             .map(|_| pulled += 1)
         } else {
-            run_git(
+            run_git_net(
                 wt_path,
                 &["-c", "protocol.file.allow=always", "submodule", "update", "--init", "--recursive", "--", sm],
             )
@@ -325,17 +351,17 @@ pub async fn pull_submodule(wt_path: &str, sm: &str) -> Result<String, String> {
     .unwrap_or(false);
 
     if on_branch {
-        run_git(&sm_path, &["pull", "--ff-only"]).await?;
+        run_git_net(&sm_path, &["pull", "--ff-only"]).await?;
         Ok("pulled".into())
     } else if tracks_branch {
-        run_git(
+        run_git_net(
             wt_path,
             &["-c", "protocol.file.allow=always", "submodule", "update", "--init", "--remote", "--recursive", "--", sm],
         )
         .await?;
         Ok("pulled".into())
     } else {
-        run_git(
+        run_git_net(
             wt_path,
             &["-c", "protocol.file.allow=always", "submodule", "update", "--init", "--recursive", "--", sm],
         )
@@ -406,7 +432,7 @@ pub async fn switch_branch(wt_path: &str, branch: &str, create: bool, base: Opti
     // sync submodules to the new branch's pins (no-op when there are none).
     // The branch HAS switched at this point, so a sync failure says so.
     if !submodule_entries(wt_path).await.is_empty() {
-        run_git(
+        run_git_net(
             wt_path,
             &["-c", "protocol.file.allow=always", "submodule", "update", "--init", "--recursive"],
         )
@@ -422,7 +448,7 @@ pub async fn fetch_submodules(wt_path: &str) -> usize {
     let mut n = 0usize;
     for (_name, sm) in submodule_entries(wt_path).await {
         let sm_path = format!("{wt_path}/{sm}");
-        if run_git(&sm_path, &["fetch", "--prune"]).await.is_ok() {
+        if run_git_net(&sm_path, &["fetch", "--prune"]).await.is_ok() {
             n += 1;
         }
     }
@@ -440,7 +466,7 @@ pub struct Branches {
 /// `git fetch --all --prune` to refresh remote-tracking branches, recursing
 /// into submodules so their objects are fetched too.
 pub async fn fetch_all(repo_path: &str) -> Result<(), String> {
-    run_git(repo_path, &["fetch", "--all", "--prune", "--recurse-submodules"])
+    run_git_net(repo_path, &["fetch", "--all", "--prune", "--recurse-submodules"])
         .await
         .map(|_| ())
 }
@@ -544,7 +570,7 @@ pub async fn create_worktree(
         // -c protocol.file.allow=always: submodules with relative/local URLs
         // would otherwise be blocked by git's file-protocol default
         let result = if with_ref {
-            run_git(
+            run_git_net(
                 wt_path,
                 &["-c", "protocol.file.allow=always", "submodule", "update", "--init", "--recursive", "--reference", &reference, "--", sm],
             )
@@ -554,7 +580,7 @@ pub async fn create_worktree(
         };
         if result.is_err() {
             progress(format!("submodule {sm}: falling back to full clone"));
-            run_git(
+            run_git_net(
                 wt_path,
                 &["-c", "protocol.file.allow=always", "submodule", "update", "--init", "--recursive", "--", sm],
             )

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -19,6 +19,14 @@ use state::AppState;
 use tauri::Manager;
 use terminal::TermTable;
 
+/// Is any Canopy window (main / popover / detached terminal) on screen?
+/// Gates the background refresh + stats loops — work nobody can see.
+pub(crate) fn any_window_visible(app: &tauri::AppHandle) -> bool {
+    app.webview_windows()
+        .values()
+        .any(|w| w.is_visible().unwrap_or(false))
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // GUI apps on macOS get a bare PATH; fix it so git/node/nvm resolve.
@@ -89,12 +97,18 @@ pub fn run() {
                 });
             }
 
-            // initial scan + 60s background git refresh
+            // initial scan + 60s background git refresh. The app lives in the
+            // tray — while no window is visible nobody can see git meta, so
+            // the periodic tick is skipped (show_main_window / the popover
+            // toggle kick an immediate refresh when a window comes back).
             tauri::async_runtime::spawn(async move {
                 let _ = state::refresh_tree(&handle).await;
                 state::refresh_all_git_meta(&handle).await;
                 loop {
                     tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+                    if !any_window_visible(&handle) {
+                        continue;
+                    }
                     let _ = state::refresh_tree(&handle).await;
                     state::refresh_all_git_meta(&handle).await;
                 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -25,6 +25,19 @@ pub fn run() {
     let _ = fix_path_env::fix();
 
     let builder = tauri::Builder::default()
+        // MUST be first: a second instance exits immediately after notifying
+        // the first. Without this, instance B's startup sweep reads instance
+        // A's persisted *live* pgids and SIGTERMs A's running services, and
+        // both instances race on settings.json/state.json writes.
+        .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+            #[cfg(target_os = "macos")]
+            let _ = app.set_activation_policy(tauri::ActivationPolicy::Regular);
+            if let Some(win) = app.get_webview_window("main") {
+                let _ = win.show();
+                let _ = win.unminimize();
+                let _ = win.set_focus();
+            }
+        }))
         .plugin(
             // rolling log file in the platform log dir (~/Library/Logs/… on
             // macOS) + stderr echo for dev. INFO default; RUST_LOG overrides.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,6 +24,21 @@ pub fn run() {
     let _ = fix_path_env::fix();
 
     let builder = tauri::Builder::default()
+        .plugin(
+            // rolling log file in the platform log dir (~/Library/Logs/… on
+            // macOS) + stderr echo for dev. INFO default; RUST_LOG overrides.
+            tauri_plugin_log::Builder::new()
+                .targets([
+                    tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::LogDir {
+                        file_name: Some("canopy".into()),
+                    }),
+                    tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Stderr),
+                ])
+                .max_file_size(2_000_000)
+                .rotation_strategy(tauri_plugin_log::RotationStrategy::KeepOne)
+                .level(log::LevelFilter::Info)
+                .build(),
+        )
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_positioner::init())
         .plugin(tauri_plugin_dialog::init());

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -107,19 +107,19 @@ pub fn run() {
                             tokio::time::sleep(std::time::Duration::from_secs(3)).await;
                             let (running, pgid) = {
                                 let table = handle.state::<ProcTable>();
-                                let procs = table.procs.lock().unwrap();
+                                let procs = table.procs.lock();
                                 (procs.contains_key(&key), procs.get(&key).map(|p| crate::proc::group_key(&p.group) as i32))
                             };
                             let log_len = {
                                 let table = handle.state::<ProcTable>();
-                                let logs = table.logs.lock().unwrap();
+                                let logs = table.logs.lock();
                                 logs.get(&key).map(|b| b.len()).unwrap_or(0)
                             };
                             eprintln!("[selftest] running={running} pgid={pgid:?} log_lines={log_len}");
                             let _ = services::stop_service(&handle, &key).await;
                             tokio::time::sleep(std::time::Duration::from_secs(4)).await;
                             let table = handle.state::<ProcTable>();
-                            let gone = table.procs.lock().unwrap().is_empty();
+                            let gone = table.procs.lock().is_empty();
                             let pg_dead = pgid.map(|p| unsafe { libc::killpg(p, 0) != 0 }).unwrap_or(true);
                             eprintln!("[selftest] after stop: table_empty={gone} pgid_dead={pg_dead}");
                             eprintln!("[selftest] {}", if running && gone && pg_dead && log_len > 0 { "PASS" } else { "FAIL" });
@@ -156,7 +156,7 @@ pub fn run() {
                             // confirm the new service is in the tree
                             let in_tree = {
                                 let st = handle.state::<state::AppState>();
-                                let tree = st.tree.read().unwrap();
+                                let tree = st.tree.read();
                                 tree.iter().flat_map(|r| r.worktrees.iter()).flat_map(|w| w.services.iter()).any(|s| s.svc_key == svc_key)
                             };
                             eprintln!("[ct] service {svc_key} in tree: {in_tree}");
@@ -166,7 +166,7 @@ pub fn run() {
                                     tokio::time::sleep(std::time::Duration::from_secs(3)).await;
                                     let running = {
                                         let t = handle.state::<services::ProcTable>();
-                                        let p = t.procs.lock().unwrap();
+                                        let p = t.procs.lock();
                                         p.contains_key(&svc_key)
                                     };
                                     eprintln!("[ct] running={running}");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,11 +20,28 @@ use tauri::Manager;
 use terminal::TermTable;
 
 /// Is any Canopy window (main / popover / detached terminal) on screen?
-/// Gates the background refresh + stats loops — work nobody can see.
+/// Queries the OS — used only by the 1s poll below; hot paths read the cache.
 pub(crate) fn any_window_visible(app: &tauri::AppHandle) -> bool {
     app.webview_windows()
         .values()
         .any(|w| w.is_visible().unwrap_or(false))
+}
+
+/// Cached answer to "is anything on screen", refreshed every second and set
+/// eagerly by the show paths. Emitting into hidden webviews keeps their
+/// WebKit/WebView2 processes hot for work nobody can see — the log pump and
+/// PTY reader consult this per emit, so it must be an atomic read, not an
+/// OS query marshalled to the main thread per 32KB chunk.
+static WINDOWS_VISIBLE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(true);
+
+pub(crate) fn windows_visible() -> bool {
+    WINDOWS_VISIBLE.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Called by every path that shows a window, so the ≤1s cache staleness can
+/// never swallow the first events after a show.
+pub(crate) fn note_window_shown() {
+    WINDOWS_VISIBLE.store(true, std::sync::atomic::Ordering::Relaxed);
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -84,6 +101,27 @@ pub fn run() {
 
             stats::spawn_stats_task(handle.clone());
 
+            // 1s visibility poll feeding the WINDOWS_VISIBLE cache
+            {
+                let handle = handle.clone();
+                tauri::async_runtime::spawn(async move {
+                    loop {
+                        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                        WINDOWS_VISIBLE.store(
+                            any_window_visible(&handle),
+                            std::sync::atomic::Ordering::Relaxed,
+                        );
+                    }
+                });
+            }
+
+            // warm the login-PATH capture off the critical path, so the first
+            // database action doesn't pay the profile-sourcing cost inline
+            #[cfg(unix)]
+            std::thread::spawn(|| {
+                let _ = toolchain::effective_path();
+            });
+
             // periodically sweep idle shell terminals (bounds long-run memory)
             {
                 let handle = handle.clone();
@@ -105,7 +143,7 @@ pub fn run() {
                 state::refresh_all(&handle).await;
                 loop {
                     tokio::time::sleep(std::time::Duration::from_secs(60)).await;
-                    if !any_window_visible(&handle) {
+                    if !windows_visible() {
                         continue;
                     }
                     state::refresh_all(&handle).await;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod commands;
 mod db;
+mod error;
 mod git;
 mod proc;
 mod services;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ mod settings;
 mod setup;
 mod state;
 mod stats;
+#[cfg(feature = "devtools")]
 mod suite;
 mod terminal;
 mod toolchain;
@@ -87,13 +88,14 @@ pub fn run() {
             });
 
             // headless end-to-end suite: WTM_SUITE=<repoId>
+            #[cfg(feature = "devtools")]
             if let Ok(repo_id) = std::env::var("WTM_SUITE") {
                 suite::run(app.handle().clone(), repo_id);
             }
 
             // headless smoke test of the process layer: WTM_SELFTEST=<svcKey>
             // (Unix-only: it pokes pgids with killpg to verify the group died)
-            #[cfg(unix)]
+            #[cfg(all(unix, feature = "devtools"))]
             if let Ok(key) = std::env::var("WTM_SELFTEST") {
                 let handle = app.handle().clone();
                 tauri::async_runtime::spawn(async move {
@@ -126,11 +128,16 @@ pub fn run() {
                 });
             }
             // headless create+start test: WTM_SELFTEST_CREATE="repoId|branch|serviceId"
+            #[cfg(feature = "devtools")]
             if let Ok(spec) = std::env::var("WTM_SELFTEST_CREATE") {
                 let handle = app.handle().clone();
                 tauri::async_runtime::spawn(async move {
                     tokio::time::sleep(std::time::Duration::from_secs(2)).await;
                     let parts: Vec<&str> = spec.split('|').collect();
+                    if parts.len() != 3 {
+                        eprintln!("[ct] FAIL: WTM_SELFTEST_CREATE wants repoId|branch|serviceId, got {spec:?}");
+                        return;
+                    }
                     let (repo_id, branch, service_id) = (parts[0], parts[1], parts[2]);
                     eprintln!("[ct] create_worktree repo={repo_id} branch={branch}");
                     match commands::create_worktree(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -102,15 +102,13 @@ pub fn run() {
             // the periodic tick is skipped (show_main_window / the popover
             // toggle kick an immediate refresh when a window comes back).
             tauri::async_runtime::spawn(async move {
-                let _ = state::refresh_tree(&handle).await;
-                state::refresh_all_git_meta(&handle).await;
+                state::refresh_all(&handle).await;
                 loop {
                     tokio::time::sleep(std::time::Duration::from_secs(60)).await;
                     if !any_window_visible(&handle) {
                         continue;
                     }
-                    let _ = state::refresh_tree(&handle).await;
-                    state::refresh_all_git_meta(&handle).await;
+                    state::refresh_all(&handle).await;
                 }
             });
 

--- a/src-tauri/src/proc.rs
+++ b/src-tauri/src/proc.rs
@@ -126,6 +126,9 @@ mod imp {
 
     pub struct ProcGroup {
         job: OwnedJobHandle,
+        /// kept for parity with the Unix pgid and for diagnostics; only
+        /// `group_key` reads it, which nothing on Windows calls (see below)
+        #[allow(dead_code)]
         pid: u32,
     }
 
@@ -214,6 +217,11 @@ mod imp {
         }
     }
 
+    /// Part of the cross-platform API surface, but unused on Windows: its only
+    /// callers are the Unix crash-orphan persist and the Unix-gated selftest.
+    /// Windows needs neither — KILL_ON_JOB_CLOSE reaps the tree when Canopy
+    /// dies, so there are no orphans to record or sweep.
+    #[allow(dead_code)]
     pub fn group_key(g: &ProcGroup) -> i64 {
         g.pid as i64
     }

--- a/src-tauri/src/services.rs
+++ b/src-tauri/src/services.rs
@@ -3,7 +3,7 @@ use crate::state::{AppState, SvcStatus};
 use serde::Serialize;
 use std::collections::{HashMap, VecDeque};
 use std::process::Stdio;
-use std::sync::Mutex;
+use parking_lot::Mutex;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tauri::{AppHandle, Emitter, Manager};
 use tokio::io::{AsyncBufReadExt, BufReader};
@@ -57,7 +57,7 @@ pub struct ProcTable {
 
 impl ProcTable {
     fn next_gen(&self) -> u64 {
-        let mut g = self.generation.lock().unwrap();
+        let mut g = self.generation.lock();
         *g += 1;
         *g
     }
@@ -76,10 +76,10 @@ struct StatusEvent<'a> {
 
 pub fn set_status(app: &AppHandle, key: &str, status: SvcStatus, started_at: Option<u64>, exit_code: Option<i32>) {
     let state = app.state::<AppState>();
-    state.statuses.write().unwrap().insert(key.to_string(), status);
+    state.statuses.write().insert(key.to_string(), status);
     // patch cached tree so late get_tree calls see fresh statuses
     {
-        let mut tree = state.tree.write().unwrap();
+        let mut tree = state.tree.write();
         for r in tree.iter_mut() {
             for w in r.worktrees.iter_mut() {
                 for s in w.services.iter_mut() {
@@ -96,7 +96,7 @@ pub fn set_status(app: &AppHandle, key: &str, status: SvcStatus, started_at: Opt
 pub fn push_log(app: &AppHandle, key: &str, line: LogLine) {
     let table = app.state::<ProcTable>();
     {
-        let mut logs = table.logs.lock().unwrap();
+        let mut logs = table.logs.lock();
         let buf = logs.entry(key.to_string()).or_default();
         buf.push_back(line.clone());
         while buf.len() > LOG_CAP {
@@ -155,7 +155,6 @@ fn persist_orphans(app: &AppHandle) {
     let orphans: Vec<OrphanProc> = table
         .procs
         .lock()
-        .unwrap()
         .iter()
         .map(|(k, p)| OrphanProc {
             svc_key: k.clone(),
@@ -165,7 +164,7 @@ fn persist_orphans(app: &AppHandle) {
         .collect();
     let state = app.state::<AppState>();
     let runtime = {
-        let mut rt = state.runtime.write().unwrap();
+        let mut rt = state.runtime.write();
         rt.orphans = orphans;
         rt.clone()
     };
@@ -178,12 +177,12 @@ fn persist_orphans(_app: &AppHandle) {}
 /// Resolve a service's config + worktree env (PORT etc.) from settings.
 fn resolve_service(app: &AppHandle, key: &str) -> Result<(ServiceCfg, String, HashMap<String, String>), String> {
     let state = app.state::<AppState>();
-    let tree = state.tree.read().unwrap();
+    let tree = state.tree.read();
     for r in tree.iter() {
         for w in r.worktrees.iter() {
             for s in w.services.iter() {
                 if s.svc_key == key {
-                    let settings = state.settings.read().unwrap();
+                    let settings = state.settings.read();
                     let repo = settings.repos.iter().find(|rc| rc.id == r.repo_id).ok_or("repo gone")?;
                     let cfg = repo
                         .services
@@ -218,7 +217,7 @@ fn resolve_service(app: &AppHandle, key: &str) -> Result<(ServiceCfg, String, Ha
 pub async fn start_service(app: &AppHandle, key: &str) -> Result<(), String> {
     {
         let table = app.state::<ProcTable>();
-        if table.procs.lock().unwrap().contains_key(key) {
+        if table.procs.lock().contains_key(key) {
             return Ok(()); // already running
         }
     }
@@ -277,7 +276,7 @@ pub async fn start_service(app: &AppHandle, key: &str) -> Result<(), String> {
     let generation = {
         let table = app.state::<ProcTable>();
         let generation = table.next_gen();
-        table.procs.lock().unwrap().insert(
+        table.procs.lock().insert(
             key.to_string(),
             ProcEntry { pid, group, started_at: Instant::now(), started_unix, generation },
         );
@@ -341,7 +340,7 @@ pub async fn start_service(app: &AppHandle, key: &str) -> Result<(), String> {
             let status = child.wait().await;
             let table = app.state::<ProcTable>();
             {
-                let mut procs = table.procs.lock().unwrap();
+                let mut procs = table.procs.lock();
                 match procs.get(&key) {
                     Some(p) if p.generation == generation => {
                         procs.remove(&key);
@@ -376,7 +375,7 @@ pub async fn start_service(app: &AppHandle, key: &str) -> Result<(), String> {
 fn flush_batch(app: &AppHandle, key: &str, batch: &mut Vec<LogLine>) {
     let table = app.state::<ProcTable>();
     {
-        let mut logs = table.logs.lock().unwrap();
+        let mut logs = table.logs.lock();
         let buf = logs.entry(key.to_string()).or_default();
         for l in batch.iter() {
             buf.push_back(l.clone());
@@ -415,7 +414,7 @@ pub async fn stop_service(app: &AppHandle, key: &str) -> Result<(), String> {
     // generation so a restart during the grace window isn't hard-killed by us.
     let generation = {
         let table = app.state::<ProcTable>();
-        let procs = table.procs.lock().unwrap();
+        let procs = table.procs.lock();
         match procs.get(key) {
             Some(p) => {
                 crate::proc::terminate_group(&p.group);
@@ -433,7 +432,7 @@ pub async fn stop_service(app: &AppHandle, key: &str) -> Result<(), String> {
     tauri::async_runtime::spawn(async move {
         tokio::time::sleep(STOP_GRACE).await;
         let table = app2.state::<ProcTable>();
-        let procs = table.procs.lock().unwrap();
+        let procs = table.procs.lock();
         if let Some(p) = procs.get(&key2) {
             if p.generation == generation {
                 crate::proc::kill_group(&p.group);
@@ -448,7 +447,7 @@ async fn wait_reaped(app: &AppHandle, key: &str, ticks: u32) -> bool {
     for _ in 0..ticks {
         tokio::time::sleep(Duration::from_millis(150)).await;
         let table = app.state::<ProcTable>();
-        if !table.procs.lock().unwrap().contains_key(key) {
+        if !table.procs.lock().contains_key(key) {
             return true;
         }
     }
@@ -458,7 +457,7 @@ async fn wait_reaped(app: &AppHandle, key: &str, ticks: u32) -> bool {
 pub async fn restart_service(app: &AppHandle, key: &str) -> Result<(), String> {
     let was_running = {
         let table = app.state::<ProcTable>();
-        let procs = table.procs.lock().unwrap();
+        let procs = table.procs.lock();
         procs.contains_key(key)
     };
     if was_running {
@@ -469,7 +468,7 @@ pub async fn restart_service(app: &AppHandle, key: &str) -> Result<(), String> {
         if !wait_reaped(app, key, 40).await {
             {
                 let table = app.state::<ProcTable>();
-                let procs = table.procs.lock().unwrap();
+                let procs = table.procs.lock();
                 if let Some(p) = procs.get(key) {
                     crate::proc::kill_group(&p.group);
                 }
@@ -492,7 +491,7 @@ pub async fn restart_service(app: &AppHandle, key: &str) -> Result<(), String> {
 pub async fn stop_all(app: &AppHandle) {
     let keys: Vec<String> = {
         let table = app.state::<ProcTable>();
-        let procs = table.procs.lock().unwrap();
+        let procs = table.procs.lock();
         procs.keys().cloned().collect()
     };
     for k in &keys {
@@ -500,7 +499,7 @@ pub async fn stop_all(app: &AppHandle) {
     }
     for _ in 0..40 {
         let table = app.state::<ProcTable>();
-        let empty = table.procs.lock().unwrap().is_empty();
+        let empty = table.procs.lock().is_empty();
         if empty {
             break;
         }
@@ -518,8 +517,8 @@ pub fn worktree_svc_keys(app: &AppHandle, wt_key: &str) -> Vec<String> {
 pub async fn reset_db(app: &AppHandle, wt_key: &str) -> Result<(), String> {
     let (cmd_str, log_key) = {
         let state = app.state::<AppState>();
-        let tree = state.tree.read().unwrap();
-        let settings = state.settings.read().unwrap();
+        let tree = state.tree.read();
+        let settings = state.settings.read();
         let mut found = None;
         for r in tree.iter() {
             for w in r.worktrees.iter() {
@@ -543,7 +542,7 @@ pub async fn reset_db(app: &AppHandle, wt_key: &str) -> Result<(), String> {
 
     {
         let table = app.state::<ProcTable>();
-        let mut resetting = table.resetting.lock().unwrap();
+        let mut resetting = table.resetting.lock();
         if resetting.get(wt_key).copied().unwrap_or(false) {
             return Err("Reset already in progress".into());
         }
@@ -574,7 +573,7 @@ pub async fn reset_db(app: &AppHandle, wt_key: &str) -> Result<(), String> {
 
     {
         let table = app.state::<ProcTable>();
-        table.resetting.lock().unwrap().remove(wt_key);
+        table.resetting.lock().remove(wt_key);
     }
 
     match out {
@@ -611,7 +610,7 @@ pub async fn reset_db(app: &AppHandle, wt_key: &str) -> Result<(), String> {
 pub fn sweep_orphans(app: &AppHandle) {
     let orphans = {
         let state = app.state::<AppState>();
-        let rt = state.runtime.read().unwrap();
+        let rt = state.runtime.read();
         rt.orphans.clone()
     };
     for o in &orphans {
@@ -628,7 +627,7 @@ pub fn sweep_orphans(app: &AppHandle) {
     }
     let state = app.state::<AppState>();
     let runtime = {
-        let mut rt = state.runtime.write().unwrap();
+        let mut rt = state.runtime.write();
         rt.orphans.clear();
         rt.clone()
     };

--- a/src-tauri/src/services.rs
+++ b/src-tauri/src/services.rs
@@ -69,6 +69,8 @@ pub struct ProcEntry {
 pub struct ProcTable {
     pub procs: Mutex<HashMap<String, ProcEntry>>,
     pub logs: Mutex<HashMap<String, VecDeque<LogLine>>>,
+    /// open append handles for the on-disk service logs (see `persist_log_lines`)
+    pub log_files: Mutex<HashMap<String, LogSink>>,
     generation: Mutex<u64>,
 }
 
@@ -140,34 +142,91 @@ pub fn push_log(app: &AppHandle, key: &str, line: LogLine) {
 
 /// Cap for one on-disk service log before it rolls to `<name>.1.log`.
 const SVC_LOG_ROTATE_BYTES: u64 = 2 * 1024 * 1024;
+/// Longest generated log filename stem; beyond this the flattened svc_key is
+/// truncated and hashed, since 255 bytes is the per-component limit on APFS,
+/// ext4 and NTFS alike and deep worktree paths flatten into long names.
+const LOG_NAME_MAX: usize = 120;
+
+/// Open sink for one service's on-disk log. Holding the handle (and counting
+/// bytes in-process) keeps the steady-state cost of a flush to a single
+/// `write` — the log pump fires every 80ms per running service, so resolving
+/// the directory and reopening the file each time was pure syscall overhead.
+pub struct LogSink {
+    file: std::fs::File,
+    written: u64,
+}
+
+/// `<app-log-dir>/services`, resolved and created once per run.
+fn service_log_dir(app: &AppHandle) -> Option<&'static std::path::PathBuf> {
+    static DIR: std::sync::OnceLock<Option<std::path::PathBuf>> = std::sync::OnceLock::new();
+    DIR.get_or_init(|| {
+        let dir = app.path().app_log_dir().ok()?.join("services");
+        std::fs::create_dir_all(&dir).ok()?;
+        Some(dir)
+    })
+    .as_ref()
+}
+
+/// svc_key (`<wt path>::<service id>`) flattened to a filesystem-safe stem,
+/// length-bounded so a deep worktree path can't overflow the 255-byte
+/// filename limit.
+fn log_file_stem(key: &str) -> String {
+    let flat: String = key
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() || c == '-' || c == '.' { c } else { '_' })
+        .collect();
+    if flat.len() <= LOG_NAME_MAX {
+        return flat;
+    }
+    // keep the tail (worktree + service, the part a human recognizes) and
+    // prefix a cheap hash of the whole key so distinct services never collide
+    let mut h: u64 = 0xcbf29ce484222325;
+    for b in key.as_bytes() {
+        h ^= *b as u64;
+        h = h.wrapping_mul(0x100000001b3);
+    }
+    let tail: String = flat.chars().skip(flat.chars().count() - (LOG_NAME_MAX - 17)).collect();
+    format!("{h:016x}_{tail}")
+}
 
 /// Append log lines to a per-service file under `<app-log-dir>/services/`.
 /// The in-memory ring keeps only LOG_CAP lines — a crash 500 lines in would
 /// otherwise lose its own cause. Best-effort: log I/O never fails a service op.
 fn persist_log_lines(app: &AppHandle, key: &str, lines: &[LogLine]) {
     use std::io::Write;
-    let Ok(dir) = app.path().app_log_dir().map(|d| d.join("services")) else { return };
-    if std::fs::create_dir_all(&dir).is_err() {
+    if lines.is_empty() {
         return;
     }
-    // svc_key is `<wt path>::<service id>` — flatten to a safe filename
-    let name: String = key
-        .chars()
-        .map(|c| if c.is_ascii_alphanumeric() || c == '-' || c == '.' { c } else { '_' })
-        .collect();
-    let path = dir.join(format!("{name}.log"));
-    // size-capped: roll the current file to `.1.log` (replacing the previous roll)
-    if let Ok(meta) = std::fs::metadata(&path) {
-        if meta.len() > SVC_LOG_ROTATE_BYTES {
-            let _ = std::fs::rename(&path, dir.join(format!("{name}.1.log")));
+    let Some(dir) = service_log_dir(app) else { return };
+    let mut body = String::new();
+    for l in lines {
+        use std::fmt::Write as _;
+        let _ = writeln!(body, "{} [{}] {}", l.t, l.lv, l.text);
+    }
+
+    let table = app.state::<ProcTable>();
+    let mut sinks = table.log_files.lock();
+    let stem = log_file_stem(key);
+    let path = dir.join(format!("{stem}.log"));
+
+    // rotate on the byte count we already track — no metadata() syscall
+    if let Some(s) = sinks.get(key) {
+        if s.written + body.len() as u64 > SVC_LOG_ROTATE_BYTES {
+            sinks.remove(key); // drop the handle before renaming (Windows)
+            let _ = std::fs::rename(&path, dir.join(format!("{stem}.1.log")));
         }
     }
-    let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(&path) else { return };
-    let mut out = String::new();
-    for l in lines {
-        out.push_str(&format!("{} [{}] {}\n", l.t, l.lv, l.text));
+    let sink = match sinks.entry(key.to_string()) {
+        std::collections::hash_map::Entry::Occupied(e) => e.into_mut(),
+        std::collections::hash_map::Entry::Vacant(e) => {
+            let Ok(file) = std::fs::OpenOptions::new().create(true).append(true).open(&path) else { return };
+            let written = file.metadata().map(|m| m.len()).unwrap_or(0);
+            e.insert(LogSink { file, written })
+        }
+    };
+    if sink.file.write_all(body.as_bytes()).is_ok() {
+        sink.written += body.len() as u64;
     }
-    let _ = f.write_all(out.as_bytes());
 }
 
 /// Persist live service pgids so a crash can be swept on next launch. Unix-only:
@@ -678,7 +737,24 @@ pub(crate) fn proc_start_time_matches(pid: u32, recorded_secs: u64) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::classify_line;
+    use super::{classify_line, log_file_stem, LOG_NAME_MAX};
+
+    #[test]
+    fn log_file_stem_is_safe_and_length_bounded() {
+        let short = log_file_stem("/Users/me/wt/feat::frontend");
+        assert_eq!(short, "_Users_me_wt_feat__frontend", "separators flattened");
+
+        // a deep path must not overflow the 255-byte filename limit
+        let deep = format!("/Users/me/{}/wt::server", "nested-dir/".repeat(40));
+        let stem = log_file_stem(&deep);
+        assert!(stem.len() <= LOG_NAME_MAX, "bounded: {}", stem.len());
+        assert!(stem.ends_with("wt__server"), "keeps the recognizable tail: {stem}");
+
+        // two long keys differing only at the head still get distinct names
+        let a = log_file_stem(&format!("/a/{}/wt::server", "x/".repeat(80)));
+        let b = log_file_stem(&format!("/b/{}/wt::server", "x/".repeat(80)));
+        assert_ne!(a, b, "hash prefix disambiguates truncated names");
+    }
 
     /// The PID-recycling guard must recognize a live process's real start time
     /// (this also proves sysinfo delivers a non-zero start_time on this OS —

--- a/src-tauri/src/services.rs
+++ b/src-tauri/src/services.rs
@@ -443,6 +443,18 @@ pub async fn stop_service(app: &AppHandle, key: &str) -> Result<(), String> {
     Ok(())
 }
 
+/// Wait up to `ticks * 150ms` for the waiter task to reap `key`.
+async fn wait_reaped(app: &AppHandle, key: &str, ticks: u32) -> bool {
+    for _ in 0..ticks {
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        let table = app.state::<ProcTable>();
+        if !table.procs.lock().unwrap().contains_key(key) {
+            return true;
+        }
+    }
+    false
+}
+
 pub async fn restart_service(app: &AppHandle, key: &str) -> Result<(), String> {
     let was_running = {
         let table = app.state::<ProcTable>();
@@ -452,12 +464,24 @@ pub async fn restart_service(app: &AppHandle, key: &str) -> Result<(), String> {
     if was_running {
         push_log(app, key, LogLine::now("warn", "restarting…"));
         stop_service(app, key).await?;
-        // wait for the waiter to reap (status -> stopped/error)
-        for _ in 0..40 {
-            tokio::time::sleep(Duration::from_millis(150)).await;
-            let table = app.state::<ProcTable>();
-            if !table.procs.lock().unwrap().contains_key(key) {
-                break;
+        // stop() SIGTERMs now and SIGKILLs at the 3s grace mark; give the
+        // waiter up to 6s to reap before escalating ourselves.
+        if !wait_reaped(app, key, 40).await {
+            {
+                let table = app.state::<ProcTable>();
+                let procs = table.procs.lock().unwrap();
+                if let Some(p) = procs.get(key) {
+                    crate::proc::kill_group(&p.group);
+                }
+            }
+            if !wait_reaped(app, key, 20).await {
+                // start_service would see the stale entry and return Ok(())
+                // doing nothing — the restart MUST fail loudly instead, or a
+                // port/database change reports applied while the old process
+                // keeps serving the old config.
+                let msg = "restart failed: previous process did not exit (SIGKILL sent) — try again";
+                push_log(app, key, LogLine::now("err", msg));
+                return Err(msg.into());
             }
         }
     }

--- a/src-tauri/src/services.rs
+++ b/src-tauri/src/services.rs
@@ -39,20 +39,19 @@ fn chrono_time() -> String {
 
 /// Local UTC offset with a 60s cache — the exact value only shifts on a DST
 /// boundary, and computing it per log line meant a localtime_r call for every
-/// line of a webpack burst.
+/// line of a webpack burst. Timestamp and offset are packed into ONE atomic
+/// (ts << 20 | offset + 50400; offsets span ±14h < 2^17) so a racing reader
+/// can never pair a fresh timestamp with a stale offset.
 fn cached_utc_offset(now_secs: u64) -> i64 {
-    use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
-    static OFFSET: AtomicI64 = AtomicI64::new(0);
-    static FETCHED_AT: AtomicU64 = AtomicU64::new(0);
-    let last = FETCHED_AT.load(Ordering::Relaxed);
-    if last == 0 || now_secs.saturating_sub(last) > 60 {
-        let off = crate::proc::local_utc_offset_secs();
-        OFFSET.store(off, Ordering::Relaxed);
-        FETCHED_AT.store(now_secs, Ordering::Relaxed);
-        off
-    } else {
-        OFFSET.load(Ordering::Relaxed)
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static PACKED: AtomicU64 = AtomicU64::new(0);
+    let p = PACKED.load(Ordering::Relaxed);
+    if p != 0 && now_secs.saturating_sub(p >> 20) <= 60 {
+        return ((p & 0xF_FFFF) as i64) - 50400;
     }
+    let fresh = crate::proc::local_utc_offset_secs().clamp(-50400, 50400);
+    PACKED.store((now_secs << 20) | ((fresh + 50400) as u64), Ordering::Relaxed);
+    fresh
 }
 
 pub struct ProcEntry {

--- a/src-tauri/src/services.rs
+++ b/src-tauri/src/services.rs
@@ -77,6 +77,9 @@ pub struct ProcEntry {
     /// process-group / job handle used to tear down the whole child tree
     pub group: crate::proc::ProcGroup,
     pub started_at: Instant,
+    /// read only by the Unix crash-orphan persist (Windows has none — the Job
+    /// Object's KILL_ON_JOB_CLOSE makes the OS reap the tree)
+    #[cfg_attr(windows, allow(dead_code))]
     pub started_unix: u64,
     /// generation guard: stop() bumps this so a stale waiter doesn't clobber state
     pub generation: u64,

--- a/src-tauri/src/services.rs
+++ b/src-tauri/src/services.rs
@@ -92,6 +92,14 @@ pub fn set_status(app: &AppHandle, key: &str, status: SvcStatus, started_at: Opt
     let _ = app.emit("service:status", &StatusEvent { svc_key: key, status, started_at, exit_code });
 }
 
+
+/// Deliver to the main window's listeners only — the popover subscribes to the
+/// shared store but renders no logs/stats, and log bursts are the hottest
+/// event in the app.
+fn main_window_only(t: &tauri::EventTarget) -> bool {
+    matches!(t, tauri::EventTarget::WebviewWindow { label } if label == "main")
+}
+
 pub fn push_log(app: &AppHandle, key: &str, line: LogLine) {
     let table = app.state::<ProcTable>();
     {
@@ -109,7 +117,7 @@ pub fn push_log(app: &AppHandle, key: &str, line: LogLine) {
         svc_key: &'a str,
         lines: Vec<LogLine>,
     }
-    let _ = app.emit("service:log", &LogEvent { svc_key: key, lines: vec![line] });
+    let _ = app.emit_filter("service:log", &LogEvent { svc_key: key, lines: vec![line] }, main_window_only);
 }
 
 /// Cap for one on-disk service log before it rolls to `<name>.1.log`.
@@ -390,7 +398,7 @@ fn flush_batch(app: &AppHandle, key: &str, batch: &mut Vec<LogLine>) {
         svc_key: &'a str,
         lines: Vec<LogLine>,
     }
-    let _ = app.emit("service:log", &LogEvent { svc_key: key, lines: std::mem::take(batch) });
+    let _ = app.emit_filter("service:log", &LogEvent { svc_key: key, lines: std::mem::take(batch) }, main_window_only);
 }
 
 fn classify_line(text: &str, from_stderr: bool) -> &'static str {

--- a/src-tauri/src/services.rs
+++ b/src-tauri/src/services.rs
@@ -486,13 +486,7 @@ pub async fn stop_all(app: &AppHandle) {
 
 /// Worktree-level: collect svc keys of one worktree.
 pub fn worktree_svc_keys(app: &AppHandle, wt_key: &str) -> Vec<String> {
-    let state = app.state::<AppState>();
-    let tree = state.tree.read().unwrap();
-    tree.iter()
-        .flat_map(|r| r.worktrees.iter())
-        .filter(|w| w.wt_key == wt_key)
-        .flat_map(|w| w.services.iter().map(|s| s.svc_key.clone()))
-        .collect()
+    app.state::<AppState>().wt_service_keys(wt_key)
 }
 
 /// Reset DB: runs the repo's resetDb command in the worktree root; output goes

--- a/src-tauri/src/services.rs
+++ b/src-tauri/src/services.rs
@@ -634,3 +634,17 @@ pub(crate) fn proc_start_time_matches(pid: u32, recorded_secs: u64) -> bool {
     let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
     recorded_secs <= now
 }
+
+#[cfg(test)]
+mod tests {
+    use super::classify_line;
+
+    #[test]
+    fn classifies_log_levels() {
+        assert_eq!(classify_line("Error: boom", false), "err");
+        assert_eq!(classify_line("npm WARN deprecated", false), "warn");
+        assert_eq!(classify_line("webpack compiled successfully", false), "ok");
+        assert_eq!(classify_line("Listening on :3000", true), "ok");
+        assert_eq!(classify_line("plain build output", true), "info", "stderr alone isn't an error");
+    }
+}

--- a/src-tauri/src/services.rs
+++ b/src-tauri/src/services.rs
@@ -43,18 +43,33 @@ fn chrono_time() -> String {
 /// Local UTC offset with a 60s cache — the exact value only shifts on a DST
 /// boundary, and computing it per log line meant a localtime_r call for every
 /// line of a webpack burst. Timestamp and offset are packed into ONE atomic
-/// (ts << 20 | offset + 50400; offsets span ±14h < 2^17) so a racing reader
-/// can never pair a fresh timestamp with a stale offset.
+/// (see `pack_offset`) so a racing reader can never pair a fresh timestamp
+/// with a stale offset.
 fn cached_utc_offset(now_secs: u64) -> i64 {
     use std::sync::atomic::{AtomicU64, Ordering};
     static PACKED: AtomicU64 = AtomicU64::new(0);
     let p = PACKED.load(Ordering::Relaxed);
-    if p != 0 && now_secs.saturating_sub(p >> 20) <= 60 {
-        return ((p & 0xF_FFFF) as i64) - 50400;
+    if p != 0 {
+        let (ts, off) = unpack_offset(p);
+        if now_secs.saturating_sub(ts) <= 60 {
+            return off;
+        }
     }
-    let fresh = crate::proc::local_utc_offset_secs().clamp(-50400, 50400);
-    PACKED.store((now_secs << 20) | ((fresh + 50400) as u64), Ordering::Relaxed);
+    let fresh = crate::proc::local_utc_offset_secs().clamp(-OFFSET_BIAS, OFFSET_BIAS);
+    PACKED.store(pack_offset(now_secs, fresh), Ordering::Relaxed);
     fresh
+}
+
+/// UTC offsets span ±14h (= ±50400s) < 2^17, so `offset + BIAS` fits the low
+/// 20 bits and the fetch timestamp takes the rest: `ts << 20 | offset + BIAS`.
+const OFFSET_BIAS: i64 = 50_400;
+
+fn pack_offset(ts_secs: u64, offset: i64) -> u64 {
+    (ts_secs << 20) | ((offset + OFFSET_BIAS) as u64)
+}
+
+fn unpack_offset(p: u64) -> (u64, i64) {
+    (p >> 20, ((p & 0xF_FFFF) as i64) - OFFSET_BIAS)
 }
 
 pub struct ProcEntry {
@@ -797,5 +812,26 @@ mod tests {
         assert_eq!(classify_line("webpack compiled successfully", false), "ok");
         assert_eq!(classify_line("Listening on :3000", true), "ok");
         assert_eq!(classify_line("plain build output", true), "info", "stderr alone isn't an error");
+    }
+
+    #[test]
+    fn contains_ci_edge_cases() {
+        assert!(super::contains_ci("XxErRoRxX", "error"), "mid-word, mixed case");
+        assert!(!super::contains_ci("err", "error"), "needle longer than hay");
+        assert!(!super::contains_ci("", "e"), "empty hay");
+        assert!(!super::contains_ci("anything", ""), "empty needle matches nothing (never classifies)");
+    }
+
+    /// The packed-atomic cache must round-trip both extremes of the legal
+    /// UTC-offset range without the timestamp and offset bleeding into each
+    /// other's bits.
+    #[test]
+    fn offset_packing_round_trips() {
+        use super::{pack_offset, unpack_offset, OFFSET_BIAS};
+        for &off in &[-OFFSET_BIAS, -3600, 0, 19800 /* +05:30 */, OFFSET_BIAS] {
+            for &ts in &[0u64, 1_722_500_000, u64::MAX >> 21] {
+                assert_eq!(unpack_offset(pack_offset(ts, off)), (ts, off), "ts={ts} off={off}");
+            }
+        }
     }
 }

--- a/src-tauri/src/services.rs
+++ b/src-tauri/src/services.rs
@@ -10,7 +10,10 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 
 pub const LOG_CAP: usize = 160;
-const LOG_FLUSH_MS: u64 = 80;
+// Flush cadence for log batches. 200ms caps store-update/render pressure at
+// 5/sec per noisy service (was 12.5/sec at 80ms) — meaningful on low-spec
+// machines during a webpack burst, imperceptible as log-tail latency.
+const LOG_FLUSH_MS: u64 = 200;
 const STOP_GRACE: Duration = Duration::from_secs(3);
 
 #[derive(Debug, Clone, Serialize)]
@@ -136,7 +139,12 @@ pub fn push_log(app: &AppHandle, key: &str, line: LogLine) {
         svc_key: &'a str,
         lines: Vec<LogLine>,
     }
-    let _ = app.emit_filter("service:log", &LogEvent { svc_key: key, lines: vec![line] }, main_window_only);
+    // ring + disk always record; the emit is skipped while nothing is on
+    // screen (the UI re-snapshots the ring via get_logs on tab select,
+    // primeLogs, and window focus)
+    if crate::windows_visible() {
+        let _ = app.emit_filter("service:log", &LogEvent { svc_key: key, lines: vec![line] }, main_window_only);
+    }
 }
 
 /// Cap for one on-disk service log before it rolls to `<name>.1.log`.
@@ -474,7 +482,12 @@ fn flush_batch(app: &AppHandle, key: &str, batch: &mut Vec<LogLine>) {
         svc_key: &'a str,
         lines: Vec<LogLine>,
     }
-    let _ = app.emit_filter("service:log", &LogEvent { svc_key: key, lines: std::mem::take(batch) }, main_window_only);
+    // see push_log: recorded always, emitted only when someone can see it
+    if crate::windows_visible() {
+        let _ = app.emit_filter("service:log", &LogEvent { svc_key: key, lines: std::mem::take(batch) }, main_window_only);
+    } else {
+        batch.clear();
+    }
 }
 
 /// Case-insensitive substring search without allocating (the old

--- a/src-tauri/src/services.rs
+++ b/src-tauri/src/services.rs
@@ -51,7 +51,6 @@ pub struct ProcEntry {
 pub struct ProcTable {
     pub procs: Mutex<HashMap<String, ProcEntry>>,
     pub logs: Mutex<HashMap<String, VecDeque<LogLine>>>,
-    pub resetting: Mutex<HashMap<String, bool>>,
     generation: Mutex<u64>,
 }
 
@@ -540,14 +539,8 @@ pub async fn reset_db(app: &AppHandle, wt_key: &str) -> Result<(), String> {
         found.ok_or("unknown worktree")?
     };
 
-    {
-        let table = app.state::<ProcTable>();
-        let mut resetting = table.resetting.lock();
-        if resetting.get(wt_key).copied().unwrap_or(false) {
-            return Err("Reset already in progress".into());
-        }
-        resetting.insert(wt_key.to_string(), true);
-    }
+    // concurrency guard: the command layer holds the per-worktree OpLease
+    // (state::try_lease) for the whole reset — no separate flag needed.
 
     #[derive(Serialize, Clone)]
     #[serde(rename_all = "camelCase")]
@@ -570,11 +563,6 @@ pub async fn reset_db(app: &AppHandle, wt_key: &str) -> Result<(), String> {
         .current_dir(wt_key)
         .output()
         .await;
-
-    {
-        let table = app.state::<ProcTable>();
-        table.resetting.lock().remove(wt_key);
-    }
 
     match out {
         Ok(o) if o.status.success() => {

--- a/src-tauri/src/services.rs
+++ b/src-tauri/src/services.rs
@@ -639,29 +639,50 @@ pub fn sweep_orphans(app: &AppHandle) {
 pub fn sweep_orphans(_app: &AppHandle) {}
 
 /// Compare recorded spawn time against the process's actual start time (±5s).
-/// Unix-only (uses `ps`); only the Unix crash sweep calls it.
+/// This is the guard against PID recycling: after a reboot (or enough process
+/// churn) the persisted pgid can belong to an unrelated process — the sweep
+/// must never SIGTERM that. Unix-only; only the Unix crash sweep calls it.
 #[cfg(unix)]
 pub(crate) fn proc_start_time_matches(pid: u32, recorded_secs: u64) -> bool {
-    let out = std::process::Command::new("ps")
-        .args(["-o", "lstart=", "-p", &pid.to_string()])
-        .output();
-    let Ok(out) = out else { return false };
-    if !out.status.success() {
-        return false;
-    }
-    let lstart = String::from_utf8_lossy(&out.stdout).trim().to_string();
-    if lstart.is_empty() {
-        return false;
-    }
-    // The pgid-existence check plus a sane recorded time is sufficient for v1;
-    // parsing lstart exactly would require another shell-out.
-    let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
-    recorded_secs <= now
+    use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
+    let mut sys = System::new();
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::Some(&[Pid::from_u32(pid)]),
+        false,
+        ProcessRefreshKind::nothing(),
+    );
+    let Some(p) = sys.process(Pid::from_u32(pid)) else { return false };
+    let actual = p.start_time(); // seconds since the epoch
+    // an unreadable start time (0) fails the match — skipping a sweep is safe,
+    // killing an innocent process group is not
+    actual != 0 && actual.abs_diff(recorded_secs) <= 5
 }
 
 #[cfg(test)]
 mod tests {
     use super::classify_line;
+
+    /// The PID-recycling guard must recognize a live process's real start time
+    /// (this also proves sysinfo delivers a non-zero start_time on this OS —
+    /// the guard fails closed to "no match" when it can't read one).
+    #[test]
+    #[cfg(unix)]
+    fn own_process_start_time_matches_itself() {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let pid = std::process::id();
+        use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
+        let mut sys = System::new();
+        sys.refresh_processes_specifics(
+            ProcessesToUpdate::Some(&[Pid::from_u32(pid)]),
+            false,
+            ProcessRefreshKind::nothing(),
+        );
+        let start = sys.process(Pid::from_u32(pid)).map(|p| p.start_time()).unwrap_or(0);
+        assert!(start > 0, "sysinfo must expose a start time");
+        assert!(super::proc_start_time_matches(pid, start), "exact start time matches");
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+        assert!(!super::proc_start_time_matches(pid, now + 3600), "wrong time must not match");
+    }
 
     #[test]
     fn classifies_log_levels() {

--- a/src-tauri/src/services.rs
+++ b/src-tauri/src/services.rs
@@ -31,10 +31,28 @@ impl LogLine {
 fn chrono_time() -> String {
     // HH:MM:SS local time without pulling in chrono
     let now = std::time::SystemTime::now();
-    let secs = now.duration_since(UNIX_EPOCH).unwrap().as_secs();
-    let offset = crate::proc::local_utc_offset_secs();
+    let secs = now.duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
+    let offset = cached_utc_offset(secs);
     let local = (secs as i64 + offset).rem_euclid(86_400);
     format!("{:02}:{:02}:{:02}", local / 3600, (local % 3600) / 60, local % 60)
+}
+
+/// Local UTC offset with a 60s cache — the exact value only shifts on a DST
+/// boundary, and computing it per log line meant a localtime_r call for every
+/// line of a webpack burst.
+fn cached_utc_offset(now_secs: u64) -> i64 {
+    use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+    static OFFSET: AtomicI64 = AtomicI64::new(0);
+    static FETCHED_AT: AtomicU64 = AtomicU64::new(0);
+    let last = FETCHED_AT.load(Ordering::Relaxed);
+    if last == 0 || now_secs.saturating_sub(last) > 60 {
+        let off = crate::proc::local_utc_offset_secs();
+        OFFSET.store(off, Ordering::Relaxed);
+        FETCHED_AT.store(now_secs, Ordering::Relaxed);
+        off
+    } else {
+        OFFSET.load(Ordering::Relaxed)
+    }
 }
 
 pub struct ProcEntry {
@@ -401,17 +419,22 @@ fn flush_batch(app: &AppHandle, key: &str, batch: &mut Vec<LogLine>) {
     let _ = app.emit_filter("service:log", &LogEvent { svc_key: key, lines: std::mem::take(batch) }, main_window_only);
 }
 
-fn classify_line(text: &str, from_stderr: bool) -> &'static str {
-    let lower = text.to_lowercase();
-    if lower.contains("error") || lower.contains("fatal") || lower.contains("err!") {
+/// Case-insensitive substring search without allocating (the old
+/// `to_lowercase()` copied every log line — thousands per webpack burst).
+fn contains_ci(hay: &str, needle: &str) -> bool {
+    let (h, n) = (hay.as_bytes(), needle.as_bytes());
+    !n.is_empty() && h.len() >= n.len() && h.windows(n.len()).any(|w| w.eq_ignore_ascii_case(n))
+}
+
+fn classify_line(text: &str, _from_stderr: bool) -> &'static str {
+    if contains_ci(text, "error") || contains_ci(text, "fatal") || contains_ci(text, "err!") {
         "err"
-    } else if lower.contains("warn") {
+    } else if contains_ci(text, "warn") {
         "warn"
-    } else if lower.contains("listening") || lower.contains("compiled successfully") || lower.contains("ready") {
+    } else if contains_ci(text, "listening") || contains_ci(text, "compiled successfully") || contains_ci(text, "ready") {
         "ok"
-    } else if from_stderr {
-        "info" // many dev tools log normal output to stderr
     } else {
+        // stderr alone isn't an error — many dev tools log normal output there
         "info"
     }
 }

--- a/src-tauri/src/services.rs
+++ b/src-tauri/src/services.rs
@@ -103,6 +103,7 @@ pub fn push_log(app: &AppHandle, key: &str, line: LogLine) {
             buf.pop_front();
         }
     }
+    persist_log_lines(app, key, std::slice::from_ref(&line));
     #[derive(Serialize, Clone)]
     #[serde(rename_all = "camelCase")]
     struct LogEvent<'a> {
@@ -110,6 +111,38 @@ pub fn push_log(app: &AppHandle, key: &str, line: LogLine) {
         lines: Vec<LogLine>,
     }
     let _ = app.emit("service:log", &LogEvent { svc_key: key, lines: vec![line] });
+}
+
+/// Cap for one on-disk service log before it rolls to `<name>.1.log`.
+const SVC_LOG_ROTATE_BYTES: u64 = 2 * 1024 * 1024;
+
+/// Append log lines to a per-service file under `<app-log-dir>/services/`.
+/// The in-memory ring keeps only LOG_CAP lines — a crash 500 lines in would
+/// otherwise lose its own cause. Best-effort: log I/O never fails a service op.
+fn persist_log_lines(app: &AppHandle, key: &str, lines: &[LogLine]) {
+    use std::io::Write;
+    let Ok(dir) = app.path().app_log_dir().map(|d| d.join("services")) else { return };
+    if std::fs::create_dir_all(&dir).is_err() {
+        return;
+    }
+    // svc_key is `<wt path>::<service id>` — flatten to a safe filename
+    let name: String = key
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() || c == '-' || c == '.' { c } else { '_' })
+        .collect();
+    let path = dir.join(format!("{name}.log"));
+    // size-capped: roll the current file to `.1.log` (replacing the previous roll)
+    if let Ok(meta) = std::fs::metadata(&path) {
+        if meta.len() > SVC_LOG_ROTATE_BYTES {
+            let _ = std::fs::rename(&path, dir.join(format!("{name}.1.log")));
+        }
+    }
+    let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(&path) else { return };
+    let mut out = String::new();
+    for l in lines {
+        out.push_str(&format!("{} [{}] {}\n", l.t, l.lv, l.text));
+    }
+    let _ = f.write_all(out.as_bytes());
 }
 
 /// Persist live service pgids so a crash can be swept on next launch. Unix-only:
@@ -352,6 +385,7 @@ fn flush_batch(app: &AppHandle, key: &str, batch: &mut Vec<LogLine>) {
             buf.pop_front();
         }
     }
+    persist_log_lines(app, key, batch);
     #[derive(Serialize, Clone)]
     #[serde(rename_all = "camelCase")]
     struct LogEvent<'a> {
@@ -568,7 +602,7 @@ pub fn sweep_orphans(app: &AppHandle) {
         }
         let alive = unsafe { libc::killpg(o.pgid, 0) == 0 };
         if alive && proc_start_time_matches(o.pgid as u32, o.spawn_time_secs) {
-            eprintln!("[wtm] sweeping orphan pgid {} ({})", o.pgid, o.svc_key);
+            log::warn!("sweeping orphan pgid {} ({})", o.pgid, o.svc_key);
             unsafe {
                 libc::killpg(o.pgid, libc::SIGTERM);
             }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -220,8 +220,7 @@ mod tests {
         fs::create_dir_all(&dir).unwrap();
         let path = dir.join("settings.json");
 
-        let mut s = Settings::default();
-        s.terminal = "iTerm".into();
+        let s = Settings { terminal: "iTerm".into(), ..Default::default() };
         save_json(&path, &s).unwrap();
         let loaded: Settings = load_json(&path);
         assert_eq!(loaded.terminal, "iTerm", "round-trips");

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -148,19 +148,49 @@ fn runtime_path(app: &AppHandle) -> PathBuf {
         .join("state.json")
 }
 
+/// Load a JSON state file. A *missing* file is a fresh install (defaults); a
+/// file that EXISTS but doesn't parse is user data in danger — quarantine it
+/// to `<name>.corrupt` and log loudly, so the repos/services/ports it held can
+/// be recovered by hand instead of being silently wiped on the next save.
 fn load_json<T: for<'a> Deserialize<'a> + Default>(path: &PathBuf) -> T {
-    fs::read_to_string(path)
-        .ok()
-        .and_then(|s| serde_json::from_str(&s).ok())
-        .unwrap_or_default()
+    let Ok(txt) = fs::read_to_string(path) else { return T::default() };
+    match serde_json::from_str(&txt) {
+        Ok(v) => v,
+        Err(e) => {
+            let backup = path.with_extension("json.corrupt");
+            let _ = fs::copy(path, &backup);
+            log::error!(
+                "failed to parse {} ({e}) — original preserved at {}; starting from defaults",
+                path.display(),
+                backup.display()
+            );
+            T::default()
+        }
+    }
 }
 
+/// Atomic save: write a sibling temp file, fsync, rename over the target. A
+/// crash or full disk mid-write can no longer truncate settings/state — the
+/// old file stays intact until the rename. Skips the write entirely when the
+/// serialized content is unchanged (state.json is saved on every refresh).
 fn save_json<T: Serialize>(path: &PathBuf, value: &T) -> Result<(), String> {
     if let Some(dir) = path.parent() {
         fs::create_dir_all(dir).map_err(|e| e.to_string())?;
     }
     let body = serde_json::to_string_pretty(value).map_err(|e| e.to_string())?;
-    fs::write(path, body).map_err(|e| e.to_string())
+    if let Ok(existing) = fs::read_to_string(path) {
+        if existing == body {
+            return Ok(());
+        }
+    }
+    let tmp = path.with_extension("json.tmp");
+    {
+        use std::io::Write;
+        let mut f = fs::File::create(&tmp).map_err(|e| format!("create {}: {e}", tmp.display()))?;
+        f.write_all(body.as_bytes()).map_err(|e| format!("write {}: {e}", tmp.display()))?;
+        f.sync_all().map_err(|e| format!("sync {}: {e}", tmp.display()))?;
+    }
+    fs::rename(&tmp, path).map_err(|e| format!("rename {} → {}: {e}", tmp.display(), path.display()))
 }
 
 pub fn load_settings(app: &AppHandle) -> Settings {
@@ -177,4 +207,36 @@ pub fn load_runtime(app: &AppHandle) -> RuntimeState {
 
 pub fn save_runtime(app: &AppHandle, s: &RuntimeState) -> Result<(), String> {
     save_json(&runtime_path(app), s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn save_is_atomic_and_load_quarantines_corrupt_files() {
+        let dir = std::env::temp_dir().join("canopy_settings_test_xyz");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("settings.json");
+
+        let mut s = Settings::default();
+        s.terminal = "iTerm".into();
+        save_json(&path, &s).unwrap();
+        let loaded: Settings = load_json(&path);
+        assert_eq!(loaded.terminal, "iTerm", "round-trips");
+        assert!(!path.with_extension("json.tmp").exists(), "temp file renamed away");
+
+        // corrupt file → defaults, but the original is preserved
+        fs::write(&path, "{ truncated").unwrap();
+        let loaded: Settings = load_json(&path);
+        assert_eq!(loaded.terminal, "", "defaults on parse failure");
+        let backup = path.with_extension("json.corrupt");
+        assert_eq!(fs::read_to_string(&backup).unwrap(), "{ truncated", "original quarantined");
+
+        // unchanged content → no rewrite (mtime-stable persistence)
+        fs::write(&path, serde_json::to_string_pretty(&s).unwrap()).unwrap();
+        save_json(&path, &s).unwrap();
+        let _ = fs::remove_dir_all(&dir);
+    }
 }

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -683,6 +683,12 @@ mod tests {
     use super::*;
 
     #[test]
+    fn wt_slug_is_db_safe() {
+        assert_eq!(wt_slug("/Users/me/wt/Feat-X.2"), "feat_x_2");
+        assert_eq!(wt_slug("/w/plain"), "plain");
+    }
+
+    #[test]
     fn interpolates_braced_vars() {
         let mut v = HashMap::new();
         v.insert("WT_DB_NAME".to_string(), "tooljet_feature_x".to_string());

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -625,26 +625,40 @@ async fn run_commands(
                 last_emit = std::time::Instant::now();
             }
         };
-        let (mut out_done, mut err_done) = (false, false);
-        while !(out_done && err_done) {
-            tokio::select! {
-                l = out_lines.next_line(), if !out_done => match l {
-                    Ok(Some(line)) => emit(&line, progress),
-                    _ => out_done = true,
-                },
-                l = err_lines.next_line(), if !err_done => match l {
-                    Ok(Some(line)) => {
-                        stderr_tail.push_back(line.clone());
-                        if stderr_tail.len() > 64 {
-                            stderr_tail.pop_front();
+        // hard ceiling per command: npm installs legitimately run long, but a
+        // command stuck on a dead registry or waiting for input it can never
+        // get (stdin is null) must not hang setup forever.
+        const STEP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60 * 60);
+        let run_fut = async {
+            let (mut out_done, mut err_done) = (false, false);
+            while !(out_done && err_done) {
+                tokio::select! {
+                    l = out_lines.next_line(), if !out_done => match l {
+                        Ok(Some(line)) => emit(&line, progress),
+                        _ => out_done = true,
+                    },
+                    l = err_lines.next_line(), if !err_done => match l {
+                        Ok(Some(line)) => {
+                            stderr_tail.push_back(line.clone());
+                            if stderr_tail.len() > 64 {
+                                stderr_tail.pop_front();
+                            }
+                            emit(&line, progress);
                         }
-                        emit(&line, progress);
-                    }
-                    _ => err_done = true,
-                },
+                        _ => err_done = true,
+                    },
+                }
             }
-        }
-        let status = child.wait().await.map_err(|e| format!("{label} wait failed: {e}"))?;
+            child.wait().await
+        };
+        let status = match tokio::time::timeout(STEP_TIMEOUT, run_fut).await {
+            Ok(res) => res.map_err(|e| format!("{label} wait failed: {e}"))?,
+            Err(_) => {
+                // kills the shell; its own children get EOF on the shared pipes
+                let _ = child.kill().await;
+                return Err(format!("{label} step timed out after {}min: {cmd}", STEP_TIMEOUT.as_secs() / 60));
+            }
+        };
         if !status.success() {
             // surface the first real error line plus the tail, so messages like
             // "Cannot find module" aren't buried under a stack.

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -2,7 +2,7 @@ use crate::git::{self, GitMeta};
 use crate::settings::{RepoCfg, RuntimeState, Settings};
 use serde::Serialize;
 use std::collections::HashMap;
-use std::sync::RwLock;
+use parking_lot::RwLock;
 use tauri::{AppHandle, Emitter, Manager};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -103,7 +103,7 @@ impl AppState {
 
     /// Resolve a worktree key to its owning repo.
     pub fn wt_context(&self, wt_key: &str) -> Option<WtContext> {
-        let tree = self.tree.read().unwrap();
+        let tree = self.tree.read();
         for r in tree.iter() {
             for w in r.worktrees.iter() {
                 if w.wt_key == wt_key {
@@ -121,7 +121,7 @@ impl AppState {
 
     /// Resolve a service key to `(wt_key, repo_id, repo_path)`.
     pub fn service_context(&self, svc_key: &str) -> Option<(String, String, String)> {
-        let tree = self.tree.read().unwrap();
+        let tree = self.tree.read();
         for r in tree.iter() {
             for w in r.worktrees.iter() {
                 if w.services.iter().any(|s| s.svc_key == svc_key) {
@@ -134,7 +134,7 @@ impl AppState {
 
     /// All service keys of one worktree.
     pub fn wt_service_keys(&self, wt_key: &str) -> Vec<String> {
-        let tree = self.tree.read().unwrap();
+        let tree = self.tree.read();
         tree.iter()
             .flat_map(|r| r.worktrees.iter())
             .filter(|w| w.wt_key == wt_key)
@@ -144,7 +144,7 @@ impl AppState {
 
     /// A registered repo's path by id.
     pub fn repo_path_by_id(&self, repo_id: &str) -> Option<String> {
-        let s = self.settings.read().unwrap();
+        let s = self.settings.read();
         s.repos.iter().find(|r| r.id == repo_id).map(|r| r.path.clone())
     }
 }
@@ -188,11 +188,11 @@ pub fn effective_port(overrides: &HashMap<String, u32>, svc_key: &str, base_port
 pub fn worktree_vars(app: &AppHandle, repo_id: &str, wt_key: &str, is_main: bool) -> HashMap<String, String> {
     let state = app.state::<AppState>();
     let idx = {
-        let mut rt = state.runtime.write().unwrap();
+        let mut rt = state.runtime.write();
         port_index(&mut rt, repo_id, wt_key, is_main)
     };
     {
-        let rt = state.runtime.read().unwrap().clone();
+        let rt = state.runtime.read().clone();
         let _ = crate::settings::save_runtime(app, &rt);
     }
     let slug = crate::setup::wt_slug(wt_key);
@@ -207,8 +207,8 @@ pub fn worktree_vars(app: &AppHandle, repo_id: &str, wt_key: &str, is_main: bool
     m.insert("WT_DB_NAME".into(), format!("{repo_slug}_{slug}"));
     m.insert("WM_WT_SLUG".into(), slug); // back-compat alias
 
-    let overrides = state.runtime.read().unwrap().port_overrides.clone();
-    let settings = state.settings.read().unwrap();
+    let overrides = state.runtime.read().port_overrides.clone();
+    let settings = state.settings.read();
     if let Some(repo) = settings.repos.iter().find(|r| r.id == repo_id) {
         for s in &repo.services {
             if let Some(bp) = s.base_port {
@@ -227,13 +227,12 @@ pub fn worktree_vars(app: &AppHandle, repo_id: &str, wt_key: &str, is_main: bool
 /// refreshed separately. Emits `tree:changed`.
 pub async fn refresh_tree(app: &AppHandle) -> Result<Vec<RepoNode>, String> {
     let state = app.state::<AppState>();
-    let repos_cfg: Vec<RepoCfg> = state.settings.read().unwrap().repos.clone();
+    let repos_cfg: Vec<RepoCfg> = state.settings.read().repos.clone();
 
     // previous git meta, preserved across rebuilds
     let prev_git: HashMap<String, GitMeta> = state
         .tree
         .read()
-        .unwrap()
         .iter()
         .flat_map(|r| r.worktrees.iter())
         .filter_map(|w| w.git.clone().map(|g| (w.wt_key.clone(), g)))
@@ -252,11 +251,11 @@ pub async fn refresh_tree(app: &AppHandle) -> Result<Vec<RepoNode>, String> {
         let mut worktrees = Vec::new();
         for wt in wts {
             let (idx, overrides) = {
-                let mut runtime = state.runtime.write().unwrap();
+                let mut runtime = state.runtime.write();
                 let idx = port_index(&mut runtime, &repo.id, &wt.path, wt.is_main);
                 (idx, runtime.port_overrides.clone())
             };
-            let statuses = state.statuses.read().unwrap();
+            let statuses = state.statuses.read();
             let services = repo
                 .services
                 .iter()
@@ -292,9 +291,9 @@ pub async fn refresh_tree(app: &AppHandle) -> Result<Vec<RepoNode>, String> {
         });
     }
 
-    *state.tree.write().unwrap() = tree.clone();
+    *state.tree.write() = tree.clone();
     {
-        let runtime = state.runtime.read().unwrap().clone();
+        let runtime = state.runtime.read().clone();
         let _ = crate::settings::save_runtime(app, &runtime);
     }
     let _ = app.emit("tree:changed", &tree);
@@ -307,7 +306,7 @@ pub async fn refresh_git_meta(app: &AppHandle, wt_path: &str) {
         let state = app.state::<AppState>();
         let mut changed = false;
         {
-            let mut tree = state.tree.write().unwrap();
+            let mut tree = state.tree.write();
             for r in tree.iter_mut() {
                 for w in r.worktrees.iter_mut() {
                     if w.wt_key == wt_path && w.git.as_ref() != Some(&meta) {
@@ -334,7 +333,7 @@ pub async fn refresh_git_meta(app: &AppHandle, wt_path: &str) {
 pub async fn refresh_all_git_meta(app: &AppHandle) {
     let paths: Vec<String> = {
         let state = app.state::<AppState>();
-        let tree = state.tree.read().unwrap();
+        let tree = state.tree.read();
         tree.iter()
             .flat_map(|r| r.worktrees.iter().map(|w| w.wt_key.clone()))
             .collect()

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -15,7 +15,7 @@ pub enum SvcStatus {
     Error,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ServiceNode {
     pub svc_key: String,
@@ -26,7 +26,7 @@ pub struct ServiceNode {
     pub status: SvcStatus,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WorktreeNode {
     pub wt_key: String,
@@ -56,7 +56,7 @@ fn env_value(wt_path: &str, key: &str) -> Option<String> {
     None
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RepoNode {
     pub repo_id: String,
@@ -348,12 +348,22 @@ pub async fn refresh_tree(app: &AppHandle) -> Result<Vec<RepoNode>, String> {
         });
     }
 
-    *state.tree.write() = tree.clone();
+    // swap in the new tree; emit only when something actually changed — the
+    // unconditional broadcast forced every window through a full JSON
+    // serialize + React reconcile once a minute even when nothing moved
+    let changed = {
+        let mut cached = state.tree.write();
+        let changed = *cached != tree;
+        *cached = tree.clone();
+        changed
+    };
     {
         let runtime = state.runtime.read().clone();
         let _ = crate::settings::save_runtime(app, &runtime);
     }
-    let _ = app.emit("tree:changed", &tree);
+    if changed {
+        let _ = app.emit("tree:changed", &tree);
+    }
     Ok(tree)
 }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -179,7 +179,7 @@ pub async fn refresh_tree(app: &AppHandle) -> Result<Vec<RepoNode>, String> {
         let wts = match git::list_worktrees(&repo.path).await {
             Ok(w) => w,
             Err(e) => {
-                eprintln!("[wtm] list_worktrees failed for {}: {e}", repo.path);
+                log::warn!("list_worktrees failed for {}: {e}", repo.path);
                 Vec::new()
             }
         };

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -386,7 +386,10 @@ pub async fn refresh_git_meta(app: &AppHandle, wt_path: &str) {
     }
 }
 
-/// Refresh git meta for every worktree (sequential; git calls are cheap).
+/// Refresh git meta for every worktree. Worktrees are independent, so the
+/// per-worktree refreshes run concurrently (chunked so a many-worktree setup
+/// doesn't fork dozens of git processes at once) — the old sequential loop
+/// could take longer than the 60s refresh interval on large repos.
 pub async fn refresh_all_git_meta(app: &AppHandle) {
     let paths: Vec<String> = {
         let state = app.state::<AppState>();
@@ -395,8 +398,18 @@ pub async fn refresh_all_git_meta(app: &AppHandle) {
             .flat_map(|r| r.worktrees.iter().map(|w| w.wt_key.clone()))
             .collect()
     };
-    for p in paths {
-        refresh_git_meta(app, &p).await;
+    for chunk in paths.chunks(6) {
+        let handles: Vec<_> = chunk
+            .iter()
+            .map(|p| {
+                let app = app.clone();
+                let p = p.clone();
+                tauri::async_runtime::spawn(async move { refresh_git_meta(&app, &p).await })
+            })
+            .collect();
+        for h in handles {
+            let _ = h.await;
+        }
     }
 }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -73,6 +73,16 @@ pub struct AppState {
     pub statuses: RwLock<HashMap<String, SvcStatus>>,
 }
 
+/// A worktree resolved to its owning repo — the answer every command needs
+/// before it can act on a `wt_key`.
+#[derive(Debug, Clone)]
+pub struct WtContext {
+    pub repo_id: String,
+    pub repo_path: String,
+    pub branch: String,
+    pub is_main: bool,
+}
+
 impl AppState {
     pub fn new(settings: Settings, runtime: RuntimeState) -> Self {
         Self {
@@ -81,6 +91,61 @@ impl AppState {
             tree: RwLock::new(Vec::new()),
             statuses: RwLock::new(HashMap::new()),
         }
+    }
+
+    // ── tree queries ──
+    //
+    // The tree is the single navigable model (repos → worktrees → services);
+    // every command used to hand-roll the same triple-nested loop with subtly
+    // different miss behavior. These are the only sanctioned lookups — they
+    // take the tree read lock briefly and return owned data, so callers never
+    // hold a lock across an await point.
+
+    /// Resolve a worktree key to its owning repo.
+    pub fn wt_context(&self, wt_key: &str) -> Option<WtContext> {
+        let tree = self.tree.read().unwrap();
+        for r in tree.iter() {
+            for w in r.worktrees.iter() {
+                if w.wt_key == wt_key {
+                    return Some(WtContext {
+                        repo_id: r.repo_id.clone(),
+                        repo_path: r.path.clone(),
+                        branch: w.branch.clone(),
+                        is_main: w.is_main,
+                    });
+                }
+            }
+        }
+        None
+    }
+
+    /// Resolve a service key to `(wt_key, repo_id, repo_path)`.
+    pub fn service_context(&self, svc_key: &str) -> Option<(String, String, String)> {
+        let tree = self.tree.read().unwrap();
+        for r in tree.iter() {
+            for w in r.worktrees.iter() {
+                if w.services.iter().any(|s| s.svc_key == svc_key) {
+                    return Some((w.wt_key.clone(), r.repo_id.clone(), r.path.clone()));
+                }
+            }
+        }
+        None
+    }
+
+    /// All service keys of one worktree.
+    pub fn wt_service_keys(&self, wt_key: &str) -> Vec<String> {
+        let tree = self.tree.read().unwrap();
+        tree.iter()
+            .flat_map(|r| r.worktrees.iter())
+            .filter(|w| w.wt_key == wt_key)
+            .flat_map(|w| w.services.iter().map(|s| s.svc_key.clone()))
+            .collect()
+    }
+
+    /// A registered repo's path by id.
+    pub fn repo_path_by_id(&self, repo_id: &str) -> Option<String> {
+        let s = self.settings.read().unwrap();
+        s.repos.iter().find(|r| r.id == repo_id).map(|r| r.path.clone())
     }
 }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -2,7 +2,7 @@ use crate::git::{self, GitMeta};
 use crate::settings::{RepoCfg, RuntimeState, Settings};
 use serde::Serialize;
 use std::collections::HashMap;
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use tauri::{AppHandle, Emitter, Manager};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -71,6 +71,40 @@ pub struct AppState {
     pub tree: RwLock<Vec<RepoNode>>,
     /// svcKey -> current status (process table lands here in Phase 4)
     pub statuses: RwLock<HashMap<String, SvcStatus>>,
+    /// wt_key -> label of the mutating operation currently holding the lease
+    /// (see `try_lease`)
+    pub ops: Mutex<HashMap<String, &'static str>>,
+}
+
+/// RAII lease for a mutating per-worktree operation. Exactly one of
+/// create/setup/remove/migrate/snapshot/restore/switch may run per worktree at
+/// a time — without this, `remove_worktree` could race `run_worktree_setup`,
+/// two creates could TOCTOU the same path, and a restore could race a
+/// snapshot. Dropped (including on panic/early return) it frees the slot.
+pub struct OpLease {
+    app: AppHandle,
+    key: String,
+}
+
+impl Drop for OpLease {
+    fn drop(&mut self) {
+        let state = self.app.state::<AppState>();
+        state.ops.lock().remove(&self.key);
+    }
+}
+
+/// Take the operation lease for `wt_key`, or fail with a conflict naming the
+/// operation already running.
+pub fn try_lease(app: &AppHandle, wt_key: &str, op: &'static str) -> Result<OpLease, crate::error::CanopyError> {
+    let state = app.state::<AppState>();
+    let mut ops = state.ops.lock();
+    if let Some(existing) = ops.get(wt_key) {
+        return Err(crate::error::CanopyError::conflict(format!(
+            "'{existing}' is already running on this worktree — wait for it to finish"
+        )));
+    }
+    ops.insert(wt_key.to_string(), op);
+    Ok(OpLease { app: app.clone(), key: wt_key.to_string() })
 }
 
 /// A worktree resolved to its owning repo — the answer every command needs
@@ -90,6 +124,7 @@ impl AppState {
             runtime: RwLock::new(runtime),
             tree: RwLock::new(Vec::new()),
             statuses: RwLock::new(HashMap::new()),
+            ops: Mutex::new(HashMap::new()),
         }
     }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -343,3 +343,31 @@ pub async fn refresh_all_git_meta(app: &AppHandle) {
         refresh_git_meta(app, &p).await;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn port_index_is_stable_and_reclaims_gaps() {
+        let mut rt = RuntimeState::default();
+        assert_eq!(port_index(&mut rt, "repo", "/main", true), 0, "main is always 0");
+        assert_eq!(port_index(&mut rt, "repo", "/wt-a", false), 1);
+        assert_eq!(port_index(&mut rt, "repo", "/wt-b", false), 2);
+        // stable across repeat calls
+        assert_eq!(port_index(&mut rt, "repo", "/wt-a", false), 1);
+        // freeing an index lets the next worktree take the first gap
+        rt.port_indices.get_mut("repo").unwrap().remove("/wt-a");
+        assert_eq!(port_index(&mut rt, "repo", "/wt-c", false), 1);
+        // separate repos have independent index spaces
+        assert_eq!(port_index(&mut rt, "other", "/wt-x", false), 1);
+    }
+
+    #[test]
+    fn effective_port_prefers_override() {
+        let mut overrides = HashMap::new();
+        assert_eq!(effective_port(&overrides, "k", 3000, 2), 3020, "derived = base + idx*10");
+        overrides.insert("k".to_string(), 4321);
+        assert_eq!(effective_port(&overrides, "k", 3000, 2), 4321, "override wins");
+    }
+}

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -112,6 +112,9 @@ pub fn release_worktree_runtime(app: &AppHandle, repo_id: &str, wt_key: &str) {
     state.statuses.write().retain(|k, _| !k.starts_with(&prefix));
     if let Some(table) = app.try_state::<crate::services::ProcTable>() {
         table.logs.lock().retain(|k, _| !k.starts_with(&prefix));
+        // close the on-disk log handles too, or a removed worktree keeps file
+        // descriptors open for the rest of the run
+        table.log_files.lock().retain(|k, _| !k.starts_with(&prefix));
     }
 }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -360,6 +360,17 @@ pub async fn refresh_tree(app: &AppHandle) -> Result<Vec<RepoNode>, String> {
         *cached = tree.clone();
         changed
     };
+    // self-heal the statuses map: a service's exit waiter can fire set_status
+    // AFTER its worktree was removed and cleaned (stop is async), re-inserting
+    // an orphan key — prune anything the rebuilt tree doesn't know.
+    {
+        let known: std::collections::HashSet<&str> = tree
+            .iter()
+            .flat_map(|r| r.worktrees.iter())
+            .flat_map(|w| w.services.iter().map(|s| s.svc_key.as_str()))
+            .collect();
+        state.statuses.write().retain(|k, _| known.contains(k.as_str()));
+    }
     {
         let runtime = state.runtime.read().clone();
         let _ = crate::settings::save_runtime(app, &runtime);
@@ -397,6 +408,21 @@ pub async fn refresh_git_meta(app: &AppHandle, wt_path: &str) {
             let _ = app.emit("worktree:git", &GitEvent { wt_key: wt_path, meta: &meta });
         }
     }
+}
+
+/// Full refresh (tree + git meta), collapsed under an in-flight guard: the
+/// 60s loop, the tray catch-up paths and show_main_window can all fire at
+/// once (tray click + window show is exactly that), and each full refresh is
+/// 2 git spawns per worktree — no reason to run three copies concurrently.
+pub async fn refresh_all(app: &AppHandle) {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    static IN_FLIGHT: AtomicBool = AtomicBool::new(false);
+    if IN_FLIGHT.swap(true, Ordering::AcqRel) {
+        return; // one is already running and will pick up the same state
+    }
+    let _ = refresh_tree(app).await;
+    refresh_all_git_meta(app).await;
+    IN_FLIGHT.store(false, Ordering::Release);
 }
 
 /// Refresh git meta for every worktree. Worktrees are independent, so the

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -93,6 +93,28 @@ impl Drop for OpLease {
     }
 }
 
+/// Release everything runtime-side that belongs to a removed worktree: its
+/// port index (so the slot is reclaimed and derived ports stop creeping up),
+/// its port overrides, its statuses, and its in-memory log buffers. Persists
+/// the runtime file. Idempotent.
+pub fn release_worktree_runtime(app: &AppHandle, repo_id: &str, wt_key: &str) {
+    let state = app.state::<AppState>();
+    let prefix = format!("{wt_key}::");
+    let runtime = {
+        let mut rt = state.runtime.write();
+        if let Some(map) = rt.port_indices.get_mut(repo_id) {
+            map.remove(wt_key);
+        }
+        rt.port_overrides.retain(|k, _| !k.starts_with(&prefix));
+        rt.clone()
+    };
+    let _ = crate::settings::save_runtime(app, &runtime);
+    state.statuses.write().retain(|k, _| !k.starts_with(&prefix));
+    if let Some(table) = app.try_state::<crate::services::ProcTable>() {
+        table.logs.lock().retain(|k, _| !k.starts_with(&prefix));
+    }
+}
+
 /// Take the operation lease for `wt_key`, or fail with a conflict naming the
 /// operation already running.
 pub fn try_lease(app: &AppHandle, wt_key: &str, op: &'static str) -> Result<OpLease, crate::error::CanopyError> {

--- a/src-tauri/src/stats.rs
+++ b/src-tauri/src/stats.rs
@@ -33,7 +33,7 @@ pub fn spawn_stats_task(app: AppHandle) {
             // enumerating every process on the machine 30×/min is the app's
             // steady-state CPU cost — skip it while nothing is on screen
             // (the stats card can't be seen from the tray)
-            if !crate::any_window_visible(&app) {
+            if !crate::windows_visible() {
                 continue;
             }
 

--- a/src-tauri/src/stats.rs
+++ b/src-tauri/src/stats.rs
@@ -30,6 +30,13 @@ pub fn spawn_stats_task(app: AppHandle) {
         loop {
             tokio::time::sleep(POLL).await;
 
+            // enumerating every process on the machine 30×/min is the app's
+            // steady-state CPU cost — skip it while nothing is on screen
+            // (the stats card can't be seen from the tray)
+            if !crate::any_window_visible(&app) {
+                continue;
+            }
+
             let tracked: Vec<(String, u32, u64)> = {
                 let table = app.state::<ProcTable>();
                 let procs = table.procs.lock();

--- a/src-tauri/src/stats.rs
+++ b/src-tauri/src/stats.rs
@@ -78,7 +78,9 @@ pub fn spawn_stats_task(app: AppHandle) {
                     uptime_sec: uptime,
                 });
             }
-            let _ = app.emit("service:stats", &StatsEvent { entries });
+            let _ = app.emit_filter("service:stats", &StatsEvent { entries }, |t| {
+                matches!(t, tauri::EventTarget::WebviewWindow { label } if label == "main")
+            });
         }
     });
 }

--- a/src-tauri/src/stats.rs
+++ b/src-tauri/src/stats.rs
@@ -32,7 +32,7 @@ pub fn spawn_stats_task(app: AppHandle) {
 
             let tracked: Vec<(String, u32, u64)> = {
                 let table = app.state::<ProcTable>();
-                let procs = table.procs.lock().unwrap();
+                let procs = table.procs.lock();
                 procs
                     .iter()
                     .map(|(k, p)| (k.clone(), p.pid, p.started_at.elapsed().as_secs()))

--- a/src-tauri/src/suite.rs
+++ b/src-tauri/src/suite.rs
@@ -28,12 +28,12 @@ fn port_bound(port: u32) -> bool {
 
 fn proc_running(app: &AppHandle, key: &str) -> bool {
     let t = app.state::<services::ProcTable>();
-    let p = t.procs.lock().unwrap();
+    let p = t.procs.lock();
     p.contains_key(key)
 }
 fn log_count(app: &AppHandle, key: &str) -> usize {
     let t = app.state::<services::ProcTable>();
-    let l = t.logs.lock().unwrap();
+    let l = t.logs.lock();
     l.get(key).map(|b| b.len()).unwrap_or(0)
 }
 
@@ -46,7 +46,7 @@ pub fn run(app: AppHandle, repo_id: String) {
         // ── Case 1: discovery + git meta ──
         let (repo_path, worktrees): (String, Vec<(String, String, bool, bool)>) = {
             let st = app.state::<state::AppState>();
-            let tree = st.tree.read().unwrap();
+            let tree = st.tree.read();
             match tree.iter().find(|r| r.repo_id == repo_id) {
                 None => {
                     fail("discovery", format!("repo '{repo_id}' not in tree"));
@@ -88,7 +88,7 @@ pub fn run(app: AppHandle, repo_id: String) {
             .find(|w| {
                 let port = {
                     let st = app.state::<state::AppState>();
-                    let tree = st.tree.read().unwrap();
+                    let tree = st.tree.read();
                     tree.iter()
                         .flat_map(|r| r.worktrees.iter())
                         .filter(|x| x.wt_key == w.0)
@@ -109,7 +109,7 @@ pub fn run(app: AppHandle, repo_id: String) {
                 let svc_key = format!("{wt_key}::frontend");
                 let port = {
                     let st = app.state::<state::AppState>();
-                    let tree = st.tree.read().unwrap();
+                    let tree = st.tree.read();
                     tree.iter()
                         .flat_map(|r| r.worktrees.iter())
                         .flat_map(|w| w.services.iter())
@@ -221,7 +221,7 @@ pub fn run(app: AppHandle, repo_id: String) {
                         let gone = !std::path::Path::new(wt_path).exists();
                         let in_tree = {
                             let st = app.state::<state::AppState>();
-                            let tree = st.tree.read().unwrap();
+                            let tree = st.tree.read();
                             tree.iter().flat_map(|r| r.worktrees.iter()).any(|w| &w.wt_key == wt_path)
                         };
                         if gone && !in_tree {
@@ -265,7 +265,7 @@ pub fn run(app: AppHandle, repo_id: String) {
                     let svc_key = format!("{wt_path}::frontend");
                     let port = {
                         let st = app.state::<state::AppState>();
-                        let tree = st.tree.read().unwrap();
+                        let tree = st.tree.read();
                         tree.iter().flat_map(|r| r.worktrees.iter()).flat_map(|w| w.services.iter())
                             .find(|s| s.svc_key == svc_key).and_then(|s| s.port).unwrap_or(0)
                     };

--- a/src-tauri/src/suite.rs
+++ b/src-tauri/src/suite.rs
@@ -240,8 +240,10 @@ pub fn run(app: AppHandle, repo_id: String) {
 
         // ── Case 7: dirty report on the main checkout ──
         if let Some((wt_key, branch, _, _)) = worktrees.first() {
-            let report = crate::git::dirty_report(wt_key).await;
-            pass("dirty-report", format!("{branch}: dirty={} ({} entries)", report.dirty, report.details.len()));
+            match crate::git::dirty_report(wt_key).await {
+                Ok(report) => pass("dirty-report", format!("{branch}: dirty={} ({} of {} shown)", report.dirty, report.details.len(), report.total)),
+                Err(e) => fail("dirty-report", format!("{branch}: {e}")),
+            }
         }
 
         // ── Case 8 (WTM_SUITE_FULL=1): the user's exact path —

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -411,7 +411,7 @@ pub fn sweep_orphans(app: &AppHandle) {
         }
         let alive = unsafe { libc::killpg(o.pgid, 0) == 0 };
         if alive && crate::services::proc_start_time_matches(o.pgid as u32, o.spawn_time_secs) {
-            eprintln!("[wtm] sweeping terminal orphan pgid {} ({})", o.pgid, o.id);
+            log::warn!("sweeping terminal orphan pgid {} ({})", o.pgid, o.id);
             unsafe {
                 libc::killpg(o.pgid, libc::SIGTERM);
             }

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -105,6 +105,14 @@ pub struct BufferSnapshot {
     pub seq: u64,
 }
 
+
+/// Terminal bytes go to the windows that render terminals: the main window
+/// and detached `term-*` windows — never the popover.
+fn terminal_windows(t: &tauri::EventTarget) -> bool {
+    matches!(t, tauri::EventTarget::WebviewWindow { label }
+        if label == "main" || label.starts_with("term-"))
+}
+
 fn b64(bytes: &[u8]) -> String {
     base64::engine::general_purpose::STANDARD.encode(bytes)
 }
@@ -254,7 +262,7 @@ pub fn open(
                         }
                     }
                     if ours {
-                        let _ = app.emit("terminal:data", &DataEvent { id: &id, data: b64(chunk), seq });
+                        let _ = app.emit_filter("terminal:data", &DataEvent { id: &id, data: b64(chunk), seq }, terminal_windows);
                     }
                 }
                 Err(_) => break,
@@ -290,7 +298,7 @@ pub fn open(
         };
         if removed {
             persist_orphans(&app);
-            let _ = app.emit("terminal:exit", &ExitEvent { id: &id });
+            let _ = app.emit_filter("terminal:exit", &ExitEvent { id: &id }, terminal_windows);
         }
     });
 

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -35,7 +35,10 @@ const READ_CHUNK: usize = 32 * 1024;
 
 pub struct PtySession {
     master: Box<dyn MasterPty + Send>,
-    writer: Box<dyn Write + Send>,
+    /// Behind its own Arc<Mutex> so a write blocked by a stalled child (full
+    /// PTY buffer) doesn't hold the sessions table lock — the reader thread
+    /// needs that lock to drain the master, which is what unblocks the write.
+    writer: std::sync::Arc<Mutex<Box<dyn Write + Send>>>,
     child: Box<dyn Child + Send + Sync>,
     /// raw byte scrollback, capped at SCROLLBACK_CAP
     scrollback: VecDeque<u8>,
@@ -191,7 +194,9 @@ pub fn open(
     drop(pair.slave);
 
     let mut reader = pair.master.try_clone_reader().map_err(|e| format!("reader clone failed: {e}"))?;
-    let writer = pair.master.take_writer().map_err(|e| format!("writer failed: {e}"))?;
+    let writer = std::sync::Arc::new(Mutex::new(
+        pair.master.take_writer().map_err(|e| format!("writer failed: {e}"))?,
+    ));
 
     // the child is its own session leader (the pty setsid's it), so pid == pgid
     let pgid = child.process_id().unwrap_or(0) as i32;
@@ -295,11 +300,17 @@ pub fn open(
 /// Write user input (keystrokes, or a command the UI injects such as the agent
 /// CLI) to a session.
 pub fn write(table: &TermTable, id: &str, data: &str) -> Result<(), String> {
-    let mut sessions = table.sessions.lock();
-    let sess = sessions.get_mut(id).ok_or("no such terminal")?;
-    sess.writer.write_all(data.as_bytes()).map_err(|e| e.to_string())?;
-    sess.last_activity = Instant::now();
-    sess.writer.flush().map_err(|e| e.to_string())
+    // clone the writer handle out, then release the table lock BEFORE the
+    // (potentially blocking) write — see the field comment on `writer`.
+    let writer = {
+        let mut sessions = table.sessions.lock();
+        let sess = sessions.get_mut(id).ok_or("no such terminal")?;
+        sess.last_activity = Instant::now();
+        sess.writer.clone()
+    };
+    let mut w = writer.lock();
+    w.write_all(data.as_bytes()).map_err(|e| e.to_string())?;
+    w.flush().map_err(|e| e.to_string())
 }
 
 /// Resize a session's PTY (xterm's fit addon drives this).

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -18,7 +18,7 @@ use crate::state::AppState;
 use std::collections::{HashMap, VecDeque};
 use std::io::{Read, Write};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Mutex;
+use parking_lot::Mutex;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tauri::{AppHandle, Emitter, Manager};
 
@@ -131,13 +131,13 @@ pub fn open(
     rows: u16,
     command: Option<String>,
 ) -> Result<(), String> {
-    let mut sessions = table.sessions.lock().unwrap();
+    let mut sessions = table.sessions.lock();
     if sessions.contains_key(id) {
         return Ok(()); // already running — idempotent attach
     }
     // A restart reuses the id; the previous run's retained output would
     // otherwise be replayed as though the new process had printed it.
-    table.exited.lock().unwrap().remove(id);
+    table.exited.lock().remove(id);
 
     let pair = native_pty_system()
         .openpty(PtySize { rows, cols, pixel_width: 0, pixel_height: 0 })
@@ -230,7 +230,7 @@ pub fn open(
                     let mut seq = 0;
                     let mut ours = false;
                     if let Some(table) = app.try_state::<TermTable>() {
-                        if let Some(sess) = table.sessions.lock().unwrap().get_mut(&id) {
+                        if let Some(sess) = table.sessions.lock().get_mut(&id) {
                             // Same generation guard the exit path uses: a restart
                             // reopens this id, and bytes this (now stale) reader
                             // drains afterwards must not be appended to — or
@@ -259,14 +259,14 @@ pub fn open(
         // hasn't already replaced this id (fast reopen), else we'd delete the
         // replacement and emit a false exit.
         let removed = if let Some(table) = app.try_state::<TermTable>() {
-            let mut sessions = table.sessions.lock().unwrap();
+            let mut sessions = table.sessions.lock();
             match sessions.get(&id) {
                 Some(s) if s.generation == generation => {
                     // Keep what it printed: the UI shows an exited tab read-only
                     // until it's closed or restarted, and without this the output
                     // would die with the session the moment the process ended.
                     let sess = sessions.remove(&id).unwrap();
-                    let mut exited = table.exited.lock().unwrap();
+                    let mut exited = table.exited.lock();
                     if exited.len() >= EXITED_CAP {
                         if let Some(oldest) = exited.iter().min_by_key(|(_, b)| b.at).map(|(k, _)| k.clone()) {
                             exited.remove(&oldest);
@@ -295,7 +295,7 @@ pub fn open(
 /// Write user input (keystrokes, or a command the UI injects such as the agent
 /// CLI) to a session.
 pub fn write(table: &TermTable, id: &str, data: &str) -> Result<(), String> {
-    let mut sessions = table.sessions.lock().unwrap();
+    let mut sessions = table.sessions.lock();
     let sess = sessions.get_mut(id).ok_or("no such terminal")?;
     sess.writer.write_all(data.as_bytes()).map_err(|e| e.to_string())?;
     sess.last_activity = Instant::now();
@@ -304,7 +304,7 @@ pub fn write(table: &TermTable, id: &str, data: &str) -> Result<(), String> {
 
 /// Resize a session's PTY (xterm's fit addon drives this).
 pub fn resize(table: &TermTable, id: &str, cols: u16, rows: u16) -> Result<(), String> {
-    let sessions = table.sessions.lock().unwrap();
+    let sessions = table.sessions.lock();
     let sess = sessions.get(id).ok_or("no such terminal")?;
     sess.master
         .resize(PtySize { rows, cols, pixel_width: 0, pixel_height: 0 })
@@ -316,14 +316,13 @@ pub fn resize(table: &TermTable, id: &str, cols: u16, rows: u16) -> Result<(), S
 /// while its worktree wasn't selected can still be read. `None` only when the id
 /// was never opened (or has since been closed).
 pub fn get_buffer(table: &TermTable, id: &str) -> Option<BufferSnapshot> {
-    if let Some(s) = table.sessions.lock().unwrap().get(id) {
+    if let Some(s) = table.sessions.lock().get(id) {
         let bytes: Vec<u8> = s.scrollback.iter().copied().collect();
         return Some(BufferSnapshot { buffer: b64(&bytes), seq: s.seq });
     }
     table
         .exited
         .lock()
-        .unwrap()
         .get(id)
         .map(|b| BufferSnapshot { buffer: b64(&b.scrollback), seq: b.seq })
 }
@@ -331,10 +330,10 @@ pub fn get_buffer(table: &TermTable, id: &str) -> Option<BufferSnapshot> {
 /// Kill and drop a session, including any retained output — closing a tab is the
 /// point at which the user is done with it.
 pub fn close(table: &TermTable, id: &str) {
-    if let Some(mut sess) = table.sessions.lock().unwrap().remove(id) {
+    if let Some(mut sess) = table.sessions.lock().remove(id) {
         let _ = sess.child.kill();
     }
-    table.exited.lock().unwrap().remove(id);
+    table.exited.lock().remove(id);
 }
 
 /// Close a session and refresh the persisted orphan list (command path).
@@ -347,11 +346,11 @@ pub fn close_and_persist(app: &AppHandle, table: &TermTable, id: &str) {
 /// no shell/agent lingers with no UI to stop it).
 pub fn close_worktree(app: &AppHandle, table: &TermTable, wt_key: &str) {
     let prefix = format!("{wt_key}::");
-    let ids: Vec<String> = table.sessions.lock().unwrap().keys().filter(|k| k.starts_with(&prefix)).cloned().collect();
+    let ids: Vec<String> = table.sessions.lock().keys().filter(|k| k.starts_with(&prefix)).cloned().collect();
     for id in &ids {
         close(table, id);
     }
-    table.exited.lock().unwrap().retain(|k, _| !k.starts_with(&prefix));
+    table.exited.lock().retain(|k, _| !k.starts_with(&prefix));
     if !ids.is_empty() {
         persist_orphans(app);
     }
@@ -359,11 +358,11 @@ pub fn close_worktree(app: &AppHandle, table: &TermTable, wt_key: &str) {
 
 /// Kill every session (app quit).
 pub fn close_all(table: &TermTable) {
-    let mut sessions = table.sessions.lock().unwrap();
+    let mut sessions = table.sessions.lock();
     for (_, mut sess) in sessions.drain() {
         let _ = sess.child.kill();
     }
-    table.exited.lock().unwrap().clear();
+    table.exited.lock().clear();
 }
 
 /// Snapshot live sessions' pgids into persisted runtime state, so a crash can be
@@ -375,13 +374,12 @@ fn persist_orphans(app: &AppHandle) {
     let orphans: Vec<TermOrphan> = table
         .sessions
         .lock()
-        .unwrap()
         .iter()
         .map(|(id, s)| TermOrphan { id: id.clone(), pgid: s.pgid, spawn_time_secs: s.started_unix })
         .collect();
     let state = app.state::<AppState>();
     let runtime = {
-        let mut rt = state.runtime.write().unwrap();
+        let mut rt = state.runtime.write();
         rt.terminal_orphans = orphans;
         rt.clone()
     };
@@ -402,7 +400,7 @@ pub fn sweep_orphans(_app: &AppHandle) {}
 pub fn sweep_orphans(app: &AppHandle) {
     let orphans = {
         let state = app.state::<AppState>();
-        let rt = state.runtime.read().unwrap();
+        let rt = state.runtime.read();
         rt.terminal_orphans.clone()
     };
     for o in &orphans {
@@ -419,7 +417,7 @@ pub fn sweep_orphans(app: &AppHandle) {
     }
     let state = app.state::<AppState>();
     let runtime = {
-        let mut rt = state.runtime.write().unwrap();
+        let mut rt = state.runtime.write();
         rt.terminal_orphans.clear();
         rt.clone()
     };
@@ -431,7 +429,7 @@ pub fn sweep_orphans(app: &AppHandle) {
 /// `terminal:exit`. Agent sessions are exempt — a quiet agent may just be
 /// waiting for the user, and killing it would lose work.
 pub fn sweep_idle(table: &TermTable) {
-    let mut sessions = table.sessions.lock().unwrap();
+    let mut sessions = table.sessions.lock();
     for (id, sess) in sessions.iter_mut() {
         if kind_of(id) == "shell" && sess.last_activity.elapsed() > IDLE_LIMIT {
             let _ = sess.child.kill();

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -261,7 +261,13 @@ pub fn open(
                             }
                         }
                     }
-                    if ours {
+                    // Skip the emit while nothing is on screen: base64 + JSON +
+                    // waking a hidden webview per chunk is pure waste. The
+                    // scrollback + seq advanced above regardless, and the UI
+                    // resyncs from the snapshot on show / on the next chunk's
+                    // seq-gap check — the same race-free cursor rehydrate
+                    // mechanism it already uses on mount.
+                    if ours && crate::windows_visible() {
                         let _ = app.emit_filter("terminal:data", &DataEvent { id: &id, data: b64(chunk), seq }, terminal_windows);
                     }
                 }

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -14,6 +14,9 @@ use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize}
 use serde::Serialize;
 #[cfg(unix)]
 use crate::settings::TermOrphan;
+// only the Unix orphan persist/sweep reads app state — on Windows the Job
+// Object reaps the tree, so both are stubs and this import would be unused
+#[cfg(unix)]
 use crate::state::AppState;
 use std::collections::{HashMap, VecDeque};
 use std::io::{Read, Write};

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -464,7 +464,28 @@ pub fn sweep_idle(table: &TermTable) {
 
 #[cfg(test)]
 mod tests {
-    use super::kind_of;
+    use super::{b64, kind_of};
+
+    /// TerminalPane detects missed chunks (emits skipped while hidden) by
+    /// computing each chunk's decoded length WITHOUT decoding it:
+    /// `len/4*3 - padding`. That formula is only correct while this encoder
+    /// emits standard, unwrapped base64 — pin the contract on the Rust side
+    /// so a future encoder change can't silently break the frontend gap math.
+    #[test]
+    fn b64_length_formula_matches_frontend_gap_math() {
+        for n in 0..=9usize {
+            let s = b64(&vec![0xAB; n]);
+            assert!(!s.contains('\n') && !s.contains('\r'), "must be unwrapped: {s:?}");
+            let pad = if s.ends_with("==") {
+                2
+            } else if s.ends_with('=') {
+                1
+            } else {
+                0
+            };
+            assert_eq!(s.len() / 4 * 3 - pad, n, "n={n} s={s}");
+        }
+    }
 
     #[test]
     fn kind_of_reads_multi_session_ids() {

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -426,6 +426,19 @@ pub fn sweep_orphans(app: &AppHandle) {
     let _ = crate::settings::save_runtime(app, &runtime);
 }
 
+/// Sweep idle SHELL sessions (bounds long-run resource growth). Killing the
+/// child makes its reader hit EOF, which removes the session and emits
+/// `terminal:exit`. Agent sessions are exempt — a quiet agent may just be
+/// waiting for the user, and killing it would lose work.
+pub fn sweep_idle(table: &TermTable) {
+    let mut sessions = table.sessions.lock().unwrap();
+    for (id, sess) in sessions.iter_mut() {
+        if kind_of(id) == "shell" && sess.last_activity.elapsed() > IDLE_LIMIT {
+            let _ = sess.child.kill();
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::kind_of;
@@ -441,18 +454,5 @@ mod tests {
         assert_eq!(kind_of("/Users/me/wt/feature::agent"), "agent");
         assert_eq!(kind_of("/Users/me/wt/feature::shell"), "shell");
         assert_eq!(kind_of("nonsense"), "nonsense");
-    }
-}
-
-/// Sweep idle SHELL sessions (bounds long-run resource growth). Killing the
-/// child makes its reader hit EOF, which removes the session and emits
-/// `terminal:exit`. Agent sessions are exempt — a quiet agent may just be
-/// waiting for the user, and killing it would lose work.
-pub fn sweep_idle(table: &TermTable) {
-    let mut sessions = table.sessions.lock().unwrap();
-    for (id, sess) in sessions.iter_mut() {
-        if kind_of(id) == "shell" && sess.last_activity.elapsed() > IDLE_LIMIT {
-            let _ = sess.child.kill();
-        }
     }
 }

--- a/src-tauri/src/toolchain.rs
+++ b/src-tauri/src/toolchain.rs
@@ -180,6 +180,54 @@ fn find_git_bash() -> Option<String> {
     None
 }
 
+/// PATH as a login shell resolves it, captured ONCE per run and unioned with
+/// the process PATH. Internal tool invocations (db CLIs) use this instead of
+/// paying profile-sourcing (nvm/asdf init: dozens of file reads + often a
+/// node exec, 300ms–1s) on every spawn. Capture failure degrades to the
+/// process PATH — which fix_path_env already promoted at startup.
+#[cfg(unix)]
+pub fn effective_path() -> String {
+    use std::sync::OnceLock;
+    static PATH: OnceLock<String> = OnceLock::new();
+    PATH.get_or_init(|| {
+        let cur = std::env::var("PATH").unwrap_or_default();
+        let captured = std::process::Command::new(user_shell())
+            .args(["-l", "-c", "printf %s \"$PATH\""])
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+            .filter(|s| !s.is_empty());
+        match captured {
+            Some(c) if c != cur && !cur.is_empty() => format!("{c}:{cur}"),
+            Some(c) => c,
+            None => cur,
+        }
+    })
+    .clone()
+}
+
+#[cfg(windows)]
+pub fn effective_path() -> String {
+    std::env::var("PATH").unwrap_or_default()
+}
+
+/// Fast non-login shell for INTERNAL tool invocations — command lines Canopy
+/// composes itself (psql/pg_dump/pg_restore/createdb/dropdb), which are pure
+/// POSIX and need only PATH (see `effective_path`). User-authored commands
+/// (services, setup, custom, reset) MUST keep `shell_argv`'s login shell:
+/// their PATH and functions may come from profile files.
+pub fn fast_shell_argv(cmdline: &str) -> (String, Vec<String>) {
+    // Windows: Git Bash without `-l` skips /etc/profile + ~/.bash_profile —
+    // same speedup, same POSIX syntax. Unix: /bin/sh is fine because the
+    // composed lines avoid bashisms (no pipefail — see db.rs).
+    #[cfg(target_os = "windows")]
+    let shell = user_shell();
+    #[cfg(not(target_os = "windows"))]
+    let shell = "/bin/sh".to_string();
+    (shell, vec!["-c".into(), cmdline.to_string()])
+}
+
 /// Build `(shell, argv)` to run `cmdline` through the user's shell. Flags are
 /// chosen per shell family: pass `-l` and `-c` as *separate* args so fish parses
 /// them (it rejects the combined `-lc`), and drop `-l` for plain `sh`/`dash`

--- a/src-tauri/src/toolchain.rs
+++ b/src-tauri/src/toolchain.rs
@@ -256,7 +256,58 @@ pub fn sh_quote(s: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{sh_quote, shell_argv};
+    use super::{fast_shell_argv, sh_quote, shell_argv};
+
+    /// The fast path's whole contract: `-c` yes, `-l` NEVER (skipping profile
+    /// init is the point), command last.
+    #[test]
+    fn fast_shell_argv_skips_login_flag() {
+        let (shell, args) = fast_shell_argv("echo hi");
+        assert!(!args.iter().any(|a| a == "-l"), "must not source profiles: {args:?}");
+        assert!(args.contains(&"-c".to_string()));
+        assert_eq!(args.last().unwrap(), "echo hi");
+        #[cfg(not(target_os = "windows"))]
+        assert_eq!(shell, "/bin/sh");
+        let _ = shell;
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fast_shell_executes_posix() {
+        let (shell, args) = fast_shell_argv("printf %s canopy-ok");
+        let out = std::process::Command::new(shell).args(args).output().expect("spawn");
+        assert!(out.status.success());
+        assert_eq!(String::from_utf8_lossy(&out.stdout), "canopy-ok");
+    }
+
+    /// Composed db command lines must stay pure POSIX: dash (Debian/Ubuntu
+    /// /bin/sh) is the shell that killed the pipefail approach — `set` is a
+    /// special builtin and an unknown option exits the shell outright. This
+    /// pins the exact export-PATH-prefix shape db.rs generates against dash
+    /// itself (macOS ships /bin/dash too, so this runs on both CI unixes).
+    #[cfg(unix)]
+    #[test]
+    fn composed_db_line_shape_is_dash_safe() {
+        if !std::path::Path::new("/bin/dash").exists() {
+            return; // no dash on this box — the ubuntu CI job covers it
+        }
+        let line = format!("export PATH={}:\"$PATH\"; printf %s ok", sh_quote("/nonexistent dir/bin"));
+        let out = std::process::Command::new("/bin/dash").args(["-c", &line]).output().expect("spawn");
+        assert!(out.status.success(), "dash rejected the composed shape: {}", String::from_utf8_lossy(&out.stderr));
+        assert_eq!(String::from_utf8_lossy(&out.stdout), "ok");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn effective_path_is_nonempty_and_cached() {
+        let p1 = super::effective_path();
+        assert!(!p1.is_empty());
+        assert!(
+            p1.split(':').any(|d| d == "/usr/bin" || d == "/bin"),
+            "system dirs must survive the union: {p1}"
+        );
+        assert_eq!(p1, super::effective_path(), "second call must hit the cache");
+    }
 
     #[test]
     fn sh_quote_round_trips_through_the_shell() {

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -7,6 +7,7 @@ use tauri::{
 // ── macOS: the popover is a non-activating NSPanel (floats over full-screen
 //    apps, hides on blur). Elsewhere it's a regular borderless top window. ──
 #[cfg(target_os = "macos")]
+#[allow(clippy::unused_unit)] // tauri_panel!'s grammar requires `-> ()`
 mod macos_panel {
     use super::*;
     use tauri_nspanel::{

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -155,6 +155,11 @@ pub fn init(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
                     let _ = win.unminimize();
                     let _ = win.set_focus();
                 }
+                // On Linux the tray MENU is the only entry point (appindicator
+                // delivers no click events), so this — not the popover toggle —
+                // is the path back from a hidden window. Without the catch-up
+                // the user would stare at up to 60s-stale git data.
+                catch_up_refresh(app);
             }
             "quit" => app.exit(0),
             _ => {}
@@ -179,12 +184,19 @@ pub fn toggle_popover(app: &AppHandle, tray_pos: PhysicalPosition<f64>, tray_siz
         .and_then(|w| w.is_visible().ok())
         .unwrap_or(false);
     if visible {
-        let app = app.clone();
-        tauri::async_runtime::spawn(async move {
-            let _ = crate::state::refresh_tree(&app).await;
-            crate::state::refresh_all_git_meta(&app).await;
-        });
+        catch_up_refresh(app);
     }
+}
+
+/// Re-run the git refresh that the background loop skips while every window is
+/// hidden. Every path that brings a window back on screen must call this —
+/// tray click (macOS), tray menu (Linux/Windows), and `show_main_window`.
+pub(crate) fn catch_up_refresh(app: &AppHandle) {
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        let _ = crate::state::refresh_tree(&app).await;
+        crate::state::refresh_all_git_meta(&app).await;
+    });
 }
 
 /// Center the popover window under the tray icon, hanging below the menu/task

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -193,6 +193,9 @@ pub fn toggle_popover(app: &AppHandle, tray_pos: PhysicalPosition<f64>, tray_siz
 /// tray click (macOS), tray menu (Linux/Windows), and `show_main_window`.
 /// Collapses with any refresh already in flight (see `state::refresh_all`).
 pub(crate) fn catch_up_refresh(app: &AppHandle) {
+    // eager visibility hint: emit gating must not swallow the first events
+    // after a show while the 1s poll catches up
+    crate::note_window_shown();
     let app = app.clone();
     tauri::async_runtime::spawn(async move {
         crate::state::refresh_all(&app).await;

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -171,6 +171,19 @@ pub fn toggle_popover(app: &AppHandle, tray_pos: PhysicalPosition<f64>, tray_siz
     macos_panel::toggle(app, tray_pos, tray_size);
     #[cfg(not(target_os = "macos"))]
     window_popover::toggle(app, tray_pos, tray_size);
+    // if the toggle just made the popover visible, catch up on the git refresh
+    // that pauses while every window is hidden
+    let visible = app
+        .get_webview_window("popover")
+        .and_then(|w| w.is_visible().ok())
+        .unwrap_or(false);
+    if visible {
+        let app = app.clone();
+        tauri::async_runtime::spawn(async move {
+            let _ = crate::state::refresh_tree(&app).await;
+            crate::state::refresh_all_git_meta(&app).await;
+        });
+    }
 }
 
 /// Center the popover window under the tray icon, hanging below the menu/task

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -191,11 +191,11 @@ pub fn toggle_popover(app: &AppHandle, tray_pos: PhysicalPosition<f64>, tray_siz
 /// Re-run the git refresh that the background loop skips while every window is
 /// hidden. Every path that brings a window back on screen must call this —
 /// tray click (macOS), tray menu (Linux/Windows), and `show_main_window`.
+/// Collapses with any refresh already in flight (see `state::refresh_all`).
 pub(crate) fn catch_up_refresh(app: &AppHandle) {
     let app = app.clone();
     tauri::async_runtime::spawn(async move {
-        let _ = crate::state::refresh_tree(&app).await;
-        crate::state::refresh_all_git_meta(&app).await;
+        crate::state::refresh_all(&app).await;
     });
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -40,7 +40,8 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src ipc: http://ipc.localhost; object-src 'none'; base-uri 'self'; frame-src 'none'",
+      "devCsp": "default-src 'self' http://localhost:1420; script-src 'self' 'unsafe-inline' http://localhost:1420; style-src 'self' 'unsafe-inline' http://localhost:1420; img-src 'self' data: blob:; font-src 'self' data: http://localhost:1420; connect-src ipc: http://ipc.localhost http://localhost:1420 ws://localhost:1420; object-src 'none'; base-uri 'self'; frame-src 'none'"
     }
   },
   "bundle": {

--- a/src/app/AgentLane.tsx
+++ b/src/app/AgentLane.tsx
@@ -5,7 +5,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { RepoNode, WorktreeNode } from "../types";
 import { laneLabel, nextTermId, useStore, type LaneSession } from "../store";
-import { hasBackend, ipc, type AgentCfg } from "../ipc";
+import { errText, hasBackend, ipc, type AgentCfg } from "../ipc";
 import { ChevLeft, ChevRight, Doc, ExpandH, Play, Plus, PopIn, PopOut, Spinner, Sparkle, Terminal as TerminalIcon, X } from "../icons";
 import TerminalPane from "./TerminalPane";
 import { ContextEditor, bodyPreview, composeAgentPrompt, composeContextMd, isBlank, runtimeFor, useWtContext } from "./WorktreeContext";
@@ -359,7 +359,7 @@ export default function AgentLane({ repo, wt }: { repo: RepoNode; wt: WorktreeNo
       openSession({ id, wtKey: wt.wtKey, kind: "agent", title, agentId: profile.id, command });
       showToast(`${title} started — ${repo.name} · ${wt.branch}`);
     } catch (e) {
-      showToast(`Agent start failed — ${String(e)}`);
+      showToast(`Agent start failed — ${errText(e)}`);
     }
   };
 

--- a/src/app/NewWorktreeModal.tsx
+++ b/src/app/NewWorktreeModal.tsx
@@ -7,7 +7,7 @@
    it seeds .canopy/context.md and later becomes the PR body. */
 import { useEffect, useMemo, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
-import { hasBackend, ipc, type Branches, type OpEvent } from "../ipc";
+import { errText, hasBackend, ipc, type Branches, type OpEvent } from "../ipc";
 import { useStore } from "../store";
 import { Alert, ChevRight, Fork, Info, Plus, Refresh, Spinner } from "../icons";
 import Modal, { Hint, Spacer } from "./canopy/Modal";
@@ -102,7 +102,7 @@ export default function NewWorktreeModal({ repoId, onClose }: { repoId: string; 
       setBranches(b);
       showToast(`Fetched — ${b.local.length} local, ${b.remote.length} remote, ${b.tags.length} tags`);
     } catch (e) {
-      setError(`Fetch failed — ${String(e)}`);
+      setError(`Fetch failed — ${errText(e)}`);
     } finally {
       setFetching(false);
     }
@@ -148,7 +148,7 @@ export default function NewWorktreeModal({ repoId, onClose }: { repoId: string; 
       select(wtPath);
       onClose();
     } catch (e) {
-      setError(String(e));
+      setError(errText(e));
     } finally {
       setBusy(false);
     }

--- a/src/app/RemoveWorktreeModal.tsx
+++ b/src/app/RemoveWorktreeModal.tsx
@@ -5,7 +5,7 @@
    branch name is typed back, because the cost here is unrecoverable work in
    private submodule clones, not just a directory. */
 import { useEffect, useState } from "react";
-import { hasBackend, ipc } from "../ipc";
+import { errText, hasBackend, ipc } from "../ipc";
 import { useStore } from "../store";
 import type { WorktreeNode } from "../types";
 import { Alert, Info, Spinner, Trash } from "../icons";
@@ -41,7 +41,7 @@ export default function RemoveWorktreeModal({ wt, onClose }: { wt: WorktreeNode;
       })
       .catch((e) => {
         setReport(null);
-        setProbeError(String(e));
+        setProbeError(errText(e));
       });
   }, [wt.wtKey]);
 
@@ -60,7 +60,7 @@ export default function RemoveWorktreeModal({ wt, onClose }: { wt: WorktreeNode;
       showToast(`Worktree removed — ${wt.branch}`);
       onClose();
     } catch (e) {
-      setError(String(e));
+      setError(errText(e));
     } finally {
       setBusy(false);
     }

--- a/src/app/RemoveWorktreeModal.tsx
+++ b/src/app/RemoveWorktreeModal.tsx
@@ -17,7 +17,7 @@ const DIRTY_CAP = 10;
 
 export default function RemoveWorktreeModal({ wt, onClose }: { wt: WorktreeNode; onClose: () => void }) {
   const showToast = useStore((s) => s.showToast);
-  const [report, setReport] = useState<{ dirty: boolean; details: string[] } | null>(null);
+  const [report, setReport] = useState<{ dirty: boolean; details: string[]; total: number } | null>(null);
   const [probeError, setProbeError] = useState<string | null>(null);
   const [deleteBranch, setDeleteBranch] = useState(false);
   const [dropDb, setDropDb] = useState(true);
@@ -27,7 +27,7 @@ export default function RemoveWorktreeModal({ wt, onClose }: { wt: WorktreeNode;
 
   useEffect(() => {
     if (!hasBackend()) {
-      setReport({ dirty: false, details: [] });
+      setReport({ dirty: false, details: [], total: 0 });
       return;
     }
     // Fail CLOSED. Treating a failed probe as "clean" would let the dialog

--- a/src/app/SettingsView.tsx
+++ b/src/app/SettingsView.tsx
@@ -14,7 +14,7 @@
 import { useEffect, useMemo, useRef, useState, type ComponentType } from "react";
 import { open as openDialog, save as saveDialog } from "@tauri-apps/plugin-dialog";
 import { getVersion } from "@tauri-apps/api/app";
-import { hasBackend, ipc, type AgentCfg, type ProvisionEntry, type ProvisionFormat, type RepoCfg, type ServiceCfg, type Settings } from "../ipc";
+import { errText, hasBackend, ipc, type AgentCfg, type ProvisionEntry, type ProvisionFormat, type RepoCfg, type ServiceCfg, type Settings } from "../ipc";
 import { useStore } from "../store";
 import Modal, { Hint, Spacer } from "./canopy/Modal";
 import {
@@ -370,7 +370,7 @@ function CommandsPage({ repo, patchRepo, markDirty, flash, selKey }: PageProps) 
   const test = (i: number, cmd: string) => {
     if (!hasBackend() || !selKey) { flash("Open a worktree to test a command"); return; }
     setRan({ i, state: "running" });
-    ipc.runCustomCommand(selKey, cmd).then(() => setRan({ i, state: "done" })).catch((e) => { setRan(null); flash(`Command failed — ${String(e)}`); });
+    ipc.runCustomCommand(selKey, cmd).then(() => setRan({ i, state: "done" })).catch((e) => { setRan(null); flash(`Command failed — ${errText(e)}`); });
   };
   return (
     <div className="sec">
@@ -1074,7 +1074,7 @@ export default function SettingsView({ onClose }: { onClose: () => void }) {
       setRepoId(added.id);
       setPage("repo-general");
       showToast("Repository added — configure it below");
-    } catch (e) { showToast(String(e)); }
+    } catch (e) { showToast(errText(e)); }
   }
 
   async function removeRepo() {
@@ -1087,7 +1087,7 @@ export default function SettingsView({ onClose }: { onClose: () => void }) {
       setRepoId(fresh.repos[0]?.id ?? "");
       setPage("general");
       showToast(`Removed ${repo.name}`);
-    } catch (e) { showToast(String(e)); }
+    } catch (e) { showToast(errText(e)); }
   }
 
   const goTo = (r: { page: PageId; label: string }) => {

--- a/src/app/SwitchBranchModal.tsx
+++ b/src/app/SwitchBranchModal.tsx
@@ -6,7 +6,7 @@
    rather than being stashed, which is occasionally what you want and
    occasionally a nasty surprise. */
 import { useEffect, useMemo, useState } from "react";
-import { hasBackend, ipc, type Branches } from "../ipc";
+import { errText, hasBackend, ipc, type Branches } from "../ipc";
 import { useStore } from "../store";
 import type { RepoNode, WorktreeNode } from "../types";
 import { Alert, Fork, Plus, Search, Spinner, Swap } from "../icons";
@@ -84,7 +84,7 @@ export default function SwitchBranchModal({
       showToast(`Switched to ${name} — dependencies reused`);
       onClose();
     } catch (e) {
-      setError(String(e));
+      setError(errText(e));
     } finally {
       setBusy(false);
     }

--- a/src/app/TerminalPane.tsx
+++ b/src/app/TerminalPane.tsx
@@ -172,6 +172,28 @@ export default function TerminalPane({
     let suppressOut = false;
     const pending: { seq: number; data: string }[] = [];
     const writeChunk = (b64: string) => termRef.current?.write(decode(b64));
+    // cumulative byte cursor of the last chunk we applied. The backend stops
+    // emitting while every window is hidden (the PTY keeps running and its
+    // scrollback keeps advancing) — a seq gap on the next event, or a stale
+    // cursor on window focus, means "resync from the snapshot".
+    let lastSeq = 0;
+    /** decoded byte length of a base64 chunk, without decoding it */
+    const b64len = (s: string) => (s.length / 4) * 3 - (s.endsWith("==") ? 2 : s.endsWith("=") ? 1 : 0);
+    const resync = async () => {
+      if (!hydrated) return; // initial hydrate owns the buffer until done
+      try {
+        const snap = await ipc.terminalGetBuffer(termId);
+        if (disposed || !termRef.current || !snap || snap.seq === lastSeq) return;
+        lastSeq = snap.seq;
+        suppressOut = true;
+        termRef.current.reset();
+        termRef.current.write(decode(snap.buffer), () => {
+          suppressOut = false;
+        });
+      } catch {
+        /* the next chunk's gap check retries */
+      }
+    };
 
     // fit only when the host is actually laid out — fitting a zero-size or
     // display:none element leaves xterm's renderer without dimensions and throws
@@ -201,8 +223,15 @@ export default function TerminalPane({
       // or the handler leaks and keeps appending after unmount.
       const u1 = await on.terminalData((e) => {
         if (e.id !== termId) return;
-        if (!hydrated) pending.push({ seq: e.seq, data: e.data });
-        else writeChunk(e.data);
+        if (!hydrated) {
+          pending.push({ seq: e.seq, data: e.data });
+        } else if (e.seq - b64len(e.data) !== lastSeq) {
+          // missed chunks (emits were skipped while hidden) — full resync
+          void resync();
+        } else {
+          writeChunk(e.data);
+          lastSeq = e.seq;
+        }
       });
       if (disposed) return u1();
       unlistenData = u1;
@@ -225,13 +254,25 @@ export default function TerminalPane({
             suppressOut = false;
           });
         }
-        for (const p of pending) if (p.seq > baseline) writeChunk(p.data);
+        lastSeq = baseline;
+        for (const p of pending)
+          if (p.seq > baseline) {
+            writeChunk(p.data);
+            lastSeq = p.seq;
+          }
         pending.length = 0;
         hydrated = true;
       } catch (err) {
         termRef.current?.write(`\r\n\x1b[31mterminal error: ${errText(err)}\x1b[0m\r\n`);
       }
     })();
+
+    // window back on screen → catch up on output emitted-nothing while hidden
+    const onVisible = () => {
+      if (!document.hidden) void resync();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    window.addEventListener("focus", onVisible);
 
     // keep the PTY sized to the widget
     const ro = new ResizeObserver(() => {
@@ -243,6 +284,8 @@ export default function TerminalPane({
 
     return () => {
       disposed = true;
+      document.removeEventListener("visibilitychange", onVisible);
+      window.removeEventListener("focus", onVisible);
       unlistenData?.();
       unlistenExit?.();
       fileLinks.dispose();

--- a/src/app/TerminalPane.tsx
+++ b/src/app/TerminalPane.tsx
@@ -10,7 +10,7 @@ import { Terminal, type IBufferLine, type ILink } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { WebLinksAddon } from "@xterm/addon-web-links";
-import { hasBackend, ipc, on } from "../ipc";
+import { errText, hasBackend, ipc, on } from "../ipc";
 import { useStore } from "../store";
 
 /** Open a URL in the user's browser (never in the app's own webview). */
@@ -117,7 +117,7 @@ export default function TerminalPane({
       // would read as output from the process and pollute copied scrollback
       new WebLinksAddon((event, uri) => {
         event?.preventDefault();
-        openExternal(uri).catch((e) => useStore.getState().showToast(`Couldn't open link — ${String(e)}`));
+        openExternal(uri).catch((e) => useStore.getState().showToast(`Couldn't open link — ${errText(e)}`));
       }),
     );
 
@@ -142,7 +142,7 @@ export default function TerminalPane({
               event?.preventDefault();
               // the :line:col tail is dropped — the editor command takes a path
               ipc.openFileInEditor(cwd, path).catch((e) => {
-                useStore.getState().showToast(`Couldn't open ${path} — ${String(e)}`);
+                useStore.getState().showToast(`Couldn't open ${path} — ${errText(e)}`);
               });
             },
           });
@@ -229,7 +229,7 @@ export default function TerminalPane({
         pending.length = 0;
         hydrated = true;
       } catch (err) {
-        termRef.current?.write(`\r\n\x1b[31mterminal error: ${String(err)}\x1b[0m\r\n`);
+        termRef.current?.write(`\r\n\x1b[31mterminal error: ${errText(err)}\x1b[0m\r\n`);
       }
     })();
 

--- a/src/app/WorktreeContext.tsx
+++ b/src/app/WorktreeContext.tsx
@@ -4,7 +4,7 @@
 // that travels with the branch is an open product question — see the handoff.
 import { Fragment, useEffect, useState, type ReactNode } from "react";
 import { Chevron, Copy, Doc, File, Info, Link as LinkIcon, Plus, Sparkle } from "../icons";
-import { hasBackend, ipc } from "../ipc";
+import { errText, hasBackend, ipc } from "../ipc";
 import type { RepoNode, WorktreeNode } from "../types";
 
 const isUrl = (s: string) => /^https?:\/\//i.test(s.trim());
@@ -18,7 +18,7 @@ async function openLink(url: string, onToast: (m: string) => void) {
       window.open(url, "_blank", "noopener");
     }
   } catch (e) {
-    onToast(`Couldn't open link — ${String(e)}`);
+    onToast(`Couldn't open link — ${errText(e)}`);
   }
 }
 
@@ -27,7 +27,7 @@ async function copyPrBody(ctx: WtContext, onToast: (m: string) => void) {
     await navigator.clipboard.writeText(composeContextMd(ctx));
     onToast("Context copied as PR body");
   } catch (e) {
-    onToast(`Couldn't copy — ${String(e)}`);
+    onToast(`Couldn't copy — ${errText(e)}`);
   }
 }
 
@@ -198,7 +198,7 @@ export function ContextEditor({
       if (isUrl(value)) openLink(value, onToast);
       else onToast("That resource is not a browser link");
     } else if (hasBackend()) {
-      ipc.openFileInEditor(wtKey, value).catch((err) => onToast(`Couldn't open file — ${String(err)}`));
+      ipc.openFileInEditor(wtKey, value).catch((err) => onToast(`Couldn't open file — ${errText(err)}`));
     } else onToast("Opening files needs the desktop app");
   };
   return (

--- a/src/app/WorktreeHeader.tsx
+++ b/src/app/WorktreeHeader.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { hasBackend, ipc, type CustomCmd } from "../ipc";
+import { errText, hasBackend, ipc, type CustomCmd } from "../ipc";
 import { useStore } from "../store";
 import type { RepoNode, SubmoduleStatus, WorktreeNode } from "../types";
 import { fmtRelTime, isLive } from "../types";
@@ -147,7 +147,7 @@ export default function WorktreeHeader({
       await ipc.runCustomCommand(wt.wtKey, cc.command);
       showToast(`${cc.label} finished — ${wt.branch}`);
     } catch (e) {
-      showToast(`${cc.label} failed — ${String(e)}`);
+      showToast(`${cc.label} failed — ${errText(e)}`);
     } finally {
       setBusyCmd(null);
     }
@@ -161,7 +161,7 @@ export default function WorktreeHeader({
       await ipc.runWorktreeSetup(wt.wtKey);
       showToast(`Setup complete — ${wt.branch}`);
     } catch (e) {
-      showToast(`Setup failed — ${String(e)}`);
+      showToast(`Setup failed — ${errText(e)}`);
     } finally {
       setSetupBusy(false);
     }
@@ -182,7 +182,7 @@ export default function WorktreeHeader({
         showToast(`✓ ${summary} — ${wt.branch}`);
         reloadSubs();
       })
-      .catch((e) => showToast(`Pull failed — ${String(e)}`))
+      .catch((e) => showToast(`Pull failed — ${errText(e)}`))
       .finally(() => setPulling(null));
   }
 
@@ -197,7 +197,7 @@ export default function WorktreeHeader({
         showToast(`✓ ${sub?.name ?? path} — ${r}`);
         reloadSubs();
       })
-      .catch((e) => showToast(`Pull failed — ${String(e)}`))
+      .catch((e) => showToast(`Pull failed — ${errText(e)}`))
       .finally(() => setPulling(null));
   }
 
@@ -211,7 +211,7 @@ export default function WorktreeHeader({
         showToast(`✓ ${sub?.name ?? path} → ${branch} · parent now shows this submodule modified`);
         reloadSubs();
       })
-      .catch((e) => showToast(`Switch failed — ${String(e)}`));
+      .catch((e) => showToast(`Switch failed — ${errText(e)}`));
   }
 
   function refetch() {
@@ -223,7 +223,7 @@ export default function WorktreeHeader({
         showToast(`✓ Fetched ${n} submodule${n === 1 ? "" : "s"}`);
         reloadSubs();
       })
-      .catch((e) => showToast(`Fetch failed — ${String(e)}`));
+      .catch((e) => showToast(`Fetch failed — ${errText(e)}`));
   }
 
   const anyRunning = wt.services.some((s) => isLive(s.status));

--- a/src/app/canopy/CommandButtons.tsx
+++ b/src/app/canopy/CommandButtons.tsx
@@ -9,7 +9,7 @@
    per-group headers only render if a group ever appears in the data. */
 import { useEffect, useRef, useState } from "react";
 import { Chevron, Play, Spinner } from "../../icons";
-import { hasBackend, ipc, type CustomCmd } from "../../ipc";
+import { errText, hasBackend, ipc, type CustomCmd } from "../../ipc";
 import { mockCustomCommands } from "../../mock";
 import { useStore } from "../../store";
 import type { WorktreeNode } from "../../types";
@@ -110,7 +110,7 @@ export default function CommandButtons({ wt }: { wt: WorktreeNode }) {
     ipc
       .runCustomCommand(wt.wtKey, c.command)
       .then(() => showToast(`${c.label} finished — ${wt.branch}`))
-      .catch((e) => showToast(`${c.label} failed — ${String(e)}`))
+      .catch((e) => showToast(`${c.label} failed — ${errText(e)}`))
       .finally(() => setBusy(false));
   };
 

--- a/src/app/canopy/DatabaseModal.tsx
+++ b/src/app/canopy/DatabaseModal.tsx
@@ -6,7 +6,7 @@
    tense and unremarkable: "Snapshot … created", "Now using tj_main". */
 import { useEffect, useState } from "react";
 import { Database, Download, Info, Refresh, Restart, Pull } from "../../icons";
-import { hasBackend, ipc } from "../../ipc";
+import { errText, hasBackend, ipc } from "../../ipc";
 import { useStore } from "../../store";
 import type { WorktreeNode } from "../../types";
 import Modal, { Hint, Spacer } from "./Modal";
@@ -42,7 +42,7 @@ export default function DatabaseModal({ wt, onClose }: { wt: WorktreeNode; onClo
       setCurrent(name);
       showToast(`Now using ${name}`);
     } catch (e) {
-      showToast(String(e));
+      showToast(errText(e));
     } finally {
       setBusy(false);
     }
@@ -75,7 +75,7 @@ export default function DatabaseModal({ wt, onClose }: { wt: WorktreeNode; onClo
                   showToast(`Snapshot ${snap.trim()} created`);
                   setSnap(null);
                 } catch (e) {
-                  showToast(String(e));
+                  showToast(errText(e));
                 } finally {
                   setBusy(false);
                 }
@@ -124,7 +124,7 @@ export default function DatabaseModal({ wt, onClose }: { wt: WorktreeNode; onClo
                 showToast("Running migration…");
                 onClose();
               } catch (e) {
-                showToast(String(e));
+                showToast(errText(e));
               }
             }}
           >
@@ -181,7 +181,7 @@ export default function DatabaseModal({ wt, onClose }: { wt: WorktreeNode; onClo
               showToast(`Exported ${current}`);
               onClose();
             } catch (e) {
-              showToast(String(e));
+              showToast(errText(e));
             }
           }}
         >
@@ -203,7 +203,7 @@ export default function DatabaseModal({ wt, onClose }: { wt: WorktreeNode; onClo
               showToast(`Restoring ${current} from file…`);
               onClose();
             } catch (e) {
-              showToast(String(e));
+              showToast(errText(e));
             }
           }}
         >

--- a/src/app/canopy/ServiceDetailModal.tsx
+++ b/src/app/canopy/ServiceDetailModal.tsx
@@ -6,7 +6,7 @@
    that fixes it stays teal, because restarting is constructive. */
 import { useMemo, useState } from "react";
 import { Alert, Info, Restart, Server, Stop } from "../../icons";
-import { hasBackend, ipc } from "../../ipc";
+import { errText, hasBackend, ipc } from "../../ipc";
 import { useStore } from "../../store";
 import { fmtUptime, type ServiceNode, type WorktreeNode } from "../../types";
 import Modal, { Hint, Spacer } from "./Modal";
@@ -72,7 +72,7 @@ export default function ServiceDetailModal({
         await ipc.setServicePort(svcKey, Number(port));
         showToast(`${svc?.name} port → ${port}`);
       } catch (e) {
-        showToast(String(e));
+        showToast(errText(e));
         return;
       }
     } else {

--- a/src/app/canopy/SetupRunnerModal.tsx
+++ b/src/app/canopy/SetupRunnerModal.tsx
@@ -6,7 +6,7 @@
    the button says what it does rather than "Hide". */
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Check, Cube, Play, Spinner } from "../../icons";
-import { hasBackend, ipc } from "../../ipc";
+import { errText, hasBackend, ipc } from "../../ipc";
 import { useStore } from "../../store";
 import type { WorktreeNode } from "../../types";
 import Modal, { Hint, Spacer } from "./Modal";
@@ -45,7 +45,7 @@ export default function SetupRunnerModal({
     }
     ipc.runWorktreeSetup(wt.wtKey).catch((e) => {
       setFailed(true);
-      showToast(`Setup failed — ${String(e)}`);
+      showToast(`Setup failed — ${errText(e)}`);
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [wt.wtKey]);

--- a/src/app/canopy/StatusBar.tsx
+++ b/src/app/canopy/StatusBar.tsx
@@ -5,7 +5,7 @@
    per-submodule control. Anchored to the control that opened it, not centred. */
 import { useEffect, useRef, useState } from "react";
 import { Bell, Chevron, Fork, Info, Pull, Search, Single, Sparkle, Split, Spinner } from "../../icons";
-import { hasBackend, ipc, type Branches } from "../../ipc";
+import { errText, hasBackend, ipc, type Branches } from "../../ipc";
 import { useStore, type LaneSession } from "../../store";
 import type { SubmoduleStatus, WorktreeNode } from "../../types";
 import { fmtRelTime } from "../../types";
@@ -193,7 +193,7 @@ function PullPop({ wt, onClose, anchor }: { wt: WorktreeNode; onClose: () => voi
         showToast(`✓ ${summary} — ${wt.branch}`);
         reload();
       })
-      .catch((e) => showToast(`Pull failed — ${String(e)}`))
+      .catch((e) => showToast(`Pull failed — ${errText(e)}`))
       .finally(() => setBusy(null));
   }
 
@@ -206,7 +206,7 @@ function PullPop({ wt, onClose, anchor }: { wt: WorktreeNode; onClose: () => voi
         showToast(`✓ ${sub.name} — ${r}`);
         reload();
       })
-      .catch((e) => showToast(`Pull failed — ${String(e)}`))
+      .catch((e) => showToast(`Pull failed — ${errText(e)}`))
       .finally(() => setBusy(null));
   }
 
@@ -219,7 +219,7 @@ function PullPop({ wt, onClose, anchor }: { wt: WorktreeNode; onClose: () => voi
         showToast(`✓ ${sub.name} → ${branch} · parent now shows this submodule modified`);
         reload();
       })
-      .catch((e) => showToast(`Switch failed — ${String(e)}`));
+      .catch((e) => showToast(`Switch failed — ${errText(e)}`));
   }
 
   return (

--- a/src/app/canopy/laneLaunch.ts
+++ b/src/app/canopy/laneLaunch.ts
@@ -13,7 +13,7 @@
    the context editor saved. Both are avoided by resolving the repo, worktree,
    agent profile and context at call time. */
 import { useCallback, useEffect, useState } from "react";
-import { hasBackend, ipc, type AgentCfg } from "../../ipc";
+import { errText, hasBackend, ipc, type AgentCfg } from "../../ipc";
 import { nextTermId, useStore } from "../../store";
 import type { RepoNode, WorktreeNode } from "../../types";
 import { composeAgentPrompt, composeContextMd, readWtContext, runtimeFor } from "../WorktreeContext";
@@ -109,7 +109,7 @@ export function useLaneLaunch(defaultRepo: RepoNode, defaultWt: WorktreeNode): L
         openSession({ id, wtKey: wt.wtKey, kind: "agent", title, agentId: profile.id, command });
         showToast(`${title} started — ${wt.branch}`);
       } catch (e) {
-        showToast(`Agent start failed — ${String(e)}`);
+        showToast(`Agent start failed — ${errText(e)}`);
       }
     },
     [agents, defaultRepo, defaultWt, openSession, profilesFor, showToast, uniqueTitle],

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -223,5 +223,39 @@ export const on = {
     listen<TerminalExitEvent>("terminal:exit", (e) => cb(e.payload)),
 };
 
+/** Structured backend error — every command rejects with `{ code, message }`. */
+export interface BackendError {
+  code:
+    | "git"
+    | "db"
+    | "setup"
+    | "process"
+    | "terminal"
+    | "config"
+    | "not_found"
+    | "invalid_input"
+    | "conflict"
+    | "internal";
+  message: string;
+}
+
+/** Human-readable message from any rejection (structured backend error, plain
+ * string from a plugin, or an Error). Use instead of `String(e)`. */
+export function errText(e: unknown): string {
+  if (e && typeof e === "object") {
+    const o = e as Record<string, unknown>;
+    if (typeof o.message === "string") return o.message;
+  }
+  return String(e);
+}
+
+/** The backend error code, when the rejection carries one. */
+export function errCode(e: unknown): BackendError["code"] | null {
+  if (e && typeof e === "object" && typeof (e as Record<string, unknown>).code === "string") {
+    return (e as BackendError).code;
+  }
+  return null;
+}
+
 /** True when running inside the Tauri webview (false in a plain browser tab). */
 export const hasBackend = () => "__TAURI_INTERNALS__" in window;

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -1,7 +1,15 @@
 // Typed IPC surface — invoke wrappers + event payloads, mirroring src-tauri.
 import { invoke } from "@tauri-apps/api/core";
-import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { type UnlistenFn } from "@tauri-apps/api/event";
+import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import type { GitMeta, LogLine, RepoNode, SubmoduleStatus, SvcStatus } from "./types";
+
+/** Window-scoped listen: registers with THIS window as the event target, so
+ * the backend can `emit_filter` high-volume events (terminal:data,
+ * service:log, service:stats) to only the windows that consume them. A
+ * broadcast `emit` still reaches window-scoped listeners. */
+const listen = <T,>(event: string, cb: (e: { payload: T }) => void): Promise<UnlistenFn> =>
+  getCurrentWebviewWindow().listen<T>(event, cb);
 
 export interface ServiceCfg {
   id: string;

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -154,7 +154,7 @@ export const ipc = {
   createWorktree: (args: { repoId: string; branch: string; base?: string; createBranch: boolean }) =>
     invoke<string>("create_worktree", { ...args, base: args.base ?? null }),
   runWorktreeSetup: (wtKey: string) => invoke<void>("run_worktree_setup", { wtKey }),
-  worktreeDirtyReport: (wtKey: string) => invoke<{ dirty: boolean; details: string[] }>("worktree_dirty_report", { wtKey }),
+  worktreeDirtyReport: (wtKey: string) => invoke<{ dirty: boolean; details: string[]; total: number }>("worktree_dirty_report", { wtKey }),
   removeWorktree: (wtKey: string, deleteBranch: boolean, dropDb: boolean) =>
     invoke<void>("remove_worktree", { wtKey, deleteBranch, dropDb }),
 };

--- a/src/onboarding/Onboarding.tsx
+++ b/src/onboarding/Onboarding.tsx
@@ -6,7 +6,7 @@
 import { useEffect, useRef, useState } from "react";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import "../styles/onboarding.css";
-import { hasBackend, ipc, type ProvisionEntry, type RepoDetection, type ServiceCfg } from "../ipc";
+import { errText, hasBackend, ipc, type ProvisionEntry, type RepoDetection, type ServiceCfg } from "../ipc";
 import { useStore } from "../store";
 import { Check, Cog, Fork, Globe, Package, Server, Spinner } from "../icons";
 
@@ -178,7 +178,7 @@ export default function Onboarding({ onClose, onCreateWorktree }: { onClose: () 
       setScanned(false);
     } catch (e) {
       setDet(null);
-      setDetErr(String(e));
+      setDetErr(errText(e));
     } finally {
       setDetecting(false);
     }
@@ -203,7 +203,7 @@ export default function Onboarding({ onClose, onCreateWorktree }: { onClose: () 
     try {
       // register the repo (idempotent — ignore "already registered")
       await ipc.addRepo(det.top).catch((e) => {
-        if (!String(e).toLowerCase().includes("already")) throw e;
+        if (!errText(e).toLowerCase().includes("already")) throw e;
       });
       const settings = await ipc.getSettings();
       const repo = settings.repos.find((r) => r.path === det.top);

--- a/src/store.ts
+++ b/src/store.ts
@@ -4,7 +4,7 @@ import { create } from "zustand";
 import type { LogLine, RepoNode, ServiceNode, SvcStats, SvcStatus, WorktreeNode } from "./types";
 import { isLive } from "./types";
 import { genLine, logTime, mockTree } from "./mock";
-import { hasBackend, ipc, on } from "./ipc";
+import { errText, hasBackend, ipc, on } from "./ipc";
 
 const LOG_CAP = 160;
 const CPU_SAMPLES = 7; // the service-detail sparkline shows seven slots
@@ -243,7 +243,7 @@ export const useStore = create<State>((set, get) => {
     setStatus(svcKey, "starting");
     ipc.serviceStart(svcKey).catch((e) => {
       setStatus(svcKey, "error");
-      showToast(String(e));
+      showToast(errText(e));
     });
   }
   function stop(svcKey: string) {
@@ -251,7 +251,7 @@ export const useStore = create<State>((set, get) => {
     const svc = findSvc(get().tree, svcKey);
     if (!svc || svc.status === "stopped") return;
     setStatus(svcKey, "stopping");
-    ipc.serviceStop(svcKey).catch((e) => showToast(String(e)));
+    ipc.serviceStop(svcKey).catch((e) => showToast(errText(e)));
   }
 
   const mock = hasBackend() ? [] : mockTree();
@@ -399,13 +399,13 @@ export const useStore = create<State>((set, get) => {
         return;
       }
       setStatus(svcKey, "stopping");
-      ipc.serviceRestart(svcKey).catch((e) => showToast(String(e)));
+      ipc.serviceRestart(svcKey).catch((e) => showToast(errText(e)));
     },
     startAll: (wtKey) => {
       if (hasBackend()) {
         const f = findWt(get().tree, wtKey);
         f?.wt.services.forEach((s) => !isLive(s.status) && setStatus(s.svcKey, "starting"));
-        ipc.worktreeStartAll(wtKey).catch((e) => showToast(String(e)));
+        ipc.worktreeStartAll(wtKey).catch((e) => showToast(errText(e)));
         return;
       }
       const f = findWt(get().tree, wtKey);
@@ -415,7 +415,7 @@ export const useStore = create<State>((set, get) => {
       if (hasBackend()) {
         const f = findWt(get().tree, wtKey);
         f?.wt.services.forEach((s) => isLive(s.status) && setStatus(s.svcKey, "stopping"));
-        ipc.worktreeStopAll(wtKey).catch((e) => showToast(String(e)));
+        ipc.worktreeStopAll(wtKey).catch((e) => showToast(errText(e)));
         return;
       }
       const f = findWt(get().tree, wtKey);
@@ -447,7 +447,7 @@ export const useStore = create<State>((set, get) => {
       }
       // resetting flag + completion arrive via reset:status events
       showToast(`Resetting database — ${label}…`);
-      ipc.resetDb(wtKey).catch((e) => showToast(String(e)));
+      ipc.resetDb(wtKey).catch((e) => showToast(errText(e)));
     },
     gitPull: (wtKey) => {
       const label = wtLabel(get().tree, wtKey);
@@ -459,7 +459,7 @@ export const useStore = create<State>((set, get) => {
       ipc
         .gitPull(wtKey)
         .then((summary) => showToast(`✓ ${summary} — ${label}`))
-        .catch((e) => showToast(`Pull failed — ${String(e)}`));
+        .catch((e) => showToast(`Pull failed — ${errText(e)}`));
     },
     openWorktree: (wtKey, where) => {
       const labels = { editor: "Opening in editor", finder: "Revealing in Finder", terminal: "Opening Terminal" };
@@ -467,10 +467,10 @@ export const useStore = create<State>((set, get) => {
       if (!hasBackend()) return;
       const call =
         where === "editor" ? ipc.openInEditor(wtKey) : where === "finder" ? ipc.revealInFinder(wtKey) : ipc.openTerminal(wtKey);
-      call.catch((e) => showToast(String(e)));
+      call.catch((e) => showToast(errText(e)));
     },
     openPort: (port) => {
-      if (hasBackend()) ipc.openPort(port).catch((e) => showToast(String(e)));
+      if (hasBackend()) ipc.openPort(port).catch((e) => showToast(errText(e)));
       else showToast(`Opening http://localhost:${port}`);
     },
     openManager: () => {


### PR DESCRIPTION
Closes #92.

Backend hardening pass: an architectural review of `src-tauri` turned into 23 prioritized fixes, then two self-review rounds that caught defects in the fixes themselves, low-spec performance work, and a safeguard test suite for every invariant introduced.

**41 tests** (was 15) · **clippy clean** with and without `--features devtools` · `--locked` reproducible · release bundle builds.

---

## Why

Review of all 5,542 lines found the hard parts done well (`proc.rs`'s Unix/Windows process-group abstraction, the generation guards, `setup.rs` refusing to clobber malformed JSON) and the weaknesses concentrated one layer up: state modeling, error handling, resource lifecycle, and paths that silently swallowed failure.

## Data-loss and correctness fixes

- **Corrupt config no longer wipes settings.** `load_json` swallowed parse errors into `Default` — a truncated `settings.json` (crash or full disk mid-write; save was a bare `fs::write`) erased every registered repo on next launch. Now: temp + fsync + rename, no-op when unchanged, and an unparseable file is quarantined to `*.json.corrupt` and logged rather than silently discarded.
- **A failed dirty probe is an error, not "clean."** `dirty_report` swallowed any git failure into `{ dirty: false }` — and that report arms `git worktree remove --force`. It now returns `Result`; the modal already failed closed on rejection.
- **Postgres failures stop being masked.** A shell pipeline reports only the last command's status, so a failed `pg_dump` feeding a tolerant `pg_restore` looked like success. The pipe now lives in Rust: both exit statuses checked, failing stage named. `.sql` restores use `ON_ERROR_STOP=1` (psql previously ran through every failure and exited 0). Restore quiesces the worktree's services first.
- **`restart_service` fails loudly.** `start_service` returns `Ok(())` for an already-tracked key, so a restart whose stop timed out silently did nothing — `switch_database`/`set_service_port` reported success while the service kept serving the old config. Now escalates to SIGKILL, then errors.
- **Real PID-recycling guard.** `proc_start_time_matches` shelled out to `ps`, discarded the result, and returned a tautology — the startup sweep could SIGTERM an unrelated process group after a reboot. Now reads the actual start time via `sysinfo` with a ±5s match, failing closed.
- **Unique repo IDs.** Lookups key on `id` while the uniqueness check was on `path`, so `~/work/tooljet` and `~/client/tooljet` collided and commands ran against the wrong repo.

## Stability

- **`parking_lot` locks** — 60+ `.lock().unwrap()` sites meant one panic while holding a lock poisoned it and every later access panicked forever, leaving a zombie window.
- **PTY write deadlock fixed** — `terminal::write` held the sessions-table mutex across a blocking `write_all`; the reader thread needed that same mutex to drain the master, which is what would unblock the write. Writer moved behind its own per-session `Arc<Mutex>`. Terminal commands are async now (`open` did openpty+spawn, `get_buffer` base64'd 256KB — both on the main thread).
- **Single-instance guard** — a second launch read the first instance's live pgids as crash orphans and SIGTERM'd its running services.
- **Per-worktree operation leases** — nothing stopped `remove_worktree` racing `run_worktree_setup`, two creates TOCTOU-ing a path, or a restore racing a snapshot. RAII lease per `wt_key`, conflicts reported with the operation in flight.
- **Full resource reclamation** — `remove_repo` was a one-line settings retain, leaving running dev servers untracked and holding ports. Port indices are now reused rather than creeping upward forever across months of churn.

## Architecture

- **Structured errors** — every command returns `Result<T, CanopyError>` serialized as `{ code, message }` (git/db/setup/process/terminal/config/not_found/invalid_input/conflict/internal), so the frontend branches on `code` instead of matching display strings. `errText()`/`errCode()` helpers replace every `String(e)` site.
- **Logging** — `tauri-plugin-log` rolling file, plus per-service on-disk logs (2MB, rotated) so a crash that scrolled past the 160-line memory ring still leaves its cause.
- **Tree query API** on `AppState` replacing ten hand-rolled triple-nested traversals with differing miss semantics; no caller holds a lock across an await.
- **Test harness gated** behind `--features devtools` — `suite.rs` plus env-var-triggered hooks (one of which panicked on malformed input) were compiled into release builds.

## Performance

- Git refresh **parallelized** (was strictly sequential; could outlast its own 60s interval) and **paused while every window is hidden**, with catch-up on all three show paths — including the Linux tray menu, the only entry point there since appindicator delivers no click events.
- `tree:changed` **diffed** before emitting — the full tree was broadcast to every window once a minute regardless.
- High-volume events **scoped** to windows that render them (`terminal:data` to main + `term-*`, logs/stats to main); frontend listeners are window-scoped.
- **No emits into hidden webviews** — a running dev server kept WebKit/WebView2 processes hot for output nobody could see. Each webview is 60–150MB, the dominant footprint on low-RAM machines. Rings/cursors/disk logs record regardless; the UI resyncs via the existing snapshot + seq-cursor mechanism.
- Log flush **80ms → 200ms** (12.5 → 5 renders/sec per noisy service during a build burst).
- **Internal Postgres CLIs skip the login shell** — every db command paid profile sourcing (nvm/asdf init, 300ms–1s) per spawn; a snapshot chained five before any data moved. Canopy-composed lines are pure POSIX and now run via `/bin/sh` with a once-per-run captured login PATH. User-authored commands deliberately keep the login shell.
- **Save is no longer blocked** on the git-meta sweep (2 spawns per worktree) — seconds of spinner for a millisecond write.
- Allocation-free log classification, cached UTC offset, held-open log file handles.

## Security

- **Real CSP.** `csp: null` meant any script injected into a webview could reach `run_custom_command`/`terminal_write` and execute as the user. Production ships `default-src 'self'`; dev gets a relaxed variant for Vite HMR.
- **Uniform containment** — every command taking a `wt_key` validates it against the registered tree, matching what `open_file_in_editor` and `setup.rs` already enforced.
- **Timeouts on every subprocess** (git 300s local / 900s network, Postgres 900s, setup steps 60min) with `kill_on_drop`. Previously not one had a timeout.

## Self-review rounds

Two passes treating the fixes themselves as suspect found four more defects, all self-inflicted:

1. **`set -o pipefail` doesn't work on dash.** `set` is a POSIX *special builtin* — an unknown option exits the shell outright, and braces + `|| true` do **not** contain it (verified: `/bin/dash` prints nothing past the guard). On Debian/Ubuntu the "fixed" snapshot path died before `pg_dump` ran. Replaced with the Rust-held pipe.
2. **The temp-file staging that replaced it** doubled a large DB's disk footprint, collided across worktrees, and stranded the half-created target on failure.
3. **Log persistence added ~5 syscalls per write** in the hot path item 20 was meant to make cheaper.
4. **Generated log filenames could exceed the 255-byte** per-component limit shared by APFS/ext4/NTFS.

Plus: refresh storms collapsed under an in-flight guard, statuses map self-heals, offset cache packed into one atomic.

## Tests (41, was 15)

Beyond the pure cores (parsers, dotenv/JSON/YAML upserts, port allocation, path containment, shell quoting), each new invariant is pinned:

- `run_piped` with **live processes**: producer exits 7 while consumer exits 0 → must name the dump stage and carry its stderr (exactly the case a pipeline reports as success).
- Composed db-line shape **executes under `/bin/dash`** — guards the POSIX-purity invariant the `/bin/sh` fast path depends on.
- `fast_shell_argv` asserts `-l` is **absent** (skipping profile init *is* the optimization).
- `b64` emits unwrapped base64 matching the `len/4*3 − padding` formula the frontend's seq-gap detection computes without decoding.
- **Real-git integration**: full worktree lifecycle (list/is_main, meta clean↔dirty, create on new branch, dirty counting, remove + branch deletion), `switch_branch` both paths, and `dirty_report` erroring on a broken repo.
- Settings round-trip + corrupt-file quarantine; offset packing at ±14h; PID-recycling guard.

CI now runs `cargo clippy --all-targets --features devtools -- -D warnings` on all three OSes, and both git dependencies are rev-pinned (`fix-path-env` had no pin at all).

---

## ⚠️ Needs verification before merge

1. **The production CSP has never been executed in a browser.** (Tracked for automation in #93.) `cargo check` cannot validate it and `tauri dev` exercises the *devCsp*, not the shipped one. Needs a `tauri build` + launch of the bundle with devtools open. Failure mode is a blank window; the fix would be a one-line `connect-src`/`script-src` widening. A release bundle builds and signs cleanly, but has not been launched.
2. **This PR is the first time these tests run on Linux and Windows** — CI only triggers on `main` pushes and PRs. Of particular interest: the new real-git integration tests on NTFS, the dash-safety test on actual Debian, and the Windows `cfg` compile of the `LogSink` rotation rename and the `ChildStdout → Stdio` conversion.
3. **Terminal resync after hidden output** deserves one manual look — hide the window while an agent prints, wait, re-show. The mechanism is the proven snapshot+cursor path, but the visual (clear and repaint) is new.

## Known-open, deliberately out of scope

Catalogued during review, not in the 1–23 list: Windows `open_terminal` builds an unquoted `cmd /C start …` (breaks on paths with spaces); dotenv values written unquoted; `export KEY=` handled in `setup.rs` but not `db.rs`/`state.rs`; `Settings.version` never read (no migration path); service "Running" means spawned, not listening; `sanitize_branch` collides `feature/foo` with `feature_foo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7F8Evug5KJBZPGYaksYYn
