### PR TITLE
UI stability: dropdown focus, repo-filter chrome, DB command settings, input focus

### DIFF
--- a/src/app/SettingsView.tsx
+++ b/src/app/SettingsView.tsx
@@ -373,6 +373,16 @@ function CommandsPage({ repo, patchRepo, markDirty, flash, selKey }: PageProps) 
     ipc.runCustomCommand(selKey, cmd).then(() => setRan({ i, state: "done" })).catch((e) => { setRan(null); flash(`Command failed — ${errText(e)}`); });
   };
   return (
+    <>
+    <div className="sec">
+      <div className="slab">Database operations<span className="n">used by “Reset database” and “Run migrations” on a worktree</span></div>
+      <div className="fgrid">
+        <span className="lb">Reset command</span>
+        <input className="inp mono" value={repo.resetDb || ""} placeholder="pnpm db:reset" spellCheck={false} onChange={(e) => { patchRepo({ resetDb: e.target.value }); markDirty("commands"); }} />
+        <span className="lb">Migrate command</span>
+        <input className="inp mono" value={repo.migrateDb || ""} placeholder="pnpm db:migrate" spellCheck={false} onChange={(e) => { patchRepo({ migrateDb: e.target.value }); markDirty("commands"); }} />
+      </div>
+    </div>
     <div className="sec">
       <div className="slab">Custom commands<span className="n">launchers in the agent lane's + menu</span></div>
       {cmds.length === 0 ? (
@@ -422,6 +432,7 @@ function CommandsPage({ repo, patchRepo, markDirty, flash, selKey }: PageProps) 
         <button className="btn" style={{ marginTop: 8 }} onClick={() => { patchRepo({ customCommands: cmds.concat([{ label: "", command: "" }]) }); setOpen(cmds.length); markDirty("commands"); }}><Plus size={11} />Add command</button>
       )}
     </div>
+    </>
   );
 }
 

--- a/src/app/canopy/RefPick.tsx
+++ b/src/app/canopy/RefPick.tsx
@@ -72,10 +72,16 @@ export default function RefPick({
           placeholder={value || placeholder}
           spellCheck={false}
           autoFocus={autoFocus}
-          onFocus={() => setOpen(true)}
+          // Open only on an explicit click (the field wrapper) or when typing —
+          // never on bare focus, or the modal's focus trap / focus returning
+          // after a pick would re-open the menu on its own.
           onChange={(e) => {
             setQ(e.target.value);
             setOpen(true);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "ArrowDown" || e.key === "Enter") setOpen(true);
+            else if (e.key === "Escape") setOpen(false);
           }}
         />
         <Chevron size={12} />

--- a/src/styles/canopy-components.css
+++ b/src/styles/canopy-components.css
@@ -44,13 +44,13 @@
 
 /* ── Input / Select / SearchField ── */
 .cx-input{width:100%;height:var(--h-input);padding:0 var(--sp-pop);border-radius:var(--r-md);border:var(--border-w) solid var(--divider);background:var(--surface-well);color:var(--text-primary);font:var(--fs-body) var(--sans);outline:none;transition:border-color var(--dur),box-shadow var(--dur)}
-.cx-input:focus{border-color:var(--action-primary);box-shadow:0 0 0 3px var(--focus-ring)}
+.cx-input:focus{border-color:var(--action-primary)}
 .cx-input::placeholder{color:var(--text-tertiary)}
 .cx-input--mono{font-family:var(--mono);font-size:var(--fs-body)}
 textarea.cx-input{height:auto;min-height:62px;padding:var(--sp-row) var(--sp-pop);resize:vertical;line-height:var(--lh-body)}
 select.cx-input{appearance:none;cursor:pointer;background-image:linear-gradient(45deg,transparent 50%,var(--text-tertiary) 50%),linear-gradient(135deg,var(--text-tertiary) 50%,transparent 50%);background-position:calc(100% - 15px) 14px,calc(100% - 10px) 14px;background-size:5px 5px;background-repeat:no-repeat}
 .cx-search{display:flex;align-items:center;gap:var(--sp-3);height:30px;padding:0 var(--sp-row);background:var(--surface-well);border:var(--border-w) solid var(--divider);border-radius:var(--r-lg);color:var(--text-tertiary)}
-.cx-search:focus-within{border-color:var(--action-primary);box-shadow:0 0 0 3px var(--focus-ring)}
+.cx-search:focus-within{border-color:var(--action-primary)}
 .cx-search input{flex:1;background:none;border:0;outline:none;color:var(--text-primary);font:var(--fs-small) var(--sans);min-width:0}
 .cx-search input::placeholder{color:var(--text-tertiary)}
 

--- a/src/styles/canopy-settings.css
+++ b/src/styles/canopy-settings.css
@@ -119,7 +119,6 @@
 }
 .cxset-root .navsearch:focus-within {
   border-color: var(--action-primary);
-  box-shadow: 0 0 0 3px var(--focus-ring);
 }
 .cxset-root .navsearch input {
   flex: 1;
@@ -548,7 +547,6 @@
 }
 .cxset-root .inp:focus {
   border-color: var(--action-primary);
-  box-shadow: 0 0 0 3px var(--focus-ring);
 }
 .cxset-root .inp::placeholder {
   color: var(--text-tertiary);

--- a/src/styles/canopy-shell.css
+++ b/src/styles/canopy-shell.css
@@ -1953,7 +1953,6 @@
    the auto-focused field otherwise lacks (matches .cx-search) */
 .cxs-pp-search:focus-within {
   border-color: var(--action-primary);
-  box-shadow: 0 0 0 3px var(--focus-ring);
 }
 .cxs-pp-search input {
   flex: 1;

--- a/src/styles/canopy-shell.css
+++ b/src/styles/canopy-shell.css
@@ -378,16 +378,20 @@
   width: 100%;
   height: var(--h-control-xs);
   padding: 0 var(--sp-3);
-  border: 1px solid var(--divider);
-  background: var(--surface-well);
+  /* the box (border + fill) is revealed on hover / while open — at rest the
+     control reads as a plain label so it doesn't compete with the list */
+  border: 1px solid transparent;
+  background: none;
   color: var(--text-secondary);
   border-radius: var(--r-md);
   font: var(--fs-small) var(--sans);
   cursor: pointer;
-  transition: border-color var(--dur), color var(--dur);
+  transition: border-color var(--dur), background var(--dur), color var(--dur);
 }
-.cxs-repobtn:hover {
+.cxs-repobtn:hover,
+.cxs-repobtn[aria-expanded="true"] {
   border-color: var(--border-pop);
+  background: var(--surface-well);
   color: var(--text-primary);
 }
 .cxs-repobtn > svg:first-child {

--- a/src/styles/onboarding.css
+++ b/src/styles/onboarding.css
@@ -193,7 +193,6 @@
 }
 .ob-root .inp:focus {
   border-color: var(--action-primary);
-  box-shadow: 0 0 0 3px var(--focus-ring);
 }
 .ob-root .inp::placeholder {
   color: var(--text-tertiary);


### PR DESCRIPTION
Base: `onboarding-design`.

## Fixes
- **Ref dropdown opens only on intent** — `RefPick` (New worktree / Switch branch) no longer opens its menu on bare focus, which the modal's focus trap (and focus returning after a pick / on Create) was re-triggering. Opens on click / typing / ↓; closes on Esc.
- **Sidebar repository filter** shows its border + fill only on hover / while open (`aria-expanded`); at rest it reads as a plain label.
- **Settings → Commands → Database operations** — edit the repo's reset / migrate commands (`repo.resetDb` / `repo.migrateDb`). Previously `reset_db` errored *"No Reset DB command configured for this repo (Settings)"* with no UI to set it.
- **Input focus** — dropped the 3px `--focus-ring` glow; the accent border alone is the focus indicator (keyboard `:focus-visible` outline unchanged).

Closes #96.