### PR TITLE
Track whether worktree setup has ever run

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -769,6 +769,11 @@ pub async fn create_worktree(
     })
     .await;
 
+    // Record the outcome before the rescan, so the tree this create publishes
+    // already carries the marker rather than reading as unprovisioned until
+    // the next 60s refresh.
+    crate::setup::write_setup_marker(&wt_path, setup_result.is_ok());
+
     refresh_tree(&app).await.map_err(CanopyError::internal)?;
     refresh_git_meta(&app, &wt_path).await;
 
@@ -803,11 +808,15 @@ pub async fn run_worktree_setup(app: AppHandle, wt_key: String) -> Result<(), Ca
     let app3 = app.clone();
     let wt3 = wt_key.clone();
     emit_op(&app, &wt_key, "create", "progress", "running setup…");
-    match crate::setup::run_setup(&wt_key, &repo_path, &vars, move |line| {
+    let result = crate::setup::run_setup(&wt_key, &repo_path, &vars, move |line| {
         emit_op(&app3, &wt3, "create", "progress", line)
     })
-    .await
-    {
+    .await;
+    crate::setup::write_setup_marker(&wt_key, result.is_ok());
+    // the marker is part of the tree, so republish it rather than making the
+    // caller wait for the next background refresh
+    refresh_tree(&app).await.map_err(CanopyError::internal)?;
+    match result {
         Ok(()) => {
             emit_op(&app, &wt_key, "create", "done", "setup complete");
             Ok(())

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -208,6 +208,127 @@ pub fn write_repo_config(repo_path: &str, provision: &[ProvisionFile], setup: &[
     std::fs::write(&path, body + "\n").map_err(|e| e.to_string())
 }
 
+// ── the setup marker ──────────────────────────────────────────────────
+//
+// Whether a worktree has ever been provisioned is a *durable* fact about the
+// worktree, not about this run of Canopy — so it lives next to the worktree
+// (`.canopy/setup.json`) rather than in app state. That survives a restart, a
+// `get_tree` rescan, and a Canopy reinstall, and it is greppable when
+// debugging a repo by hand.
+//
+// `.canopy/` is already the worktree-local Canopy directory (see
+// `write_worktree_context`) and self-ignores via its own `.gitignore`, so the
+// marker never shows up in `git status`.
+
+/// The marker's on-disk shape. `ok` records whether the run that wrote it
+/// succeeded — a failed setup still leaves a marker, so the UI can say "last
+/// run failed" instead of the much weaker "never provisioned".
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SetupMarker {
+    /// schema version, so a future field can be added without a silent misread
+    version: u32,
+    /// unix seconds when the run finished
+    ran_at: i64,
+    ok: bool,
+}
+
+/// How we know a worktree was provisioned.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SetupSource {
+    /// read from `.canopy/setup.json` — authoritative
+    Marker,
+    /// no marker, but every declared provisioned file is already present.
+    /// Worktrees created before the marker existed land here; without this
+    /// they would all claim "never provisioned" and invite a pointless
+    /// re-install of every dependency tree on the machine.
+    Inferred,
+}
+
+/// What Canopy knows about a worktree's provisioning.
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetupState {
+    /// unix seconds of the recorded run; absent when inferred
+    pub ran_at: Option<i64>,
+    /// did the recorded run succeed (inferred state is always `true` —
+    /// the files exist, so *something* provisioned them)
+    pub ok: bool,
+    pub source: SetupSource,
+}
+
+fn marker_path(wt_path: &str) -> std::path::PathBuf {
+    Path::new(wt_path).join(".canopy").join("setup.json")
+}
+
+/// Record that setup finished for a worktree. Best-effort: setup itself
+/// already succeeded (or failed) by the time this runs, and a marker we
+/// couldn't write must never turn a good run into a reported failure — the
+/// worst case is the worktree reads as unprovisioned and offers a re-run.
+pub fn write_setup_marker(wt_path: &str, ok: bool) {
+    let dir = Path::new(wt_path).join(".canopy");
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        log::warn!("setup marker: mkdir {} failed: {e}", dir.display());
+        return;
+    }
+    // keep `.canopy/` out of git the same way write_worktree_context does,
+    // without ever truncating an existing ignore file
+    let ignore = dir.join(".gitignore");
+    if !ignore.exists() {
+        let _ = std::fs::write(&ignore, "*\n");
+    }
+    let ran_at = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    let marker = SetupMarker { version: 1, ran_at, ok };
+    match serde_json::to_string_pretty(&marker) {
+        Ok(body) => {
+            if let Err(e) = std::fs::write(marker_path(wt_path), body + "\n") {
+                log::warn!("setup marker: write failed for {wt_path}: {e}");
+            }
+        }
+        Err(e) => log::warn!("setup marker: serialize failed: {e}"),
+    }
+}
+
+/// A worktree's provisioning state plus whether its repo declares any
+/// provisioning at all — the pair the tree needs, from a single config read.
+///
+/// Called once per worktree per tree rebuild, so it stays cheap: one small
+/// read for the marker, one for the config, and — only when the marker misses
+/// — an `exists()` per declared provisioned file. No directory walks.
+///
+/// Returns `(state, configured)`. `state == None` means "never provisioned as
+/// far as Canopy can tell"; that is only actionable when `configured` is true.
+pub fn setup_status(wt_path: &str, repo_path: &str) -> (Option<SetupState>, bool) {
+    let cfg = read_config(wt_path, repo_path);
+    let configured = !cfg.provision.is_empty() || !cfg.setup.is_empty();
+
+    if let Ok(txt) = std::fs::read_to_string(marker_path(wt_path)) {
+        if let Ok(m) = serde_json::from_str::<SetupMarker>(&txt) {
+            let state = SetupState { ran_at: Some(m.ran_at), ok: m.ok, source: SetupSource::Marker };
+            return (Some(state), configured);
+        }
+        // a corrupt marker is not evidence of anything — fall through to the
+        // file-presence inference rather than trusting a half-written file
+        log::warn!("setup marker at {wt_path} is unreadable — falling back to file inference");
+    }
+
+    // No usable marker. If the repo declares provisioned files and every one
+    // of them already exists here, provisioning demonstrably happened.
+    let declared: Vec<&ProvisionFile> = cfg.provision.iter().filter(|p| !p.path.trim().is_empty()).collect();
+    if declared.is_empty() {
+        // Nothing to infer from: a setup-commands-only repo leaves no
+        // inspectable trace, so absence of a marker is all we have.
+        return (None, configured);
+    }
+    let all_present = declared.iter().all(|p| Path::new(wt_path).join(&p.path).exists());
+    let state = all_present.then_some(SetupState { ran_at: None, ok: true, source: SetupSource::Inferred });
+    (state, configured)
+}
+
 /// Stable, db-safe per-worktree identifier from the worktree folder name:
 /// lowercased, non-alphanumerics → '_'.
 pub fn wt_slug(wt_path: &str) -> String {
@@ -681,6 +802,70 @@ async fn run_commands(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn setup_marker_round_trips_and_infers_for_legacy_worktrees() {
+        let dir = std::env::temp_dir().join("canopy_setup_marker_test_xyz");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let d = dir.to_str().unwrap();
+        // a repo that declares one provisioned file + a setup command
+        std::fs::write(
+            dir.join(".worktreemanager.json"),
+            r#"{ "provision": [{"path": ".env", "format": "dotenv", "keys": {"A": "1"}}], "setup": ["echo hi"] }"#,
+        )
+        .unwrap();
+
+        // no marker, no provisioned file → never provisioned, but configured
+        let (state, configured) = setup_status(d, d);
+        assert!(state.is_none(), "no marker and no provisioned file = never ran");
+        assert!(configured, "the repo declares provisioning");
+
+        // legacy worktree: the declared file exists but no marker was ever
+        // written — inferred rather than reported as unprovisioned
+        std::fs::write(dir.join(".env"), "A=1\n").unwrap();
+        let (state, _) = setup_status(d, d);
+        let state = state.expect("presence of every declared file infers a run");
+        assert_eq!(state.source, SetupSource::Inferred);
+        assert!(state.ran_at.is_none(), "an inferred run has no timestamp");
+        assert!(state.ok);
+
+        // a real run writes the marker, which outranks the inference
+        write_setup_marker(d, true);
+        let (state, _) = setup_status(d, d);
+        let state = state.expect("marker present");
+        assert_eq!(state.source, SetupSource::Marker, "the marker wins over inference");
+        assert!(state.ran_at.unwrap() > 0, "marker carries a timestamp");
+        assert!(state.ok);
+        assert_eq!(std::fs::read_to_string(dir.join(".canopy/.gitignore")).unwrap(), "*\n", "marker dir self-ignores");
+
+        // a failed run is recorded as a failure, not as "never ran" — the UI
+        // needs to distinguish half-provisioned from untouched
+        write_setup_marker(d, false);
+        let (state, _) = setup_status(d, d);
+        assert!(!state.expect("marker present").ok, "failure is recorded");
+
+        // a corrupt marker falls back to inference rather than being trusted
+        std::fs::write(dir.join(".canopy/setup.json"), "{ truncated").unwrap();
+        let (state, _) = setup_status(d, d);
+        assert_eq!(state.expect("falls back").source, SetupSource::Inferred);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn setup_status_reports_unconfigured_repos() {
+        let dir = std::env::temp_dir().join("canopy_setup_unconfigured_test_xyz");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let d = dir.to_str().unwrap();
+        // no .worktreemanager.json at all → nothing to provision, so a missing
+        // marker must NOT read as an actionable "never provisioned"
+        let (state, configured) = setup_status(d, d);
+        assert!(state.is_none());
+        assert!(!configured, "no config = nothing to run");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     #[test]
     fn wt_slug_is_db_safe() {

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -36,6 +36,14 @@ pub struct WorktreeNode {
     pub git: Option<GitMeta>,
     /// database name from the worktree's .env (PG_DB), if present
     pub db_name: Option<String>,
+    /// what Canopy knows about this worktree's provisioning; `None` = never
+    /// provisioned as far as it can tell. Read from `.canopy/setup.json`, or
+    /// inferred from the presence of every declared provisioned file.
+    pub setup: Option<crate::setup::SetupState>,
+    /// does the owning repo declare anything to provision or run at all? A
+    /// repo with no `.worktreemanager.json` can't have "unprovisioned"
+    /// worktrees, so `setup: None` there means "nothing to do", not "act".
+    pub setup_configured: bool,
     pub services: Vec<ServiceNode>,
 }
 
@@ -332,8 +340,11 @@ pub async fn refresh_tree(app: &AppHandle) -> Result<Vec<RepoNode>, String> {
                 })
                 .collect();
 
+            let (setup, setup_configured) = crate::setup::setup_status(&wt.path, &repo.path);
             worktrees.push(WorktreeNode {
                 db_name: env_value(&wt.path, "PG_DB"),
+                setup,
+                setup_configured,
                 wt_key: wt.path.clone(),
                 git: prev_git.get(&wt.path).cloned(),
                 branch: wt.branch,

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -407,5 +407,7 @@ const EMPTY_WT: WorktreeNode = {
   isMain: false,
   git: null,
   dbName: null,
+  setup: null,
+  setupConfigured: false,
   services: [],
 };

--- a/src/app/nextAction.ts
+++ b/src/app/nextAction.ts
@@ -74,13 +74,24 @@ export function agentState(s: LaneSession): AgentState {
   return s.running ? "busy" : "idle";
 }
 
-/** True once the backend can tell us a worktree has never been provisioned.
+/** Does this worktree need provisioning before it is usable?
 
-    TODO(#53): `WorktreeNode` carries no setup record, so this is always false
-    and the "Run setup" branch below is unreachable. The engine falls through
-    to the next applicable state rather than guessing. */
-function neverSetUp(_wt: WorktreeNode): boolean {
-  return false;
+    True in exactly two cases, both of which a human must act on:
+      - the repo declares provisioning and Canopy has no record of it running
+      - the last recorded run failed, so the worktree is half-provisioned
+
+    Deliberately false when the repo declares nothing to provision (there is
+    no action to offer) and for the main checkout (it is the source the
+    worktrees are seeded *from*, not a thing Canopy provisions). */
+export function needsSetup(wt: WorktreeNode): boolean {
+  if (wt.isMain || !wt.setupConfigured) return false;
+  return wt.setup === null || !wt.setup.ok;
+}
+
+/** Why the setup action is being offered — a half-provisioned worktree is a
+    materially different situation from one that was never touched. */
+function setupWhy(wt: WorktreeNode): string {
+  return wt.setup === null ? "never provisioned" : "the last run failed";
 }
 
 export function nextAction(wt: WorktreeNode, sessions: LaneSession[]): NextAction {
@@ -117,8 +128,8 @@ export function nextAction(wt: WorktreeNode, sessions: LaneSession[]): NextActio
       sessionId: waiting.id,
     };
 
-  if (neverSetUp(wt))
-    return { id: "setup", kind: "primary", icon: Cube, label: "Run setup", why: "never provisioned", key: "⏎" };
+  if (needsSetup(wt))
+    return { id: "setup", kind: "primary", icon: Cube, label: "Run setup", why: setupWhy(wt), key: "⏎" };
 
   if (starting)
     return {
@@ -238,14 +249,13 @@ export function attentionItems(tree: RepoNode[], sessions: Record<string, LaneSe
           act: "Answer",
         });
       }
-      // TODO(#53): "Setup never run" belongs here once the backend records it.
-      if (neverSetUp(wt))
+      if (needsSetup(wt))
         out.push({
           id: `${wt.wtKey}::setup`,
           sev: 2,
           kind: "todo",
           wtKey: wt.wtKey,
-          title: "Setup never run",
+          title: wt.setup === null ? "Setup never run" : "Setup failed",
           wt: wt.branch,
           act: "Run setup",
         });

--- a/src/mock.ts
+++ b/src/mock.ts
@@ -1,6 +1,6 @@
 // Phase-2 mock backend — reproduces the prototype SEED + simulated behavior.
 // Deleted in Phase 3/4 when the Rust backend takes over via ipc.ts.
-import type { LogLine, RepoNode, ServiceNode, SvcKind } from "./types";
+import type { LogLine, RepoNode, ServiceNode, SetupState, SvcKind } from "./types";
 
 const svc = (
   wtKey: string,
@@ -13,6 +13,9 @@ const svc = (
 
 const min = 60;
 const nowS = () => Date.now() / 1000;
+
+/* A provisioned worktree, as the marker file would report it. */
+const RAN: SetupState = { ranAt: nowS() - 3 * 24 * 60 * min, ok: true, source: "marker" };
 
 /* Custom commands for the no-backend dev build, so the rail's command buttons
    render without a real settings file. Mirrors the design's CMDS seed. */
@@ -38,6 +41,8 @@ export function mockTree(): RepoNode[] {
           path: "~/code/acme-web",
           isMain: true,
           dbName: null,
+          setup: RAN,
+          setupConfigured: true,
           git: { ahead: 0, behind: 0, dirty: false, lastCommitTs: nowS() - 2 * 60 * min, lastCommitMsg: "checkout: fix tax rounding" },
           services: [
             svc("~/code/acme-web", "frontend", "Frontend", "web", 3000, "running"),
@@ -50,6 +55,8 @@ export function mockTree(): RepoNode[] {
           path: "~/code/.wt/acme-web-checkout",
           isMain: false,
           dbName: "db_2",
+          setup: RAN,
+          setupConfigured: true,
           git: { ahead: 7, behind: 2, dirty: true, lastCommitTs: nowS() - 11 * min, lastCommitMsg: "wip: express checkout drawer" },
           services: [
             svc("~/code/.wt/acme-web-checkout", "frontend", "Frontend", "web", 3010, "stopped"),
@@ -69,6 +76,8 @@ export function mockTree(): RepoNode[] {
           path: "~/code/payments-api",
           isMain: true,
           dbName: null,
+          setup: RAN,
+          setupConfigured: true,
           git: { ahead: 0, behind: 0, dirty: false, lastCommitTs: nowS() - 24 * 60 * min, lastCommitMsg: "bump stripe sdk to 14.2" },
           services: [
             svc("~/code/payments-api", "api", "API", "server", 8080, "running"),
@@ -81,6 +90,8 @@ export function mockTree(): RepoNode[] {
           path: "~/code/.wt/payments-refund",
           isMain: false,
           dbName: "db_4",
+          setup: null,
+          setupConfigured: true,
           git: { ahead: 3, behind: 0, dirty: true, lastCommitTs: nowS() - 4 * min, lastCommitMsg: "refund: idempotency key guard" },
           services: [svc("~/code/.wt/payments-refund", "api", "API", "server", 8090, "running")],
         },
@@ -97,6 +108,8 @@ export function mockTree(): RepoNode[] {
           path: "~/dev/design-system",
           isMain: true,
           dbName: null,
+          setup: null,
+          setupConfigured: false,
           git: { ahead: 1, behind: 0, dirty: false, lastCommitTs: nowS() - 5 * 60 * min, lastCommitMsg: "Button: focus ring tokens" },
           services: [svc("~/dev/design-system", "storybook", "Storybook", "web", 6006, "running")],
         },

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,20 @@ export interface GitMeta {
   lastCommitMsg: string;
 }
 
+/** How Canopy knows a worktree was provisioned. `marker` is the durable
+    `.canopy/setup.json` record; `inferred` means there was no marker but every
+    declared provisioned file is present — the back-compat path for worktrees
+    created before the marker existed. */
+export type SetupSource = "marker" | "inferred";
+
+export interface SetupState {
+  /** unix seconds of the recorded run; null when inferred */
+  ranAt: number | null;
+  /** did that run succeed */
+  ok: boolean;
+  source: SetupSource;
+}
+
 export interface WorktreeNode {
   wtKey: string;
   branch: string;
@@ -25,6 +39,10 @@ export interface WorktreeNode {
   isMain: boolean;
   git: GitMeta | null;
   dbName: string | null;
+  /** provisioning record; null = never provisioned as far as Canopy can tell */
+  setup: SetupState | null;
+  /** does the owning repo declare anything to provision or run? */
+  setupConfigured: boolean;
   services: ServiceNode[];
 }
 


### PR DESCRIPTION
Closes #53

## The problem

`nextAction()` ranks *"Setup never ran → **Run setup**"* third, above pulling and starting services, and the cross-worktree **Needs you** queue lists the same condition. Neither could be computed: `WorktreeNode` carried no setup record, so `neverSetUp()` was hardcoded `false` and the branch was permanently unreachable — the engine fell through to pull/start on a worktree that wasn't usable yet.

## Why this solution

**A marker file in the worktree (`.canopy/setup.json`), not app state.**

Whether a worktree has been provisioned is a durable fact *about the worktree*, not about this run of Canopy. Putting it next to the worktree means it survives an app restart, a `get_tree` rescan, a Canopy reinstall, and a settings wipe — and it's greppable when you're debugging a repo by hand. `.canopy/` already exists as the worktree-local Canopy directory (`write_worktree_context` uses it) and self-ignores via its own `.gitignore`, so the marker never appears in `git status`.

**The back-compat problem, and the answer.** Every worktree that exists today predates the marker. A naive implementation would have all of them announce "never provisioned" and invite a pointless re-install of every `node_modules` tree on the machine — a worse outcome than the bug being fixed. So when the marker is missing, `setup_status` falls back to a *positive* filesystem signal: if the repo declares provisioned files and every one of them is already present, provisioning demonstrably happened. That result is tagged `source: "inferred"` and carries no timestamp, so the UI never claims precision it doesn't have.

When the repo declares nothing to provision, there is nothing to infer *from* and nothing to offer — hence the separate `setupConfigured` flag, so a missing marker in an unconfigured repo stays silent instead of becoming a permanent nag.

**Failure is recorded too.** A failed run still writes a marker with `ok: false`. A half-provisioned worktree is a materially different situation from an untouched one, and the action's `why` says so ("the last run failed" vs "never provisioned").

## How it works

| | |
|---|---|
| `setup.rs` | `SetupState { ranAt, ok, source }`; `write_setup_marker()` (best-effort — a marker that can't be written never turns a good run into a reported failure) and `setup_status()` returning `(state, configured)` from a single config read |
| `state.rs` | `WorktreeNode.setup` + `.setupConfigured`, populated in `refresh_tree` |
| `commands.rs` | marker written on both paths that finish setup — `create_worktree` (inline) and `run_worktree_setup`, each before the rescan so the published tree already carries it |
| `nextAction.ts` | `neverSetUp()` → exported `needsSetup()`: true when the repo declares provisioning and there's no record, **or** the recorded run failed. False for the main checkout — it's the source worktrees are seeded *from*, not something Canopy provisions |

Cost per worktree per tree rebuild: one small marker read, one config read, and — only on a marker miss — an `exists()` per declared file. No directory walks.

## Verification

- Two new unit tests in `setup.rs` cover marker round-trip, the legacy-worktree inference, marker-beats-inference precedence, failure recording, corrupt-marker fallback, and the unconfigured-repo case.
- `cargo test` 43 passed · `cargo clippy --all-targets --features devtools -- -D warnings` clean · `tsc --noEmit` clean.
- `mock.ts` gives the refund worktree `setup: null` so the "Run setup" branch is reachable in the no-backend dev build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYXXuRwMVeF6Dv7xebjQJL