### PR TITLE
Measure per-worktree disk usage for the overview Size column

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -772,6 +772,10 @@ pub async fn create_worktree(
     refresh_tree(&app).await.map_err(CanopyError::internal)?;
     refresh_git_meta(&app, &wt_path).await;
 
+    // installing dependencies is the single biggest change a worktree's
+    // footprint ever sees — measure it now rather than serving a stale figure
+    crate::disk::request(&app, vec![wt_path.clone()], true);
+
     match setup_result {
         Ok(()) => {
             emit_op(&app, &wt_path, "create", "done", "worktree ready");
@@ -809,6 +813,7 @@ pub async fn run_worktree_setup(app: AppHandle, wt_key: String) -> Result<(), Ca
     .await
     {
         Ok(()) => {
+            crate::disk::request(&app, vec![wt_key.clone()], true);
             emit_op(&app, &wt_key, "create", "done", "setup complete");
             Ok(())
         }
@@ -1157,6 +1162,34 @@ pub fn save_repo_config(app: AppHandle, repo_id: String, provision: Vec<Provisio
     let path = repo_path(&app, &repo_id)?;
     let files: Vec<crate::setup::ProvisionFile> = provision.into_iter().map(Into::into).collect();
     crate::setup::write_repo_config(&path, &files, &setup).map_err(CanopyError::config)
+}
+
+// ── disk usage ──
+
+/// Every measurement Canopy currently holds, keyed by `wt_key`. Returns
+/// instantly from cache — a window that opens the overview gets whatever
+/// earlier scans found rather than waiting on a fresh walk.
+#[tauri::command]
+pub fn get_disk_usage(app: AppHandle) -> std::collections::HashMap<String, crate::disk::DiskUsage> {
+    crate::disk::snapshot(&app)
+}
+
+/// Queue worktrees for measurement and return immediately; results arrive as
+/// `worktree:disk` events. Unknown keys are dropped rather than walked — this
+/// is the one command that takes a caller-supplied path list, so it applies the
+/// same containment rule as every other `wt_key` entry point.
+#[tauri::command]
+pub fn scan_disk_usage(app: AppHandle, wt_keys: Vec<String>, force: bool) -> Result<(), CanopyError> {
+    let known: Vec<String> = {
+        let state = app.state::<AppState>();
+        let tree = state.tree.read();
+        wt_keys
+            .into_iter()
+            .filter(|k| tree.iter().flat_map(|r| r.worktrees.iter()).any(|w| &w.wt_key == k))
+            .collect()
+    };
+    crate::disk::request(&app, known, force);
+    Ok(())
 }
 
 /// `git fetch --all --prune` then return the refreshed branch lists.

--- a/src-tauri/src/disk.rs
+++ b/src-tauri/src/disk.rs
@@ -1,0 +1,250 @@
+// Per-worktree on-disk footprint, for the overview's Size column.
+//
+// The column answers one question: "what would I reclaim by removing this?"
+// That framing settles the two design decisions this module has to make.
+//
+// 1. WHAT IS COUNTED — everything under the worktree root, `node_modules` and
+//    build output included. Those are the bulk of the footprint and they *are*
+//    freed by removal, so excluding them would answer a question nobody asked.
+//    Ignored-by-git is irrelevant here; git has no opinion about disk.
+//
+// 2. WHEN IT RUNS — never on the UI path. A recursive walk of a few
+//    `node_modules` trees is hundreds of thousands of `stat` calls; making the
+//    overview await that would freeze it on open. So scans run on the blocking
+//    pool, one at a time, and publish `worktree:disk` when each finishes. The
+//    overview renders "—" until a result arrives and never blocks on one.
+use serde::Serialize;
+use std::collections::{HashMap, VecDeque};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use parking_lot::Mutex;
+use tauri::{AppHandle, Emitter, Manager};
+
+/// A completed measurement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiskUsage {
+    pub bytes: u64,
+    /// unix seconds — the UI shows how stale a figure is rather than implying
+    /// it is live
+    pub scanned_at: i64,
+    /// the walk hit a budget and stopped early, so `bytes` is a floor. Surfaced
+    /// rather than hidden: a number that silently under-reports is worse than
+    /// one labelled approximate.
+    pub partial: bool,
+}
+
+/// Re-scan anything older than this when a scan is requested. A worktree's size
+/// moves on the scale of installs and builds, not seconds — and each scan is
+/// genuinely expensive, so the default is deliberately lazy.
+const STALE_AFTER: Duration = Duration::from_secs(10 * 60);
+
+/// Ceilings for a single walk. A worktree containing a runaway directory (or a
+/// mount point that shouldn't have been there) must not pin a blocking thread
+/// indefinitely — the result is reported `partial` instead.
+const MAX_ENTRIES: u64 = 4_000_000;
+const MAX_WALL: Duration = Duration::from_secs(90);
+
+#[derive(Default)]
+pub struct DiskCache {
+    /// wt_key -> last completed measurement
+    usage: Mutex<HashMap<String, DiskUsage>>,
+    /// worktrees waiting to be walked, in request order
+    queue: Mutex<VecDeque<String>>,
+    /// is the single drain task alive? Scans are serialized: two concurrent
+    /// recursive walks on one disk are slower than the same two in sequence,
+    /// and they'd compete with whatever the user is actually running.
+    draining: AtomicBool,
+}
+
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct DiskEvent<'a> {
+    wt_key: &'a str,
+    #[serde(flatten)]
+    usage: DiskUsage,
+}
+
+fn now_secs() -> i64 {
+    SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs() as i64).unwrap_or(0)
+}
+
+/// Every measurement Canopy currently holds. Read by `get_disk_usage` so a
+/// window that opens the overview late gets what earlier scans already found
+/// instead of waiting for a re-scan.
+pub fn snapshot(app: &AppHandle) -> HashMap<String, DiskUsage> {
+    app.try_state::<DiskCache>().map(|c| c.usage.lock().clone()).unwrap_or_default()
+}
+
+/// Drop a worktree's measurement (it was removed, or something invalidated it).
+pub fn forget(app: &AppHandle, wt_key: &str) {
+    if let Some(cache) = app.try_state::<DiskCache>() {
+        cache.usage.lock().remove(wt_key);
+        cache.queue.lock().retain(|k| k != wt_key);
+    }
+}
+
+/// Queue `wt_keys` for measurement, skipping any whose cached figure is still
+/// fresh unless `force`. Returns immediately — results arrive as `worktree:disk`.
+pub fn request(app: &AppHandle, wt_keys: Vec<String>, force: bool) {
+    let Some(cache) = app.try_state::<DiskCache>() else { return };
+    let now = now_secs();
+    {
+        let usage = cache.usage.lock();
+        let mut queue = cache.queue.lock();
+        for key in wt_keys {
+            if queue.contains(&key) {
+                continue; // already waiting — don't walk the same tree twice
+            }
+            let fresh = !force
+                && usage
+                    .get(&key)
+                    .is_some_and(|u| now.saturating_sub(u.scanned_at) < STALE_AFTER.as_secs() as i64);
+            if !fresh {
+                queue.push_back(key);
+            }
+        }
+        if queue.is_empty() {
+            return;
+        }
+    }
+    // one drain task at a time; a second request just adds to its queue
+    if cache.draining.swap(true, Ordering::AcqRel) {
+        return;
+    }
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        loop {
+            let next = {
+                let Some(cache) = app.try_state::<DiskCache>() else { break };
+                let next = cache.queue.lock().pop_front();
+                match next {
+                    Some(k) => k,
+                    None => {
+                        // Clear the flag while still holding no queue lock, then
+                        // re-check: a request that landed between the pop and the
+                        // clear would otherwise see `draining` true and never be
+                        // drained by anyone.
+                        cache.draining.store(false, Ordering::Release);
+                        if cache.queue.lock().is_empty() {
+                            break;
+                        }
+                        if cache.draining.swap(true, Ordering::AcqRel) {
+                            break; // someone else took over
+                        }
+                        continue;
+                    }
+                }
+            };
+            let path = next.clone();
+            let measured = tauri::async_runtime::spawn_blocking(move || measure(&path)).await;
+            let Ok(usage) = measured else { continue };
+            if let Some(cache) = app.try_state::<DiskCache>() {
+                cache.usage.lock().insert(next.clone(), usage);
+            }
+            let _ = app.emit("worktree:disk", &DiskEvent { wt_key: &next, usage });
+        }
+    });
+}
+
+/// Walk `root` and total the size of every regular file beneath it.
+///
+/// Symlinks are stat'd, never followed: following them would double-count a
+/// linked package cache and could walk out of the worktree entirely (or in a
+/// cycle). The link itself contributes its own tiny size, which is what
+/// removing the worktree actually frees.
+fn measure(root: &str) -> DiskUsage {
+    let started = Instant::now();
+    let mut total: u64 = 0;
+    let mut entries: u64 = 0;
+    let mut partial = false;
+    let mut stack: Vec<PathBuf> = vec![PathBuf::from(root)];
+
+    while let Some(dir) = stack.pop() {
+        if entries >= MAX_ENTRIES || started.elapsed() > MAX_WALL {
+            partial = true;
+            break;
+        }
+        let Ok(rd) = std::fs::read_dir(&dir) else {
+            // unreadable directory (permissions, a race with a delete) — skip
+            // it rather than abandoning the whole measurement
+            continue;
+        };
+        for entry in rd.flatten() {
+            entries += 1;
+            let Ok(meta) = entry.metadata_no_follow() else { continue };
+            if meta.is_dir() {
+                stack.push(entry.path());
+            } else {
+                total += meta.len();
+            }
+        }
+    }
+
+    DiskUsage { bytes: total, scanned_at: now_secs(), partial }
+}
+
+/// `DirEntry::metadata` already does not follow symlinks on the platforms we
+/// ship, but that is a documented behaviour of the *entry*, not of the path —
+/// spelling it out here keeps the guarantee explicit and testable.
+trait NoFollow {
+    fn metadata_no_follow(&self) -> std::io::Result<std::fs::Metadata>;
+}
+
+impl NoFollow for std::fs::DirEntry {
+    fn metadata_no_follow(&self) -> std::io::Result<std::fs::Metadata> {
+        std::fs::symlink_metadata(self.path())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn measure_totals_files_recursively() {
+        let dir = std::env::temp_dir().join("canopy_disk_test_xyz");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("node_modules/pkg")).unwrap();
+        std::fs::write(dir.join("a.txt"), vec![0u8; 1000]).unwrap();
+        std::fs::write(dir.join("node_modules/pkg/index.js"), vec![0u8; 2500]).unwrap();
+
+        let u = measure(dir.to_str().unwrap());
+        assert_eq!(u.bytes, 3500, "counts nested files, node_modules included");
+        assert!(!u.partial, "a small tree completes");
+        assert!(u.scanned_at > 0, "carries a timestamp");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn measure_does_not_follow_symlinks_out_of_the_tree() {
+        let base = std::env::temp_dir().join("canopy_disk_link_test_xyz");
+        let _ = std::fs::remove_dir_all(&base);
+        let inside = base.join("wt");
+        let outside = base.join("elsewhere");
+        std::fs::create_dir_all(&inside).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        std::fs::write(inside.join("small.txt"), vec![0u8; 100]).unwrap();
+        std::fs::write(outside.join("huge.bin"), vec![0u8; 50_000]).unwrap();
+
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&outside, inside.join("link")).unwrap();
+
+        let u = measure(inside.to_str().unwrap());
+        #[cfg(unix)]
+        assert!(u.bytes < 1000, "the 50KB outside the worktree is not counted: {}", u.bytes);
+        assert!(u.bytes >= 100, "the real file inside still counts");
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn measure_survives_a_missing_root() {
+        // a worktree deleted between the request and the walk must not panic
+        let u = measure("/canopy/definitely/not/a/real/path");
+        assert_eq!(u.bytes, 0);
+        assert!(!u.partial, "nothing to walk is complete, not truncated");
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod commands;
 mod db;
+mod disk;
 mod error;
 mod git;
 mod proc;
@@ -94,6 +95,7 @@ pub fn run() {
             ));
             app.manage(ProcTable::default());
             app.manage(TermTable::default());
+            app.manage(disk::DiskCache::default());
 
             // kill process groups left over from a crashed previous run
             services::sweep_orphans(&handle);
@@ -312,6 +314,8 @@ pub fn run() {
             commands::set_service_port,
             commands::run_migration,
             commands::run_custom_command,
+            commands::get_disk_usage,
+            commands::scan_disk_usage,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -110,6 +110,9 @@ pub fn release_worktree_runtime(app: &AppHandle, repo_id: &str, wt_key: &str) {
     };
     let _ = crate::settings::save_runtime(app, &runtime);
     state.statuses.write().retain(|k, _| !k.starts_with(&prefix));
+    // a measurement for a path that no longer exists would otherwise sit in the
+    // cache forever, and be served to the overview if the path is ever reused
+    crate::disk::forget(app, wt_key);
     if let Some(table) = app.try_state::<crate::services::ProcTable>() {
         table.logs.lock().retain(|k, _| !k.starts_with(&prefix));
         // close the on-disk log handles too, or a removed worktree keeps file

--- a/src/app/canopy/Overview.tsx
+++ b/src/app/canopy/Overview.tsx
@@ -2,13 +2,25 @@
 
    Attention first, then running, then idle. Every section's table shares one
    geometry so columns align down the whole page. */
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { Alert, ChevRight, Play, Restart, SidebarIcon, Sparkle, Stop, Terminal } from "../../icons";
 import { useStore, type LaneSession } from "../../store";
 import { isLive, type RepoNode, type WorktreeNode } from "../../types";
 import { agentState, dotClass, nextAction, wtDot, type AttnItem } from "../nextAction";
 
 const EMPTY: LaneSession[] = [];
+
+/* Sizes here are read to decide what to reclaim, so the unit is the one that
+   makes that decision: whole GB below a decimal, MB under a gigabyte. A
+   worktree is 1–2 GB, and "1.4 GB" answers the question that "1,483 MB"
+   makes you do arithmetic for. */
+function fmtBytes(n: number): string {
+  const gb = n / 1024 ** 3;
+  if (gb >= 1) return `${gb.toFixed(1)} GB`;
+  const mb = n / 1024 ** 2;
+  if (mb >= 1) return `${Math.round(mb)} MB`;
+  return `${Math.max(1, Math.round(n / 1024))} KB`;
+}
 
 export default function Overview({
   attn,
@@ -28,6 +40,8 @@ export default function Overview({
   const tree = useStore((s) => s.tree);
   const sessions = useStore((s) => s.sessions);
   const stats = useStore((s) => s.stats);
+  const disk = useStore((s) => s.disk);
+  const scanDisk = useStore((s) => s.scanDisk);
   const startAll = useStore((s) => s.startAll);
   const stopAll = useStore((s) => s.stopAll);
   const showToast = useStore((s) => s.showToast);
@@ -39,6 +53,14 @@ export default function Overview({
     .flat()
     .filter((s) => s.kind === "agent" && s.running).length;
   const needs = new Set(attn.map((a) => a.wtKey));
+
+  // Measure lazily: the walk only happens because someone opened this view,
+  // and anything measured recently enough is skipped by the backend. Runs on
+  // mount and whenever the worktree set changes, never on every render.
+  const keys = useMemo(() => flat.map((f) => f.wt.wtKey).join("\u0000"), [flat]);
+  useEffect(() => {
+    if (keys) scanDisk(keys.split("\u0000"));
+  }, [keys, scanDisk]);
 
   const head = (
     <tr>
@@ -100,12 +122,19 @@ export default function Overview({
         </td>
         <td className="r num">{live ? `${cpu.toFixed(1)}%` : "—"}</td>
         <td className="r num">{live ? `${Math.round(mem)} MB` : "—"}</td>
-        {/* TODO(#55): no backend measures a worktree's on-disk footprint yet.
-            The column is kept so the table geometry matches the design and
-            wiring it up stays purely additive. */}
-        <td className="r num muted" title="Disk usage is not measured yet">
-          —
-        </td>
+        {(() => {
+          const d = disk[wt.wtKey];
+          // No result yet is an honest "—": the walk is queued or running, and
+          // an estimate in this column would be a number someone deletes on.
+          if (!d) return <td className="r num muted" title="Measuring…">—</td>;
+          const when = new Date(d.scannedAt * 1000).toLocaleTimeString();
+          return (
+            <td className="r num" title={d.partial ? `At least ${fmtBytes(d.bytes)} — the scan hit its limit (${when})` : `Measured at ${when}`}>
+              {d.partial ? "≥ " : ""}
+              {fmtBytes(d.bytes)}
+            </td>
+          );
+        })()}
         <td className="num muted">
           {g ? (
             <>

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -165,7 +165,23 @@ export const ipc = {
   worktreeDirtyReport: (wtKey: string) => invoke<{ dirty: boolean; details: string[]; total: number }>("worktree_dirty_report", { wtKey }),
   removeWorktree: (wtKey: string, deleteBranch: boolean, dropDb: boolean) =>
     invoke<void>("remove_worktree", { wtKey, deleteBranch, dropDb }),
+
+  /** every measurement held so far — instant, from cache */
+  getDiskUsage: () => invoke<Record<string, DiskUsage>>("get_disk_usage"),
+  /** queue worktrees for measurement; resolves immediately, results arrive as
+      `worktree:disk`. Fresh figures are skipped unless `force`. */
+  scanDiskUsage: (wtKeys: string[], force = false) => invoke<void>("scan_disk_usage", { wtKeys, force }),
 };
+
+/** A worktree's on-disk footprint: everything under its root, `node_modules`
+    and build output included — that is what removing it actually frees. */
+export interface DiskUsage {
+  bytes: number;
+  /** unix seconds */
+  scannedAt: number;
+  /** the walk hit a budget and stopped early, so `bytes` is a floor */
+  partial: boolean;
+}
 
 export interface GitEvent extends GitMeta {
   wtKey: string;
@@ -204,6 +220,9 @@ export interface TerminalDataEvent {
 export interface TerminalExitEvent {
   id: string;
 }
+export interface DiskEvent extends DiskUsage {
+  wtKey: string;
+}
 /** Scrollback snapshot + the cursor it ends at (race-free rehydrate). */
 export interface TerminalSnapshot {
   buffer: string;
@@ -229,6 +248,8 @@ export const on = {
     listen<TerminalDataEvent>("terminal:data", (e) => cb(e.payload)),
   terminalExit: (cb: (e: TerminalExitEvent) => void): Promise<UnlistenFn> =>
     listen<TerminalExitEvent>("terminal:exit", (e) => cb(e.payload)),
+  worktreeDisk: (cb: (e: DiskEvent) => void): Promise<UnlistenFn> =>
+    listen<DiskEvent>("worktree:disk", (e) => cb(e.payload)),
 };
 
 /** Structured backend error — every command rejects with `{ code, message }`. */

--- a/src/store.ts
+++ b/src/store.ts
@@ -2,6 +2,7 @@
 // Rust via events; in a plain browser tab it falls back to the Phase-2 mock.
 import { create } from "zustand";
 import type { LogLine, RepoNode, ServiceNode, SvcStats, SvcStatus, WorktreeNode } from "./types";
+import type { DiskUsage } from "./ipc";
 import { isLive } from "./types";
 import { genLine, logTime, mockTree } from "./mock";
 import { errText, hasBackend, ipc, on } from "./ipc";
@@ -81,6 +82,11 @@ interface State {
   logs: Record<string, LogLine[]>;
   ops: Record<string, OpLog>;
   stats: Record<string, SvcStats>;
+  /** wtKey -> last completed on-disk measurement (see disk.rs). Absent until a
+      scan finishes; the overview renders "—" rather than blocking on one. */
+  disk: Record<string, DiskUsage>;
+  /** ask the backend to measure these worktrees; results arrive as events */
+  scanDisk: (wtKeys: string[], force?: boolean) => void;
   /** rolling CPU samples per service — the service-detail sparkline. Kept
       client-side because the backend streams point-in-time stats and has no
       reason to retain history for a modal that may never open. */
@@ -265,6 +271,7 @@ export const useStore = create<State>((set, get) => {
     logs: seedLogs(mock),
     ops: {},
     stats: seedStats(mock),
+    disk: {},
     cpuHistory: {},
     exitCodes: {},
     resetting: {},
@@ -277,6 +284,11 @@ export const useStore = create<State>((set, get) => {
     collapsed: false,
     sessions: {},
     activeTerm: {},
+    scanDisk: (wtKeys, force = false) => {
+      // No mock fallback: inventing a size would put a fabricated number in a
+      // column whose entire purpose is deciding what to delete.
+      if (hasBackend() && wtKeys.length) ipc.scanDiskUsage(wtKeys, force).catch(() => {});
+    },
     openSession: (s) => {
       sessionStartedAt[s.id] = Date.now();
       set((st) => ({
@@ -609,6 +621,18 @@ export function initSync(): () => void {
       }));
     }),
   );
+
+  // disk measurements: one event per completed walk, so a plain merge.
+  track(
+    on.worktreeDisk((e) => {
+      useStore.setState((st) => ({
+        disk: { ...st.disk, [e.wtKey]: { bytes: e.bytes, scannedAt: e.scannedAt, partial: e.partial } },
+      }));
+    }),
+  );
+  // pick up whatever earlier scans already found — a window opened later (or
+  // the popover) should not have to re-walk trees this process already measured
+  ipc.getDiskUsage().then((d) => useStore.setState({ disk: d })).catch(() => {});
 
   track(
     on.serviceStats((e) => {


### PR DESCRIPTION
Closes #55

## The problem

The **All worktrees** overview (⌘O) has a per-worktree **Size** column between Memory and Git. It rendered `—` for every row with `title="Disk usage is not measured yet"` — nothing in the backend computed an on-disk footprint.

## Why this solution

The column exists to answer one question: **"what would I reclaim by removing this?"** That framing settles both open design decisions in the issue.

**What is counted: everything under the worktree root**, `node_modules` and build output included. The issue flags this as worth deciding — and removal frees exactly those bytes, so excluding them would answer a question nobody asked. Git-ignored status is irrelevant here; git has no opinion about disk.

**When it runs: never on the UI path.** A recursive walk of a few `node_modules` trees is hundreds of thousands of `stat` calls. Making the overview `await` that would freeze it on open. So:

- scans run on the **blocking pool**, and publish a `worktree:disk` event when each finishes
- they are **serialized** — two concurrent recursive walks on one disk are slower than the same two in sequence, and they'd compete with whatever the user is actually running
- the overview renders `—` until a result arrives and **never blocks on one**

**Lazy, as the issue prefers.** Nothing is measured until someone opens the overview. A figure under 10 minutes old is reused rather than re-walked — a worktree's size moves on the scale of installs and builds, not seconds. It's force-refreshed after setup (installing dependencies is the single biggest change a footprint ever sees) and dropped from cache when a worktree is removed, so a stale number can't be served if the path is later reused.

**Symlinks are stat'd, never followed.** Otherwise a linked package cache is double-counted and the walk can leave the worktree entirely — or loop. The link's own size is counted, which is what removal actually frees.

**A truncated walk says so.** Budgets (4M entries / 90s) stop a runaway directory or stray mount from pinning a blocking thread forever. The result is flagged `partial` and rendered `≥ 1.4 GB`. A number that silently under-reports is worse than one labelled approximate.

**No mock fallback.** In the no-backend dev build the column stays `—`. Inventing a size would put a fabricated number in the one column people delete things based on. (The design mock derived a size arithmetically from the branch name; the issue explicitly calls that scaffolding, not a spec.)

## How it works

| | |
|---|---|
| `disk.rs` (new) | `DiskUsage { bytes, scannedAt, partial }`; a request queue with a single drain task; `measure()` — iterative DFS, no recursion, unreadable directories skipped rather than aborting the whole measurement |
| `commands.rs` | `get_disk_usage` (instant, from cache) and `scan_disk_usage` (queue + return). The latter takes a caller-supplied path list, so it filters against the tree — the same containment rule every other `wt_key` entry point applies |
| `state.rs` | `release_worktree_runtime` forgets the measurement alongside ports/statuses/logs |
| `store.ts` / `Overview.tsx` | `disk` slice hydrated from cache on init, merged on each event; the Size cell formats GB/MB and puts the measurement time in the tooltip |

## Verification

- Three unit tests: recursive totalling including `node_modules`; a symlink to a 50 KB tree outside the worktree **not** counted (Unix); and a missing root returning 0 without panicking — a worktree deleted between request and walk.
- `cargo test` 44 passed · `cargo clippy --all-targets --features devtools -- -D warnings` clean · `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYXXuRwMVeF6Dv7xebjQJL