### PR TITLE
Persist worktree pinning in settings rather than localStorage

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -675,6 +675,30 @@ pub async fn quit_app(app: AppHandle) -> Result<(), CanopyError> {
     Ok(())
 }
 
+/// Pin or unpin a worktree in the sidebar. Persists to `Settings` and
+/// republishes the tree, which is what carries the flag to every window.
+#[tauri::command]
+pub async fn set_worktree_pinned(app: AppHandle, wt_key: String, pinned: bool) -> Result<(), CanopyError> {
+    ensure_known_worktree(&app, &wt_key)?;
+    let updated = {
+        let state = app.state::<AppState>();
+        let mut s = state.settings.write();
+        let has = s.pinned_worktrees.iter().any(|k| k == &wt_key);
+        if has == pinned {
+            return Ok(()); // already in the requested state — no write, no event
+        }
+        if pinned {
+            s.pinned_worktrees.push(wt_key.clone());
+        } else {
+            s.pinned_worktrees.retain(|k| k != &wt_key);
+        }
+        s.clone()
+    };
+    settings::save_settings(&app, &updated).map_err(CanopyError::config)?;
+    refresh_tree(&app).await.map_err(CanopyError::internal)?;
+    Ok(())
+}
+
 // ── worktree create / remove ──
 
 #[derive(serde::Serialize, Clone)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -312,6 +312,7 @@ pub fn run() {
             commands::set_service_port,
             commands::run_migration,
             commands::run_custom_command,
+            commands::set_worktree_pinned,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -13,6 +13,14 @@ pub struct Settings {
     pub repos: Vec<RepoCfg>,
     /// show the in-place "Switch branch" action in the worktree header
     pub show_switch_branch: bool,
+    /// Worktrees the user pinned to the top of the sidebar, by `wt_key`.
+    ///
+    /// Lives here rather than in `RuntimeState` because it is a *preference*,
+    /// not derived state: it should travel with the config file, be editable by
+    /// hand, and survive a state-file reset. Pruned when a worktree is removed
+    /// so the list can't grow without bound.
+    #[serde(default)]
+    pub pinned_worktrees: Vec<String>,
 }
 
 impl Default for Settings {
@@ -23,6 +31,7 @@ impl Default for Settings {
             terminal: String::new(),
             repos: Vec::new(),
             show_switch_branch: true,
+            pinned_worktrees: Vec::new(),
         }
     }
 }
@@ -232,6 +241,19 @@ mod tests {
         assert_eq!(loaded.terminal, "", "defaults on parse failure");
         let backup = path.with_extension("json.corrupt");
         assert_eq!(fs::read_to_string(&backup).unwrap(), "{ truncated", "original quarantined");
+
+        // a settings file written before pinning existed must still load, with
+        // an empty pin list rather than falling back to full defaults
+        fs::write(&path, r#"{"version":1,"terminal":"iTerm","repos":[]}"#).unwrap();
+        let loaded: Settings = load_json(&path);
+        assert_eq!(loaded.terminal, "iTerm", "pre-pinning settings still parse");
+        assert!(loaded.pinned_worktrees.is_empty(), "absent pin list defaults to empty");
+
+        // pins round-trip
+        let s = Settings { pinned_worktrees: vec!["/wt/a".into()], ..Default::default() };
+        save_json(&path, &s).unwrap();
+        let loaded: Settings = load_json(&path);
+        assert_eq!(loaded.pinned_worktrees, vec!["/wt/a".to_string()]);
 
         // unchanged content → no rewrite (mtime-stable persistence)
         fs::write(&path, serde_json::to_string_pretty(&s).unwrap()).unwrap();

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -36,6 +36,11 @@ pub struct WorktreeNode {
     pub git: Option<GitMeta>,
     /// database name from the worktree's .env (PG_DB), if present
     pub db_name: Option<String>,
+    /// pinned to the top of the sidebar. Denormalized onto the tree (the list
+    /// itself lives in `Settings`) so every window — including the popover —
+    /// gets it from the `tree:changed` it already subscribes to, with no extra
+    /// fetch and no second source of truth to drift.
+    pub pinned: bool,
     pub services: Vec<ServiceNode>,
 }
 
@@ -110,6 +115,18 @@ pub fn release_worktree_runtime(app: &AppHandle, repo_id: &str, wt_key: &str) {
     };
     let _ = crate::settings::save_runtime(app, &runtime);
     state.statuses.write().retain(|k, _| !k.starts_with(&prefix));
+    // Drop the pin too. Nothing else prunes this list, so without it every
+    // removed worktree leaves an entry that grows the config file forever and
+    // silently re-pins the path if it is ever recreated.
+    let settings = {
+        let mut s = state.settings.write();
+        let before = s.pinned_worktrees.len();
+        s.pinned_worktrees.retain(|k| k != wt_key);
+        (before != s.pinned_worktrees.len()).then(|| s.clone())
+    };
+    if let Some(s) = settings {
+        let _ = crate::settings::save_settings(app, &s);
+    }
     if let Some(table) = app.try_state::<crate::services::ProcTable>() {
         table.logs.lock().retain(|k, _| !k.starts_with(&prefix));
         // close the on-disk log handles too, or a removed worktree keeps file
@@ -298,6 +315,9 @@ pub async fn refresh_tree(app: &AppHandle) -> Result<Vec<RepoNode>, String> {
         .filter_map(|w| w.git.clone().map(|g| (w.wt_key.clone(), g)))
         .collect();
 
+    let pinned: std::collections::HashSet<String> =
+        state.settings.read().pinned_worktrees.iter().cloned().collect();
+
     let mut tree = Vec::new();
     for repo in &repos_cfg {
         let wts = match git::list_worktrees(&repo.path).await {
@@ -334,6 +354,7 @@ pub async fn refresh_tree(app: &AppHandle) -> Result<Vec<RepoNode>, String> {
 
             worktrees.push(WorktreeNode {
                 db_name: env_value(&wt.path, "PG_DB"),
+                pinned: pinned.contains(&wt.path),
                 wt_key: wt.path.clone(),
                 git: prev_git.get(&wt.path).cloned(),
                 branch: wt.branch,

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -407,5 +407,6 @@ const EMPTY_WT: WorktreeNode = {
   isMain: false,
   git: null,
   dbName: null,
+  pinned: false,
   services: [],
 };

--- a/src/app/SettingsView.tsx
+++ b/src/app/SettingsView.tsx
@@ -154,7 +154,7 @@ function hlLine(line: string): string {
 }
 
 const MOCK: Settings = {
-  version: 1, editor: { command: "code" }, terminal: "Terminal", showSwitchBranch: true,
+  version: 1, editor: { command: "code" }, terminal: "Terminal", showSwitchBranch: true, pinnedWorktrees: [],
   repos: [{
     id: "tooljet", name: "ToolJet", path: "~/ToolJetSpace/CE/ToolJet", worktreeDir: ".worktrees", resetDb: "", migrateDb: "",
     services: [

--- a/src/app/canopy/SidebarNav.tsx
+++ b/src/app/canopy/SidebarNav.tsx
@@ -8,7 +8,7 @@ import { Chevron, Editor, Logs, Pin, Play, Plus, Search, SidebarIcon, Sparkle, S
 import { useStore, type LaneSession } from "../../store";
 import { isLive, type RepoNode, type WorktreeNode } from "../../types";
 import { agentState, dotClass, wtDot, type AttnItem } from "../nextAction";
-import { isPinned, togglePin, usePins } from "../pins";
+import { isPinned, togglePin } from "../pins";
 
 type Flat = { wt: WorktreeNode; repo: RepoNode };
 
@@ -39,7 +39,6 @@ export default function SidebarNav({
   const sessions = useStore((s) => s.sessions);
   const toggleWorktree = useStore((s) => s.toggleWorktree);
   const openWorktree = useStore((s) => s.openWorktree);
-  const pins = usePins();
   const [closed, setClosed] = useState<Record<string, boolean>>({});
 
   const flat = useMemo<Flat[]>(() => tree.flatMap((repo) => repo.worktrees.map((wt) => ({ wt, repo }))), [tree]);
@@ -48,23 +47,22 @@ export default function SidebarNav({
   const groups = useMemo(() => {
     const vis = flat.filter(({ wt, repo }) => !q || `${wt.branch} ${repo.name}`.toLowerCase().includes(q));
     const needs = new Set(attn.map((a) => a.wtKey));
-    const pinned = new Set(pins);
     const rest = vis.filter((f) => !needs.has(f.wt.wtKey));
     return [
       { k: "attn", label: "Needs you", items: vis.filter((f) => needs.has(f.wt.wtKey)) },
-      { k: "pin", label: "Pinned", items: rest.filter((f) => pinned.has(f.wt.wtKey)) },
+      { k: "pin", label: "Pinned", items: rest.filter((f) => f.wt.pinned) },
       {
         k: "run",
         label: "Running",
-        items: rest.filter((f) => !pinned.has(f.wt.wtKey) && f.wt.services.some((s) => isLive(s.status))),
+        items: rest.filter((f) => !f.wt.pinned && f.wt.services.some((s) => isLive(s.status))),
       },
       {
         k: "idle",
         label: "Idle",
-        items: rest.filter((f) => !pinned.has(f.wt.wtKey) && !f.wt.services.some((s) => isLive(s.status))),
+        items: rest.filter((f) => !f.wt.pinned && !f.wt.services.some((s) => isLive(s.status))),
       },
     ].filter((g) => g.items.length);
-  }, [flat, q, attn, pins]);
+  }, [flat, q, attn]);
 
   return (
     <aside className={"cxs-side" + (hidden ? " is-hidden" : "")} inert={hidden || undefined} aria-hidden={hidden || undefined}>
@@ -151,7 +149,7 @@ function WorktreeRow({
   // isLive() excludes `stopping`, so a worktree mid-shutdown reads as idle and
   // the toggle would offer "Start services" — which then races the shutdown.
   const settling = wt.services.some((s) => s.status === "starting" || s.status === "stopping");
-  const pinned = isPinned(wt.wtKey);
+  const pinned = isPinned(wt);
 
   return (
     <div className={"cxs-wtr" + (selected ? " is-on" : "")} onClick={onSelect} role="button" tabIndex={0}
@@ -219,7 +217,7 @@ function WorktreeRow({
           title={pinned ? "Unpin" : "Pin to the top"}
           onClick={(e) => {
             e.stopPropagation();
-            togglePin(wt.wtKey);
+            togglePin(wt);
           }}
         >
           <Pin size={11} />

--- a/src/app/pins.ts
+++ b/src/app/pins.ts
@@ -1,59 +1,32 @@
 /* Worktree pinning — what keeps the two or three worktrees you actually live
    in above a long tail of branches.
 
-   TODO(#56): this is localStorage, which is per-webview. The popover window
-   can't see these pins, they don't travel with the config file the way every
-   other preference does, and nothing prunes entries for removed worktrees.
-   When `pinned` lands on WorktreeNode (or Settings), this module collapses to
-   an ipc call and the storage code goes away. */
-import { useSyncExternalStore } from "react";
+   The pin set lives in `Settings` (see settings.rs) and is denormalized onto
+   every `WorktreeNode` as `pinned`, so this module is a thin read of the tree
+   plus one command. That fixes the three things localStorage got wrong: the
+   popover window shares the state, pins travel with the config file like every
+   other preference, and removing a worktree prunes its entry. */
+import { hasBackend, ipc } from "../ipc";
+import { useStore } from "../store";
+import type { WorktreeNode } from "../types";
 
-const KEY = "canopy.pinned";
+export function isPinned(wt: WorktreeNode): boolean {
+  return wt.pinned;
+}
 
-let pins: Set<string> = load();
-const listeners = new Set<() => void>();
-/** useSyncExternalStore compares by identity, so hand out a stable snapshot
-    and only replace it when the set actually changes. */
-let snapshot: readonly string[] = Object.freeze([...pins]);
-
-function load(): Set<string> {
-  try {
-    const raw = localStorage.getItem(KEY);
-    const arr = raw ? JSON.parse(raw) : [];
-    return new Set(Array.isArray(arr) ? arr.filter((x): x is string => typeof x === "string") : []);
-  } catch {
-    return new Set();
+/** Flip a worktree's pin. The backend persists and republishes the tree, so
+    there is no local state to reconcile — every window re-renders from the
+    same `tree:changed`. */
+export function togglePin(wt: WorktreeNode) {
+  if (!hasBackend()) {
+    // no-backend dev build: keep the interaction alive against the mock tree
+    useStore.setState((st) => ({
+      tree: st.tree.map((r) => ({
+        ...r,
+        worktrees: r.worktrees.map((w) => (w.wtKey === wt.wtKey ? { ...w, pinned: !w.pinned } : w)),
+      })),
+    }));
+    return;
   }
-}
-
-function commit() {
-  snapshot = Object.freeze([...pins]);
-  try {
-    localStorage.setItem(KEY, JSON.stringify(snapshot));
-  } catch {
-    /* private mode / quota — pins stay in memory for this session */
-  }
-  listeners.forEach((l) => l());
-}
-
-export function isPinned(wtKey: string): boolean {
-  return pins.has(wtKey);
-}
-
-export function togglePin(wtKey: string) {
-  if (pins.has(wtKey)) pins.delete(wtKey);
-  else pins.add(wtKey);
-  commit();
-}
-
-/** Subscribe to the pin set. Returns the pinned wtKeys. */
-export function usePins(): readonly string[] {
-  return useSyncExternalStore(
-    (cb) => {
-      listeners.add(cb);
-      return () => listeners.delete(cb);
-    },
-    () => snapshot,
-    () => snapshot,
-  );
+  ipc.setWorktreePinned(wt.wtKey, !wt.pinned).catch(() => {});
 }

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -57,6 +57,8 @@ export interface Settings {
   terminal: string;
   repos: RepoCfg[];
   showSwitchBranch: boolean;
+  /** worktrees pinned to the top of the sidebar, by wtKey */
+  pinnedWorktrees: string[];
 }
 
 export type ProvisionFormat = "dotenv" | "json" | "yaml" | "text";
@@ -165,6 +167,7 @@ export const ipc = {
   worktreeDirtyReport: (wtKey: string) => invoke<{ dirty: boolean; details: string[]; total: number }>("worktree_dirty_report", { wtKey }),
   removeWorktree: (wtKey: string, deleteBranch: boolean, dropDb: boolean) =>
     invoke<void>("remove_worktree", { wtKey, deleteBranch, dropDb }),
+  setWorktreePinned: (wtKey: string, pinned: boolean) => invoke<void>("set_worktree_pinned", { wtKey, pinned }),
 };
 
 export interface GitEvent extends GitMeta {

--- a/src/mock.ts
+++ b/src/mock.ts
@@ -38,6 +38,7 @@ export function mockTree(): RepoNode[] {
           path: "~/code/acme-web",
           isMain: true,
           dbName: null,
+          pinned: false,
           git: { ahead: 0, behind: 0, dirty: false, lastCommitTs: nowS() - 2 * 60 * min, lastCommitMsg: "checkout: fix tax rounding" },
           services: [
             svc("~/code/acme-web", "frontend", "Frontend", "web", 3000, "running"),
@@ -50,6 +51,7 @@ export function mockTree(): RepoNode[] {
           path: "~/code/.wt/acme-web-checkout",
           isMain: false,
           dbName: "db_2",
+          pinned: true,
           git: { ahead: 7, behind: 2, dirty: true, lastCommitTs: nowS() - 11 * min, lastCommitMsg: "wip: express checkout drawer" },
           services: [
             svc("~/code/.wt/acme-web-checkout", "frontend", "Frontend", "web", 3010, "stopped"),
@@ -69,6 +71,7 @@ export function mockTree(): RepoNode[] {
           path: "~/code/payments-api",
           isMain: true,
           dbName: null,
+          pinned: false,
           git: { ahead: 0, behind: 0, dirty: false, lastCommitTs: nowS() - 24 * 60 * min, lastCommitMsg: "bump stripe sdk to 14.2" },
           services: [
             svc("~/code/payments-api", "api", "API", "server", 8080, "running"),
@@ -81,6 +84,7 @@ export function mockTree(): RepoNode[] {
           path: "~/code/.wt/payments-refund",
           isMain: false,
           dbName: "db_4",
+          pinned: false,
           git: { ahead: 3, behind: 0, dirty: true, lastCommitTs: nowS() - 4 * min, lastCommitMsg: "refund: idempotency key guard" },
           services: [svc("~/code/.wt/payments-refund", "api", "API", "server", 8090, "running")],
         },
@@ -97,6 +101,7 @@ export function mockTree(): RepoNode[] {
           path: "~/dev/design-system",
           isMain: true,
           dbName: null,
+          pinned: false,
           git: { ahead: 1, behind: 0, dirty: false, lastCommitTs: nowS() - 5 * 60 * min, lastCommitMsg: "Button: focus ring tokens" },
           services: [svc("~/dev/design-system", "storybook", "Storybook", "web", 6006, "running")],
         },

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,9 @@ export interface WorktreeNode {
   isMain: boolean;
   git: GitMeta | null;
   dbName: string | null;
+  /** pinned to the top of the sidebar (persisted in Settings, denormalized
+      here so every window gets it from the tree it already subscribes to) */
+  pinned: boolean;
   services: ServiceNode[];
 }
 


### PR DESCRIPTION
Closes #56

## The problem

Pinning already worked — pin/unpin from the sidebar row, with the **Pinned** group rendering from it — but it was persisted to `localStorage` under `canopy.pinned`. `localStorage` is per-webview, which is wrong in three ways this app actually hits:

1. **The popover doesn't see it.** Canopy runs a second webview; pins set in the main window were invisible there.
2. **It isn't portable.** Every other preference lives in `Settings` and travels with the config file. Pins didn't.
3. **It leaks.** Nothing pruned entries for removed worktrees, so the key grew without bound.

## Why this solution

The issue offers two shapes — `pinned: bool` on `WorktreeNode`, or `pinnedWorktrees: Vec<String>` on `Settings`. **This does both, deliberately, with one of them as the source of truth.**

**Storage: `Settings.pinnedWorktrees`.** A pin is a *preference*, not derived state. It belongs in the config file, next to the editor command and the terminal choice — hand-editable, portable, and surviving a `state.json` reset. `RuntimeState` would have been the wrong home: that file is for things Canopy derives and can rebuild (port indices, orphan pgids).

**Transport: `WorktreeNode.pinned`.** Storage alone doesn't fix complaint #1 — the popover would need its own settings fetch and its own invalidation. Denormalizing the flag onto the tree means every window gets it from the `tree:changed` event it *already* subscribes to. No extra fetch, no cache to invalidate, and no second source of truth to drift: the field is computed from the settings list on every `refresh_tree`.

**Pruning where everything else is pruned.** `release_worktree_runtime` already reclaims a removed worktree's port index, port overrides, statuses and log buffers. The pin joins them, so there's one place that knows what a removal releases rather than a rule that lives only in `remove_worktree` and gets missed by `remove_repo`. It writes settings only when something actually changed.

**`set_worktree_pinned` is idempotent** — a request matching the current state returns without a write or an event, so a double-click can't produce a redundant config write and a tree rebuild.

## How it works

| | |
|---|---|
| `settings.rs` | `pinned_worktrees: Vec<String>`, `#[serde(default)]` so existing config files load unchanged |
| `state.rs` | `WorktreeNode.pinned` computed per rebuild; pruning folded into `release_worktree_runtime` |
| `commands.rs` | `set_worktree_pinned(wt_key, pinned)` — validates the key, persists, republishes the tree |
| `pins.ts` | 59 lines of `localStorage` + `useSyncExternalStore` plumbing → a tree read and one command (the no-backend build patches the mock tree so the interaction still works) |
| `SidebarNav.tsx` | groups read `f.wt.pinned` directly; the `usePins()` subscription is gone |

## Verification

- `settings.rs` test extended: a settings file written *before* pinning existed still parses (with an empty list, not a fall back to full defaults), and pins round-trip through save/load.
- `cargo test` 41 passed · `cargo clippy --all-targets --features devtools -- -D warnings` clean · `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYXXuRwMVeF6Dv7xebjQJL