### PR TITLE
Preview a worktree's derived path, ports and database before creating it

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -694,11 +694,119 @@ fn emit_op(app: &AppHandle, wt_key: &str, op: &'static str, state: &'static str,
     );
 }
 
+/// Where a worktree for `branch` lands. The single definition — `create_worktree`
+/// and `preview_worktree` both call it, so the path the modal promises is the
+/// path creation uses.
+pub(crate) fn derive_worktree_path(repo: &RepoCfg, branch: &str) -> String {
+    let wt_dir = if repo.worktree_dir.trim().is_empty() {
+        format!("{}-worktrees", repo.path)
+    } else {
+        repo.worktree_dir.clone()
+    };
+    format!("{wt_dir}/{}", sanitize_branch(branch))
+}
+
 pub(crate) fn sanitize_branch(branch: &str) -> String {
     branch
         .chars()
         .map(|c| if c.is_alphanumeric() || c == '-' || c == '.' { c } else { '_' })
         .collect()
+}
+
+/// One service's port in the preview, with whether anything already holds it.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PreviewPort {
+    pub service_id: String,
+    pub name: String,
+    pub port: u32,
+    /// the branch of the worktree already using this port, if any
+    pub taken_by: Option<String>,
+}
+
+/// What creating a worktree for this branch would produce. Read-only: it
+/// allocates no port index, touches no disk, and registers nothing.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorktreePreview {
+    pub path: String,
+    pub slug: String,
+    /// `None` when the repo's provisioning never references `${WT_DB_NAME}` —
+    /// no isolated database would be created, and naming one would be a
+    /// promise the setup doesn't keep
+    pub db_name: Option<String>,
+    pub ports: Vec<PreviewPort>,
+    /// the derived path is already on disk, so creation would be refused
+    pub path_exists: bool,
+}
+
+/// Preview a worktree before creating it.
+///
+/// Shares every derivation with `create_worktree` — the path via
+/// `derive_worktree_path`, the port index via `peek_port_index` (the same
+/// first-free-slot rule, with `assign: false`), and the database name via
+/// `derived_db_name`, which is also what `worktree_vars` exposes as
+/// `${WT_DB_NAME}`. The panel's entire value is that it matches what you
+/// actually get; a parallel implementation that drifts would be worse than no
+/// panel at all.
+#[tauri::command]
+pub fn preview_worktree(app: AppHandle, repo_id: String, branch: String) -> Result<WorktreePreview, CanopyError> {
+    let repo = {
+        let state = app.state::<AppState>();
+        let s = state.settings.read();
+        s.repos.iter().find(|r| r.id == repo_id).cloned().ok_or_else(|| CanopyError::not_found("unknown repo"))?
+    };
+    let path = derive_worktree_path(&repo, &branch);
+
+    let state = app.state::<AppState>();
+    // peek, never assign: opening the modal must not consume a port slot that
+    // a worktree created moments later from a different branch would then skip
+    let idx = {
+        let mut rt = state.runtime.write();
+        crate::state::peek_port_index(&mut rt, &repo_id, &path)
+    };
+    let overrides = state.runtime.read().port_overrides.clone();
+
+    // every port already spoken for, and by which branch
+    let held: std::collections::HashMap<u32, String> = {
+        let tree = state.tree.read();
+        tree.iter()
+            .flat_map(|r| r.worktrees.iter())
+            .flat_map(|w| w.services.iter().filter_map(|s| s.port.map(|p| (p, w.branch.clone()))))
+            .collect()
+    };
+
+    let ports = repo
+        .services
+        .iter()
+        .filter_map(|s| {
+            let base = s.base_port? as u32;
+            let key = crate::state::svc_key(&path, &s.id);
+            let port = crate::state::effective_port(&overrides, &key, base, idx);
+            Some(PreviewPort {
+                service_id: s.id.clone(),
+                name: s.name.clone(),
+                port,
+                taken_by: held.get(&port).cloned(),
+            })
+        })
+        .collect();
+
+    // Only claim a database if provisioning would actually create one.
+    let cfg = crate::setup::read_repo_config(&repo.path);
+    let uses_db = cfg
+        .provision
+        .iter()
+        .any(|p| p.keys.iter().any(|(_, tpl)| tpl.contains("${WT_DB_NAME}")));
+    let db_name = uses_db.then(|| crate::state::derived_db_name(&repo_id, &path));
+
+    Ok(WorktreePreview {
+        slug: crate::setup::wt_slug(&path),
+        path_exists: std::path::Path::new(&path).exists(),
+        path,
+        db_name,
+        ports,
+    })
 }
 
 #[tauri::command]
@@ -718,12 +826,7 @@ pub async fn create_worktree(
             .cloned()
             .ok_or_else(|| CanopyError::not_found("unknown repo"))?
     };
-    let wt_dir = if repo.worktree_dir.trim().is_empty() {
-        format!("{}-worktrees", repo.path)
-    } else {
-        repo.worktree_dir.clone()
-    };
-    let wt_path = format!("{wt_dir}/{}", sanitize_branch(&branch));
+    let wt_path = derive_worktree_path(&repo, &branch);
     if std::path::Path::new(&wt_path).exists() {
         return Err(CanopyError::conflict(format!("Path already exists: {wt_path}")));
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -299,6 +299,7 @@ pub fn run() {
             commands::open_port,
             commands::show_main_window,
             commands::quit_app,
+            commands::preview_worktree,
             commands::create_worktree,
             commands::run_worktree_setup,
             commands::worktree_dirty_report,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -213,9 +213,20 @@ pub fn svc_key(wt_key: &str, service_id: &str) -> String {
     format!("{wt_key}::{service_id}")
 }
 
-/// Stable per-worktree port index: main checkout = 0, others get the first free
-/// slot, persisted so ports never shuffle. Effective port = basePort + index*10.
-fn port_index(runtime: &mut RuntimeState, repo_id: &str, wt_key: &str, is_main: bool) -> u32 {
+/// The port index a worktree has, or would be given: main checkout = 0, others
+/// take the first free slot. Effective port = basePort + index*10.
+///
+/// `assign` is the only difference between allocating and previewing. Keeping
+/// them one function is the point — the New-worktree modal's whole value is
+/// that the ports it shows are the ports you get, and a second implementation
+/// of "first free slot" would drift silently the first time this rule changes.
+fn resolve_port_index(
+    runtime: &mut RuntimeState,
+    repo_id: &str,
+    wt_key: &str,
+    is_main: bool,
+    assign: bool,
+) -> u32 {
     let map = runtime.port_indices.entry(repo_id.to_string()).or_default();
     if let Some(i) = map.get(wt_key) {
         return *i;
@@ -231,8 +242,31 @@ fn port_index(runtime: &mut RuntimeState, repo_id: &str, wt_key: &str, is_main: 
         }
         i
     };
-    map.insert(wt_key.to_string(), idx);
+    if assign {
+        map.insert(wt_key.to_string(), idx);
+    }
     idx
+}
+
+/// Stable per-worktree port index, persisted so ports never shuffle.
+fn port_index(runtime: &mut RuntimeState, repo_id: &str, wt_key: &str, is_main: bool) -> u32 {
+    resolve_port_index(runtime, repo_id, wt_key, is_main, true)
+}
+
+/// What a worktree that doesn't exist yet would be given. Allocates nothing.
+pub fn peek_port_index(runtime: &mut RuntimeState, repo_id: &str, wt_key: &str) -> u32 {
+    resolve_port_index(runtime, repo_id, wt_key, false, false)
+}
+
+/// The database name a worktree gets — the same `WT_DB_NAME` that
+/// `worktree_vars` exposes to provisioning templates.
+pub fn derived_db_name(repo_id: &str, wt_key: &str) -> String {
+    let slug = crate::setup::wt_slug(wt_key);
+    let repo_slug: String = repo_id
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c.to_ascii_lowercase() } else { '_' })
+        .collect();
+    format!("{repo_slug}_{slug}")
 }
 
 /// A service's effective port: an explicit override if set, else the derived
@@ -256,15 +290,11 @@ pub fn worktree_vars(app: &AppHandle, repo_id: &str, wt_key: &str, is_main: bool
         let _ = crate::settings::save_runtime(app, &rt);
     }
     let slug = crate::setup::wt_slug(wt_key);
-    let repo_slug: String = repo_id
-        .chars()
-        .map(|c| if c.is_ascii_alphanumeric() { c.to_ascii_lowercase() } else { '_' })
-        .collect();
 
     let mut m = HashMap::new();
     m.insert("WT_SLUG".into(), slug.clone());
     m.insert("WT_INDEX".into(), idx.to_string());
-    m.insert("WT_DB_NAME".into(), format!("{repo_slug}_{slug}"));
+    m.insert("WT_DB_NAME".into(), derived_db_name(repo_id, wt_key));
     m.insert("WM_WT_SLUG".into(), slug); // back-compat alias
 
     let overrides = state.runtime.read().port_overrides.clone();
@@ -469,6 +499,30 @@ mod tests {
         assert_eq!(port_index(&mut rt, "repo", "/wt-c", false), 1);
         // separate repos have independent index spaces
         assert_eq!(port_index(&mut rt, "other", "/wt-x", false), 1);
+    }
+
+    #[test]
+    fn peek_matches_assignment_without_consuming_a_slot() {
+        let mut rt = RuntimeState::default();
+        port_index(&mut rt, "repo", "/main", true);
+        port_index(&mut rt, "repo", "/wt-a", false);
+
+        // the preview reports exactly what an assignment would hand out …
+        let peeked = peek_port_index(&mut rt, "repo", "/wt-new");
+        assert_eq!(peeked, 2, "first free slot");
+        // … twice, because peeking never consumes it
+        assert_eq!(peek_port_index(&mut rt, "repo", "/wt-other"), 2, "a preview reserves nothing");
+        // and the real assignment then agrees with the preview
+        assert_eq!(port_index(&mut rt, "repo", "/wt-new", false), peeked, "preview == what you get");
+        // only now is the slot gone
+        assert_eq!(peek_port_index(&mut rt, "repo", "/wt-other"), 3);
+    }
+
+    #[test]
+    fn derived_db_name_is_shared_with_worktree_vars() {
+        // the same value the ${WT_DB_NAME} template resolves to
+        assert_eq!(derived_db_name("ToolJet", "/w/.worktrees/Feature-X.2"), "tooljet_feature_x_2");
+        assert_eq!(derived_db_name("my repo", "/w/plain"), "my_repo_plain");
     }
 
     #[test]

--- a/src/app/NewWorktreeModal.tsx
+++ b/src/app/NewWorktreeModal.tsx
@@ -7,18 +7,18 @@
    it seeds .canopy/context.md and later becomes the PR body. */
 import { useEffect, useMemo, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
-import { errText, hasBackend, ipc, type Branches, type OpEvent } from "../ipc";
+import { errText, hasBackend, ipc, type Branches, type OpEvent, type WorktreePreview } from "../ipc";
 import { useStore } from "../store";
 import { Alert, ChevRight, Fork, Info, Plus, Refresh, Spinner } from "../icons";
 import Modal, { Hint, Spacer } from "./canopy/Modal";
 import RefPick from "./canopy/RefPick";
 import { seedWtContext } from "./WorktreeContext";
 
-/** Mirrors `sanitize_branch` in commands.rs:605 exactly — alphanumerics, `-`
-    and `.` survive, everything else becomes `_`, and CASE IS PRESERVED. An
-    approximation here is worse than nothing: the panel exists to tell you
-    where the worktree lands, so `Feature/foo` must read `Feature_foo`, not
-    `feature-foo`. Rust's is_alphanumeric is Unicode-aware, hence \p{L}\p{N}. */
+/** Slug preview for the NO-BACKEND dev build only. With a backend, every value
+    in the "You'll get" panel comes from `preview_worktree`, which shares its
+    derivation with `create_worktree` — so this approximation can never be what
+    a real user reads. Mirrors `sanitize_branch`: alphanumerics, `-` and `.`
+    survive, everything else becomes `_`, case preserved. */
 const sanitizeBranch = (b: string) => b.replace(/[^\p{L}\p{N}.-]/gu, "_");
 
 export default function NewWorktreeModal({ repoId, onClose }: { repoId: string; onClose: () => void }) {
@@ -44,6 +44,8 @@ export default function NewWorktreeModal({ repoId, onClose }: { repoId: string; 
   const [issueDescription, setIssueDescription] = useState("");
   /** the repo's configured worktree dir; blank means `${repo.path}-worktrees` */
   const [worktreeDir, setWorktreeDir] = useState<string | null>(null);
+  /** what creating this branch would actually produce (backend-derived) */
+  const [preview, setPreview] = useState<WorktreePreview | null>(null);
 
   const activeRepo = tree.find((r) => r.repoId === repo);
   // git refuses to check the same branch out twice; show them, disabled
@@ -110,11 +112,36 @@ export default function NewWorktreeModal({ repoId, onClose }: { repoId: string; 
 
   const branch = mode === "new" ? name.trim() : existing;
   const ok = !!branch;
-  // create_worktree: `${worktree_dir || repo.path + "-worktrees"}/${sanitize_branch(branch)}`
+
+  // Ask the backend what this branch would produce. Debounced because it runs
+  // on every keystroke of the name field; the command itself allocates nothing,
+  // so an in-flight request that is superseded costs only its own work.
+  useEffect(() => {
+    if (!hasBackend() || !repo || !branch) {
+      setPreview(null);
+      return;
+    }
+    let alive = true;
+    const t = setTimeout(() => {
+      ipc
+        .previewWorktree(repo, branch)
+        .then((p) => alive && setPreview(p))
+        .catch(() => alive && setPreview(null));
+    }, 150);
+    return () => {
+      alive = false;
+      clearTimeout(t);
+    };
+  }, [repo, branch]);
+
+  // With a backend the path is the backend's; the local derivation is only the
+  // no-backend dev build's stand-in.
   const destination =
-    ok && worktreeDir !== null && activeRepo
+    preview?.path ??
+    (ok && !hasBackend() && worktreeDir !== null && activeRepo
       ? `${worktreeDir.trim() || `${activeRepo.path}-worktrees`}/${sanitizeBranch(branch)}`
-      : null;
+      : null);
+  const clashingPorts = (preview?.ports ?? []).filter((p) => p.takenBy);
 
   async function create() {
     if (!ok) return;
@@ -263,14 +290,38 @@ export default function NewWorktreeModal({ repoId, onClose }: { repoId: string; 
         <dl className="cx-kv">
           <dt>Path</dt>
           <dd title={destination ?? undefined}>{destination ?? "—"}</dd>
-          {/* TODO(#58): ports and the database name are assigned inside
-              create_worktree. Deriving them here would duplicate backend logic
-              that can drift, and a wrong port is worse than a blank one. */}
           <dt>Ports</dt>
-          <dd title="Assigned at creation">—</dd>
+          <dd>
+            {preview?.ports.length ? (
+              preview.ports.map((p, i) => (
+                <span key={p.serviceId} className={p.takenBy ? "cx-kv__bad" : undefined} title={p.takenBy ? `Port ${p.port} is already used by ${p.takenBy}` : undefined}>
+                  {i > 0 && " · "}
+                  {p.name.toLowerCase()} <b>{p.port}</b>
+                </span>
+              ))
+            ) : preview ? (
+              /* the repo declares no service with a base port — there is
+                 nothing to assign, which is different from "not known yet" */
+              <span title="No service in this repo declares a base port">none</span>
+            ) : (
+              "—"
+            )}
+          </dd>
           <dt>Database</dt>
-          <dd title="Assigned at creation">—</dd>
+          <dd title={preview && !preview.dbName ? "This repo's provisioning never references ${WT_DB_NAME}" : undefined}>
+            {preview ? (preview.dbName ?? "none") : "—"}
+          </dd>
         </dl>
+        {preview?.pathExists && (
+          <Hint icon={Alert}>That path already exists — creation will be refused. Pick another branch name.</Hint>
+        )}
+        {clashingPorts.length > 0 && (
+          <Hint icon={Alert}>
+            {clashingPorts.length === 1
+              ? `Port ${clashingPorts[0].port} is already used by ${clashingPorts[0].takenBy} — change it after creating.`
+              : `${clashingPorts.length} derived ports are already in use — change them after creating.`}
+          </Hint>
+        )}
       </div>
 
       <details className="cxm-disc">

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -80,6 +80,26 @@ export interface RepoConfigFile {
   migrate: string[];
 }
 
+/** One service's derived port in the create preview. */
+export interface PreviewPort {
+  serviceId: string;
+  name: string;
+  port: number;
+  /** branch of the worktree already holding this port, if any */
+  takenBy: string | null;
+}
+
+export interface WorktreePreview {
+  path: string;
+  slug: string;
+  /** null when the repo's provisioning never references ${WT_DB_NAME}, i.e. no
+      isolated database would be created */
+  dbName: string | null;
+  ports: PreviewPort[];
+  /** the derived path already exists, so creation would be refused */
+  pathExists: boolean;
+}
+
 export interface Branches {
   local: string[];
   remote: string[];
@@ -159,6 +179,10 @@ export const ipc = {
   runMigration: (wtKey: string) => invoke<void>("run_migration", { wtKey }),
   runCustomCommand: (wtKey: string, command: string) => invoke<void>("run_custom_command", { wtKey, command }),
 
+  /** what creating this branch would produce — allocates nothing, shares its
+      derivation with `create_worktree` */
+  previewWorktree: (repoId: string, branch: string) =>
+    invoke<WorktreePreview>("preview_worktree", { repoId, branch }),
   createWorktree: (args: { repoId: string; branch: string; base?: string; createBranch: boolean }) =>
     invoke<string>("create_worktree", { ...args, base: args.base ?? null }),
   runWorktreeSetup: (wtKey: string) => invoke<void>("run_worktree_setup", { wtKey }),

--- a/src/styles/canopy-components.css
+++ b/src/styles/canopy-components.css
@@ -195,6 +195,10 @@ select.cx-input{appearance:none;cursor:pointer;background-image:linear-gradient(
 .cx-kv dt{color:var(--text-tertiary)}
 .cx-kv dd{margin:0;font:var(--fs-small) var(--mono);color:var(--text-secondary);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .cx-kv dd em{font-style:normal;color:var(--action-primary)}
+/* a derived value that already collides — the number is still shown, because
+   knowing WHICH port clashes is the point; red marks the problem, not the fix */
+.cx-kv__bad{color:var(--state-error)}
+.cx-kv dd b{font-weight:var(--fw-medium);color:var(--text-primary)}
 
 /* ── Coming soon ───────────────────────────────────────────────────
    For designed surfaces whose backend does not exist yet. A whole screen


### PR DESCRIPTION
Closes #58

## The problem

The **New worktree** modal's "You'll get" panel is its main reassurance — it answers *"where will this land and will it collide with anything?"* while the branch name is still editable. It showed a client-derived slug and `—` for both Ports and Database, because `create_worktree` derives the path, assigns ports and names the database **inside** the create call, with no way to ask beforehand.

## Why this solution

The issue is explicit: *"It must share the derivation code with `create_worktree` rather than reimplement it — the whole value of the panel is that it matches what you actually get. A second implementation that drifts is worse than no panel."* That constraint drove the whole design.

**One rule, one function, a boolean apart.** The port allocator already knew how to pick "the first free slot". Rather than write a read-only twin, `port_index` and the new `peek_port_index` are both thin wrappers over `resolve_port_index(…, assign: bool)`. Preview and creation cannot disagree about which index a branch gets, because they run the same code.

**Previewing must reserve nothing.** Opening the modal, or typing four characters into the name field, must not consume a port slot that a worktree created moments later would then skip. `assign: false` is what guarantees that, and a test asserts peeking twice returns the same index while a real assignment then matches what the preview promised.

**The frontend stops duplicating `sanitize_branch`.** It carried a hand-maintained regex mirroring the Rust function, complete with a comment about Unicode-awareness and case preservation — exactly the drift risk the issue names. It is now demoted to a stand-in for the no-backend dev build only; with a backend, users read the backend's own answer.

**Collisions belong in this panel**, since it's where the decision is made. `pathExists` warns that creation would be refused, and each port carries `takenBy` — the *branch* already holding it, not just a boolean, because "port 3190 is used by `hotfix/refund`" is actionable and "conflict" isn't.

**`dbName` is nullable, on purpose.** It's returned only when the repo's provisioning actually references `${WT_DB_NAME}`; otherwise the panel reads "none". Naming a database that setup would never create is a promise the app doesn't keep — the same reasoning the issue applies to guessed ports. Ports get the same treatment: "none" when no service declares a base port, which is a different fact from "not known yet" (`—`).

## How it works

| | |
|---|---|
| `state.rs` | `resolve_port_index(assign)` + `peek_port_index`; `derived_db_name` extracted and now used *by* `worktree_vars`, so the preview reads the same source as the template |
| `commands.rs` | `derive_worktree_path(repo, branch)` — the single path definition, called by create and preview; `preview_worktree` returns path/slug/dbName/ports/pathExists |
| `NewWorktreeModal.tsx` | 150ms-debounced preview per keystroke; the panel renders real ports and database, with clash hints |

## Verification

- `peek_matches_assignment_without_consuming_a_slot` — the preview reports the first free slot, reports it again unchanged, and the subsequent real assignment equals what was previewed.
- `derived_db_name_is_shared_with_worktree_vars` pins the slug rules.
- `cargo test` 43 passed · `cargo clippy --all-targets --features devtools -- -D warnings` clean · `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYXXuRwMVeF6Dv7xebjQJL