### PR TITLE
Settings/General: automatic update checks & crash reports

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -231,6 +231,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,6 +439,7 @@ dependencies = [
  "log",
  "parking_lot",
  "portable-pty",
+ "reqwest",
  "serde",
  "serde_json",
  "sysinfo",
@@ -471,6 +495,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -514,6 +540,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -523,6 +566,15 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -599,6 +651,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1132,6 +1193,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1331,8 +1398,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1354,10 +1423,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1509,6 +1581,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1621,6 +1712,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1629,6 +1721,21 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1919,6 +2026,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1944,6 +2081,16 @@ checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.2",
+ "libc",
 ]
 
 [[package]]
@@ -2088,6 +2235,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2209,7 +2362,7 @@ checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
  "bitflags 2.13.0",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
  "libc",
 ]
 
@@ -2524,6 +2677,12 @@ dependencies = [
  "libc",
  "pathdiff",
 ]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "option-ext"
@@ -2872,6 +3031,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases 0.2.2",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.4.2",
+ "lru-slab",
+ "rand",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases 0.2.2",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2891,6 +3107,32 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "raw-window-handle"
@@ -2977,19 +3219,26 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3026,6 +3275,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3054,6 +3317,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3066,6 +3404,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3124,6 +3471,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3331,7 +3701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3372,6 +3742,22 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -3495,6 +3881,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3603,7 +3995,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -3660,7 +4052,7 @@ dependencies = [
  "heck 0.5.0",
  "http",
  "image",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -3910,7 +4302,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -3933,7 +4325,7 @@ checksum = "4e6fac707727b7a2f48e4ded90976324267371073edbb415ffb73bb0458d203f"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -4146,6 +4538,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -4468,6 +4870,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4713,6 +5121,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4766,6 +5184,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5038,6 +5465,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5441,7 +5877,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2",
@@ -5592,6 +6028,12 @@ dependencies = [
  "syn 2.0.117",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -48,6 +48,10 @@ tauri-plugin-single-instance = "2"
 # the coding-agent CLI inside one). portable-pty is cross-platform (helps Linux).
 portable-pty = "0.9"
 base64 = "0.23"
+# One HTTPS GET, twice a day, to ask GitHub whether a newer release exists.
+# rustls rather than the platform TLS stack so the Linux build needs no extra
+# system package, and default features off so this stays a client, not a server.
+reqwest = { version = "0.13", default-features = false, features = ["rustls", "json", "http2"] }
 
 # POSIX process control (process groups, killpg, localtime_r). On Windows the
 # equivalent lives in the `windows` crate below (Job Objects). See src/proc.rs.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1159,6 +1159,28 @@ pub fn save_repo_config(app: AppHandle, repo_id: String, provision: Vec<Provisio
     crate::setup::write_repo_config(&path, &files, &setup).map_err(CanopyError::config)
 }
 
+/// Check GitHub for a newer release now, regardless of the auto-check
+/// preference — pressing the button IS the consent.
+#[tauri::command]
+pub async fn check_for_update(app: AppHandle) -> Result<crate::updates::UpdateStatus, CanopyError> {
+    Ok(crate::updates::check_now(&app).await)
+}
+
+/// How many crash reports are on disk, so the UI offers the folder only when
+/// there is something in it.
+#[tauri::command]
+pub fn crash_report_count(app: AppHandle) -> usize {
+    crate::updates::crash_report_count(&app)
+}
+
+/// Reveal the crash-report folder. Reports never leave the machine, so this is
+/// the only way to hand one to a bug report.
+#[tauri::command]
+pub fn open_crash_reports(app: AppHandle) -> Result<(), CanopyError> {
+    let dir = crate::updates::crash_dir(&app).ok_or_else(|| CanopyError::not_found("no log directory"))?;
+    reveal_in_finder(dir.to_string_lossy().into_owned())
+}
+
 /// `git fetch --all --prune` then return the refreshed branch lists.
 #[tauri::command]
 pub async fn fetch_branches(app: AppHandle, repo_id: String) -> Result<git::Branches, CanopyError> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ mod stats;
 mod suite;
 mod terminal;
 mod toolchain;
+mod updates;
 mod tray;
 
 use services::ProcTable;
@@ -94,6 +95,11 @@ pub fn run() {
             ));
             app.manage(ProcTable::default());
             app.manage(TermTable::default());
+
+            // crash reports + the update check need AppState for their
+            // preferences, so both are installed after it is managed
+            updates::install_panic_hook(handle.clone());
+            updates::spawn_check_task(handle.clone());
 
             // kill process groups left over from a crashed previous run
             services::sweep_orphans(&handle);
@@ -312,6 +318,9 @@ pub fn run() {
             commands::set_service_port,
             commands::run_migration,
             commands::run_custom_command,
+            commands::check_for_update,
+            commands::open_crash_reports,
+            commands::crash_report_count,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -13,6 +13,38 @@ pub struct Settings {
     pub repos: Vec<RepoCfg>,
     /// show the in-place "Switch branch" action in the worktree header
     pub show_switch_branch: bool,
+    #[serde(default)]
+    pub updates: UpdatesCfg,
+    #[serde(default)]
+    pub crash_reports: CrashCfg,
+}
+
+/// Update-check preferences. Canopy checks the project's GitHub releases for a
+/// newer tag; it never downloads or installs anything on its own (see
+/// `updates.rs` for why).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct UpdatesCfg {
+    /// check for a newer release in the background
+    pub auto_check: bool,
+}
+
+impl Default for UpdatesCfg {
+    fn default() -> Self {
+        // Checking is a single small request a few times a day and is the only
+        // way someone learns a fix shipped, so it is on by default. Anything
+        // that *installs* would not be.
+        Self { auto_check: true }
+    }
+}
+
+/// Crash-report preferences.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase", default)]
+pub struct CrashCfg {
+    /// record a stack trace to the log directory when Canopy panics.
+    /// Opt-in: off until the user turns it on.
+    pub enabled: bool,
 }
 
 impl Default for Settings {
@@ -23,6 +55,8 @@ impl Default for Settings {
             terminal: String::new(),
             repos: Vec::new(),
             show_switch_branch: true,
+            updates: UpdatesCfg::default(),
+            crash_reports: CrashCfg::default(),
         }
     }
 }

--- a/src-tauri/src/updates.rs
+++ b/src-tauri/src/updates.rs
@@ -1,0 +1,242 @@
+// Update checking and crash reports.
+//
+// ── Why checking, and not installing ──
+//
+// Tauri's updater can download and install a new bundle, but only for
+// *signed* releases: it needs a `pubkey` in tauri.conf.json whose private half
+// lives in CI. This repository has neither, and inventing a public key would
+// ship an app whose update path silently fails on every launch.
+//
+// So Canopy does the honest half: it asks GitHub whether a newer release
+// exists and tells you, with a link. Installing stays a deliberate act until
+// release signing is set up — at which point this module is where the download
+// would attach.
+//
+// ── Why crash reports are written, not sent ──
+//
+// There is no crash-report endpoint to send to. Rather than a toggle that
+// quietly does nothing, the preference controls whether a panic is *recorded*
+// at all: with it on, a panic writes its message, backtrace, app version and
+// OS to the log directory, which is the thing a bug report can attach. Nothing
+// leaves the machine, and the UI says so.
+use serde::{Deserialize, Serialize};
+use std::io::Write;
+use tauri::{AppHandle, Emitter, Manager};
+
+/// Where release metadata comes from. The repository is public, so this needs
+/// no token; unauthenticated GitHub API requests are rate-limited to 60/hour
+/// per IP, which a twice-daily check cannot approach.
+const RELEASES_URL: &str = "https://api.github.com/repos/emidhun/canopy/releases/latest";
+
+/// How often the background check runs. Deliberately slow: a release lands at
+/// most every few days, and a chattier poll buys nothing.
+const CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_secs(12 * 60 * 60);
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateStatus {
+    /// the version this build is
+    pub current: String,
+    /// the newest published release, when the check succeeded
+    pub latest: Option<String>,
+    /// `latest` is newer than `current`
+    pub available: bool,
+    /// where to read about it / download it
+    pub url: Option<String>,
+    /// why the last check produced nothing, for the UI to show verbatim
+    pub error: Option<String>,
+    /// unix seconds of the last completed check
+    pub checked_at: i64,
+}
+
+#[derive(Deserialize)]
+struct GhRelease {
+    tag_name: String,
+    html_url: String,
+    #[serde(default)]
+    draft: bool,
+    #[serde(default)]
+    prerelease: bool,
+}
+
+fn now_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+pub fn current_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+/// Compare two dotted version strings numerically, ignoring a leading `v` and
+/// anything after a `-` (so `v0.5.0-beta.1` compares as `0.5.0`).
+///
+/// String comparison would order `0.10.0` before `0.9.0`, which is exactly the
+/// case a naive check gets wrong and nobody notices until the tenth minor.
+fn is_newer(candidate: &str, current: &str) -> bool {
+    fn parts(v: &str) -> Vec<u64> {
+        v.trim().trim_start_matches(['v', 'V']).split('-').next().unwrap_or("").split('.').map(|p| p.parse().unwrap_or(0)).collect()
+    }
+    let (a, b) = (parts(candidate), parts(current));
+    for i in 0..a.len().max(b.len()) {
+        let (x, y) = (a.get(i).copied().unwrap_or(0), b.get(i).copied().unwrap_or(0));
+        if x != y {
+            return x > y;
+        }
+    }
+    false
+}
+
+/// Ask GitHub for the newest published release. Drafts and prereleases are
+/// skipped — someone running a stable build should not be told a beta is
+/// "available".
+async fn fetch_latest() -> Result<GhRelease, String> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(15))
+        // GitHub rejects requests without one
+        .user_agent(concat!("Canopy/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .map_err(|e| e.to_string())?;
+    let resp = client
+        .get(RELEASES_URL)
+        .header("Accept", "application/vnd.github+json")
+        .send()
+        .await
+        .map_err(|e| format!("could not reach GitHub: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("GitHub returned {}", resp.status()));
+    }
+    let rel: GhRelease = resp.json().await.map_err(|e| format!("unreadable release data: {e}"))?;
+    if rel.draft || rel.prerelease {
+        return Err("the newest release is a draft or prerelease".into());
+    }
+    Ok(rel)
+}
+
+/// Run one check and emit `app:update` with the result.
+pub async fn check_now(app: &AppHandle) -> UpdateStatus {
+    let current = current_version().to_string();
+    let status = match fetch_latest().await {
+        Ok(rel) => UpdateStatus {
+            available: is_newer(&rel.tag_name, &current),
+            latest: Some(rel.tag_name),
+            url: Some(rel.html_url),
+            error: None,
+            current,
+            checked_at: now_secs(),
+        },
+        Err(e) => UpdateStatus {
+            latest: None,
+            available: false,
+            url: None,
+            error: Some(e),
+            current,
+            checked_at: now_secs(),
+        },
+    };
+    let _ = app.emit("app:update", &status);
+    status
+}
+
+/// Background loop honouring `Settings.updates.auto_check`. The preference is
+/// re-read every tick rather than captured, so turning it off takes effect
+/// without a restart.
+pub fn spawn_check_task(app: AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        // let the app finish starting before spending anything on the network
+        tokio::time::sleep(std::time::Duration::from_secs(20)).await;
+        loop {
+            let enabled = app
+                .try_state::<crate::state::AppState>()
+                .map(|s| s.settings.read().updates.auto_check)
+                .unwrap_or(false);
+            if enabled {
+                let _ = check_now(&app).await;
+            }
+            tokio::time::sleep(CHECK_INTERVAL).await;
+        }
+    });
+}
+
+// ── crash reports ─────────────────────────────────────────────────────
+
+/// `<app-log-dir>/crashes`.
+pub fn crash_dir(app: &AppHandle) -> Option<std::path::PathBuf> {
+    let dir = app.path().app_log_dir().ok()?.join("crashes");
+    std::fs::create_dir_all(&dir).ok()?;
+    Some(dir)
+}
+
+/// Install the panic hook. It always chains to the previous hook (so the
+/// existing stderr/log output is untouched) and only writes a report when the
+/// preference is on — read at panic time, so toggling it needs no restart.
+pub fn install_panic_hook(app: AppHandle) {
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let enabled = app
+            .try_state::<crate::state::AppState>()
+            .map(|s| s.settings.read().crash_reports.enabled)
+            .unwrap_or(false);
+        if enabled {
+            if let Err(e) = write_report(&app, info) {
+                // a failure here must never mask the panic itself
+                log::error!("could not write crash report: {e}");
+            }
+        }
+        previous(info);
+    }));
+}
+
+fn write_report(app: &AppHandle, info: &std::panic::PanicHookInfo<'_>) -> Result<(), String> {
+    let dir = crash_dir(app).ok_or("no log directory")?;
+    let path = dir.join(format!("crash-{}.txt", now_secs()));
+    let mut f = std::fs::File::create(&path).map_err(|e| e.to_string())?;
+    // Stack traces and environment only — never settings, repo paths or
+    // anything the user typed. "Stack traces only" is the promise the
+    // preference makes, so the writer is what keeps it.
+    writeln!(f, "Canopy {} ({} {})", current_version(), std::env::consts::OS, std::env::consts::ARCH)
+        .map_err(|e| e.to_string())?;
+    writeln!(f, "when: {}", now_secs()).map_err(|e| e.to_string())?;
+    if let Some(loc) = info.location() {
+        writeln!(f, "where: {}:{}:{}", loc.file(), loc.line(), loc.column()).map_err(|e| e.to_string())?;
+    }
+    writeln!(f, "what: {info}").map_err(|e| e.to_string())?;
+    writeln!(f, "\n{}", std::backtrace::Backtrace::force_capture()).map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+/// How many reports are on disk, so the UI can offer to open the folder only
+/// when there is something in it.
+pub fn crash_report_count(app: &AppHandle) -> usize {
+    crash_dir(app)
+        .and_then(|d| std::fs::read_dir(d).ok())
+        .map(|rd| rd.flatten().filter(|e| e.path().extension().is_some_and(|x| x == "txt")).count())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_newer;
+
+    #[test]
+    fn version_comparison_is_numeric_not_lexical() {
+        assert!(is_newer("0.5.0", "0.4.0"));
+        assert!(is_newer("v0.5.0", "0.4.0"), "leading v ignored");
+        assert!(!is_newer("0.4.0", "0.4.0"), "same version is not newer");
+        assert!(!is_newer("0.3.9", "0.4.0"));
+        // the case a string compare gets wrong, and nobody notices until the
+        // tenth minor release
+        assert!(is_newer("0.10.0", "0.9.0"), "10 > 9 numerically");
+        assert!(!is_newer("0.9.0", "0.10.0"));
+        // differing component counts
+        assert!(is_newer("1.0", "0.9.9"));
+        assert!(!is_newer("1.0", "1.0.0"), "1.0 == 1.0.0");
+        assert!(is_newer("1.0.1", "1.0"));
+        // a prerelease of the SAME version is not an upgrade
+        assert!(!is_newer("0.4.0-beta.1", "0.4.0"));
+        // garbage never claims to be newer
+        assert!(!is_newer("nightly", "0.4.0"));
+    }
+}

--- a/src/app/SettingsView.tsx
+++ b/src/app/SettingsView.tsx
@@ -14,7 +14,8 @@
 import { useEffect, useMemo, useRef, useState, type ComponentType } from "react";
 import { open as openDialog, save as saveDialog } from "@tauri-apps/plugin-dialog";
 import { getVersion } from "@tauri-apps/api/app";
-import { errText, hasBackend, ipc, type AgentCfg, type ProvisionEntry, type ProvisionFormat, type RepoCfg, type ServiceCfg, type Settings } from "../ipc";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { errText, hasBackend, ipc, type AgentCfg, type ProvisionEntry, type ProvisionFormat, type RepoCfg, type ServiceCfg, type Settings, type UpdateStatus } from "../ipc";
 import { useStore } from "../store";
 import Modal, { Hint, Spacer } from "./canopy/Modal";
 import {
@@ -155,6 +156,7 @@ function hlLine(line: string): string {
 
 const MOCK: Settings = {
   version: 1, editor: { command: "code" }, terminal: "Terminal", showSwitchBranch: true,
+  updates: { autoCheck: true }, crashReports: { enabled: false },
   repos: [{
     id: "tooljet", name: "ToolJet", path: "~/ToolJetSpace/CE/ToolJet", worktreeDir: ".worktrees", resetDb: "", migrateDb: "",
     services: [
@@ -703,10 +705,87 @@ function GeneralPage({ settings, patch, markDirty }: PageProps) {
             <button key={c} className="ico" disabled style={{ background: c, borderColor: i === 0 ? "var(--text-primary)" : "transparent", width: 22, height: 22 }} />))}</div>
         </div>
       </div>
-      <Adv n="not wired yet">
-        <Soon>Automatic updates and crash reporting aren't configurable from here yet.</Soon>
-      </Adv>
+      <UpdatesSection settings={settings} patch={patch} markDirty={markDirty} />
     </>
+  );
+}
+
+/* Updates + crash reports.
+
+   Canopy checks whether a newer release exists and links to it; it does not
+   download or install. That needs signed release bundles, which this project
+   does not produce yet — an updater that silently fails every launch would be
+   worse than an honest link. Crash reports are written to the log directory
+   and never transmitted, because there is nowhere to transmit them to. */
+function UpdatesSection({ settings, patch, markDirty }: Pick<PageProps, "settings" | "patch" | "markDirty">) {
+  const [status, setStatus] = useState<UpdateStatus | null>(null);
+  const [checking, setChecking] = useState(false);
+  const [crashes, setCrashes] = useState(0);
+
+  useEffect(() => {
+    if (!hasBackend()) return;
+    ipc.crashReportCount().then(setCrashes).catch(() => {});
+  }, [settings.crashReports?.enabled]);
+
+  const check = async () => {
+    if (!hasBackend()) return;
+    setChecking(true);
+    try {
+      setStatus(await ipc.checkForUpdate());
+    } catch {
+      /* the command reports its own failure in `error`; a rejection here means
+         the backend is gone, and there is nothing useful to say about that */
+    } finally {
+      setChecking(false);
+    }
+  };
+
+  return (
+    <div className="sec">
+      <div className="slab">Updates &amp; diagnostics</div>
+      <TRow
+        title="Check for updates automatically"
+        hint="Asks GitHub twice a day whether a newer release exists. Nothing is downloaded or installed."
+        on={settings.updates?.autoCheck !== false}
+        onToggle={() => { patch({ updates: { autoCheck: !(settings.updates?.autoCheck !== false) } }); markDirty("general"); }}
+      />
+      <div className="row" style={{ marginTop: 8, alignItems: "center", gap: 10 }}>
+        <button className="btn" onClick={check} disabled={checking || !hasBackend()}>
+          {checking ? "Checking…" : "Check now"}
+        </button>
+        <span className="hint" style={{ marginTop: 0 }}>
+          {!status
+            ? `You're on ${hasBackend() ? "this build" : "a dev build"}.`
+            : status.error
+              ? status.error
+              : status.available
+                ? `${status.latest} is available — you have ${status.current}.`
+                : `Up to date (${status.current}).`}
+        </span>
+        {status?.available && status.url && (
+          <button className="btn" onClick={() => openUrl(status.url as string).catch(() => {})}>
+            Open release
+          </button>
+        )}
+      </div>
+
+      <div style={{ marginTop: 14 }}>
+        <TRow
+          title="Record crash reports"
+          hint="Writes a stack trace to the log folder if Canopy crashes. Stack traces only, and nothing is sent anywhere."
+          on={!!settings.crashReports?.enabled}
+          onToggle={() => { patch({ crashReports: { enabled: !settings.crashReports?.enabled } }); markDirty("general"); }}
+        />
+        {crashes > 0 && (
+          <div className="row" style={{ marginTop: 8, alignItems: "center", gap: 10 }}>
+            <button className="btn" onClick={() => ipc.openCrashReports().catch(() => {})}>
+              Show {crashes} report{crashes === 1 ? "" : "s"}
+            </button>
+            <span className="hint" style={{ marginTop: 0 }}>Attach one to a bug report.</span>
+          </div>
+        )}
+      </div>
+    </div>
   );
 }
 

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -57,6 +57,20 @@ export interface Settings {
   terminal: string;
   repos: RepoCfg[];
   showSwitchBranch: boolean;
+  updates: { autoCheck: boolean };
+  crashReports: { enabled: boolean };
+}
+
+/** Result of an update check. Canopy reports what exists; it never downloads
+    or installs (release signing isn't set up — see updates.rs). */
+export interface UpdateStatus {
+  current: string;
+  latest: string | null;
+  available: boolean;
+  url: string | null;
+  /** why the last check produced nothing — shown verbatim */
+  error: string | null;
+  checkedAt: number;
 }
 
 export type ProvisionFormat = "dotenv" | "json" | "yaml" | "text";
@@ -165,6 +179,10 @@ export const ipc = {
   worktreeDirtyReport: (wtKey: string) => invoke<{ dirty: boolean; details: string[]; total: number }>("worktree_dirty_report", { wtKey }),
   removeWorktree: (wtKey: string, deleteBranch: boolean, dropDb: boolean) =>
     invoke<void>("remove_worktree", { wtKey, deleteBranch, dropDb }),
+
+  checkForUpdate: () => invoke<UpdateStatus>("check_for_update"),
+  crashReportCount: () => invoke<number>("crash_report_count"),
+  openCrashReports: () => invoke<void>("open_crash_reports"),
 };
 
 export interface GitEvent extends GitMeta {


### PR DESCRIPTION
Closes #78

## Scope

#78 lists six controls. **Theme / density / accent are implemented by the open PR #97** — re-doing them here would mean two competing implementations of the same three controls and a guaranteed merge conflict in `appearance.ts` / `tokens.css` / `SettingsView.tsx`. This PR delivers the other half: **automatic updates and crash reports**. #78 closes when both land.

## Why this solution

Both toggles now do exactly what their label says — which required changing what two of the labels claim.

### Updates: check and link, don't download

The design says *"Automatic updates (background download + install on restart)"*. Tauri's updater can do that, but **only for signed releases**: it needs a `pubkey` in `tauri.conf.json` whose private half lives in CI as `TAURI_SIGNING_PRIVATE_KEY`. This repo has neither, and `release.yml` doesn't sign.

Fabricating a public key would ship an app whose update path fails silently on every launch — the worst outcome, because nobody finds out until they're stuck on an old build. So Canopy does the honest half: one HTTPS GET to the public releases API, twice a day, reporting whether something newer exists and linking to it. When release signing is set up, `updates.rs` is exactly where the download attaches.

Details that matter:

- **Numeric version comparison.** A string compare orders `0.10.0` before `0.9.0` — the bug nobody notices until the tenth minor release. Tested, along with prereleases of the same version not counting as an upgrade, differing component counts (`1.0` vs `1.0.0`), and garbage never claiming to be newer.
- **Drafts and prereleases are skipped** — someone on a stable build shouldn't be told a beta is "available".
- **The preference is re-read every tick**, not captured, so turning it off takes effect without a restart.
- **"Check now" works regardless of the toggle** — pressing the button *is* the consent.
- Default on: it's one small request and it's the only way someone learns a fix shipped. Anything that *installed* would not default on.

### Crash reports: record locally, send nowhere

The design says *"Send crash reports (stack traces only)"*. There is no crash-report endpoint. A toggle labelled "Send" that sends nothing is worse than no toggle, so the preference controls whether a panic is **recorded**: with it on, a panic writes message, location, backtrace, version and OS to `<app-log-dir>/crashes/`, and the UI offers to reveal the folder so a report can be attached to a bug. The copy states plainly that nothing is sent.

- **Opt-in** (default off) — the design's own framing, and the right default for anything touching diagnostics.
- **"Stack traces only" is enforced by the writer**: it emits the panic, location, backtrace and platform, and nothing else. No settings, no repo paths, nothing the user typed.
- **The hook chains** to the previous one, so the existing stderr + log-file output is unchanged, and a failure to write a report can never mask the panic itself.
- The preference is read **at panic time**, so toggling needs no restart.

## Dependency

One addition: `reqwest` (`default-features = false`, `rustls` + `json`). rustls rather than platform TLS so the Linux CI job needs no extra system package.

## Verification

`version_comparison_is_numeric_not_lexical` covers the ten cases above. `cargo test` 42 passed · `cargo clippy --all-targets --features devtools -- -D warnings` clean · `tsc --noEmit` clean.

## Note for the maintainer

To upgrade "check" into "download + install": run `tauri signer generate`, put the public key in `tauri.conf.json`'s `plugins.updater.pubkey`, add the private key + password as repo secrets, and pass them to `tauri-action` in `release.yml`. The check logic and preference stay as they are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYXXuRwMVeF6Dv7xebjQJL