### PR TITLE
Settings/Commands: command groups

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -85,6 +85,10 @@ pub struct CustomCmd {
     pub label: String,
     /// Shell command run in the worktree root
     pub command: String,
+    /// Optional heading this command sits under in the rail's Commands menu.
+    /// Empty = ungrouped, which is where every existing command starts.
+    #[serde(default)]
+    pub group: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/src/app/SettingsView.tsx
+++ b/src/app/SettingsView.tsx
@@ -14,7 +14,7 @@
 import { useEffect, useMemo, useRef, useState, type ComponentType } from "react";
 import { open as openDialog, save as saveDialog } from "@tauri-apps/plugin-dialog";
 import { getVersion } from "@tauri-apps/api/app";
-import { errText, hasBackend, ipc, type AgentCfg, type ProvisionEntry, type ProvisionFormat, type RepoCfg, type ServiceCfg, type Settings } from "../ipc";
+import { errText, hasBackend, ipc, type AgentCfg, type CustomCmd, type ProvisionEntry, type ProvisionFormat, type RepoCfg, type ServiceCfg, type Settings } from "../ipc";
 import { useStore } from "../store";
 import Modal, { Hint, Spacer } from "./canopy/Modal";
 import {
@@ -161,7 +161,7 @@ const MOCK: Settings = {
       { id: "fe", name: "Frontend", kind: "web", command: "pnpm --filter frontend dev", cwd: "frontend", basePort: 8232, env: { NODE_ENV: "development" } },
       { id: "srv", name: "Server", kind: "server", command: "pnpm --filter server start:dev", cwd: "server", basePort: 3150, env: { LOG_LEVEL: "debug" } },
     ],
-    customCommands: [{ label: "Lint", command: "pnpm lint" }, { label: "Unit tests", command: "pnpm test --run" }],
+    customCommands: [{ label: "Lint", command: "pnpm lint", group: "Checks" }, { label: "Unit tests", command: "pnpm test --run", group: "Checks" }],
     agentCommand: "claude",
     agents: [{ id: "a1", name: "Claude Code", command: "claude", promptOnLaunch: true }, { id: "a2", name: "Codex", command: "codex", promptOnLaunch: true }],
   }],
@@ -365,20 +365,24 @@ function CommandsPage({ repo, patchRepo, markDirty, flash, selKey }: PageProps) 
   const [ran, setRan] = useState<{ i: number; state: "running" | "done" } | null>(null);
   if (!repo) return null;
   const cmds = repo.customCommands || [];
-  const patch = (i: number, p: Partial<{ label: string; command: string }>) => { patchRepo({ customCommands: cmds.map((c, j) => (j === i ? { ...c, ...p } : c)) }); markDirty("commands"); };
+  const patch = (i: number, p: Partial<CustomCmd>) => { patchRepo({ customCommands: cmds.map((c, j) => (j === i ? { ...c, ...p } : c)) }); markDirty("commands"); };
   const move = (i: number, d: number) => { const j = i + d; if (j < 0 || j >= cmds.length) return; const n = cmds.slice(); [n[i], n[j]] = [n[j], n[i]]; patchRepo({ customCommands: n }); markDirty("commands"); };
   const test = (i: number, cmd: string) => {
     if (!hasBackend() || !selKey) { flash("Open a worktree to test a command"); return; }
     setRan({ i, state: "running" });
     ipc.runCustomCommand(selKey, cmd).then(() => setRan({ i, state: "done" })).catch((e) => { setRan(null); flash(`Command failed — ${errText(e)}`); });
   };
+  // Existing groups become suggestions: grouping is only useful when names
+  // match exactly, and free typing is how you end up with "Build" and "build".
+  const groupNames = Array.from(new Set(cmds.map((c) => (c.group ?? "").trim()).filter(Boolean)));
   return (
     <div className="sec">
+      <datalist id="cx-cmd-groups">{groupNames.map((g) => <option key={g} value={g} />)}</datalist>
       <div className="slab">Custom commands<span className="n">launchers in the agent lane's + menu</span></div>
       {cmds.length === 0 ? (
         <div className="empty">
           <p>No commands yet. Add one like <code>Lint</code> = <code>pnpm lint</code> — it appears in every worktree's + menu.</p>
-          <button className="btn sm" onClick={() => { patchRepo({ customCommands: [{ label: "", command: "" }] }); markDirty("commands"); }}><Plus size={10} />Add command</button>
+          <button className="btn sm" onClick={() => { patchRepo({ customCommands: [{ label: "", command: "", group: "" }] }); markDirty("commands"); }}><Plus size={10} />Add command</button>
         </div>
       ) : (
         <div className="objs">
@@ -402,7 +406,10 @@ function CommandsPage({ repo, patchRepo, markDirty, flash, selKey }: PageProps) 
                   <div className="fgrid">
                     <span className="lb">Label</span><input className="inp" value={c.label} placeholder="Lint" onChange={(e) => patch(i, { label: e.target.value })} />
                     <span className="lb">Command</span><input className="inp mono" value={c.command} placeholder="pnpm lint" onChange={(e) => patch(i, { command: e.target.value })} />
-                    <span className="lb">Group</span><input className="inp" disabled placeholder="coming soon" title="Command groups aren't stored yet" />
+                    <span className="lb">Group</span>
+                    <input className="inp" value={c.group ?? ""} placeholder="ungrouped" list="cx-cmd-groups"
+                      title="Commands sharing a group get a header in the rail's Commands menu"
+                      onChange={(e) => patch(i, { group: e.target.value })} />
                   </div>
                   {ran && ran.i === i && (
                     <div className="testout">
@@ -419,7 +426,7 @@ function CommandsPage({ repo, patchRepo, markDirty, flash, selKey }: PageProps) 
         </div>
       )}
       {cmds.length > 0 && (
-        <button className="btn" style={{ marginTop: 8 }} onClick={() => { patchRepo({ customCommands: cmds.concat([{ label: "", command: "" }]) }); setOpen(cmds.length); markDirty("commands"); }}><Plus size={11} />Add command</button>
+        <button className="btn" style={{ marginTop: 8 }} onClick={() => { patchRepo({ customCommands: cmds.concat([{ label: "", command: "", group: "" }]) }); setOpen(cmds.length); markDirty("commands"); }}><Plus size={11} />Add command</button>
       )}
     </div>
   );

--- a/src/app/canopy/CommandButtons.tsx
+++ b/src/app/canopy/CommandButtons.tsx
@@ -4,9 +4,10 @@
 
    The first command gets its own labelled run button; the rest collapse into a
    single "Commands" popover so the bar cannot grow without bound as the user
-   adds more. Mirrors the design's CmdButtons (cx-app.jsx). The backend
-   `CustomCmd` is `{ label, command }` with no group field, so the design's
-   per-group headers only render if a group ever appears in the data. */
+   adds more. Mirrors the design's CmdButtons (cx-app.jsx). Commands carry an
+   optional `group`, and the popover renders a header per group; ungrouped
+   commands sit together under no header, so a repo that never sets one looks
+   exactly as it did. */
 import { useEffect, useRef, useState } from "react";
 import { Chevron, Play, Spinner } from "../../icons";
 import { errText, hasBackend, ipc, type CustomCmd } from "../../ipc";
@@ -14,8 +15,8 @@ import { mockCustomCommands } from "../../mock";
 import { useStore } from "../../store";
 import type { WorktreeNode } from "../../types";
 
-// CustomCmd has no `group` yet; read it defensively so grouping still works if
-// one is ever added to the settings schema.
+/** `group` is optional in practice — a settings file written before groups
+    existed has none — so it is read defensively rather than assumed. */
 type Grouped = CustomCmd & { group?: string };
 
 export default function CommandButtons({ wt }: { wt: WorktreeNode }) {

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -24,6 +24,9 @@ export interface ServiceCfg {
 export interface CustomCmd {
   label: string;
   command: string;
+  /** heading this command sits under in the rail's Commands menu; empty =
+      ungrouped, which is where every existing command starts */
+  group: string;
 }
 
 /** A coding-agent launcher available for one repository. The command is run

--- a/src/mock.ts
+++ b/src/mock.ts
@@ -16,12 +16,12 @@ const nowS = () => Date.now() / 1000;
 
 /* Custom commands for the no-backend dev build, so the rail's command buttons
    render without a real settings file. Mirrors the design's CMDS seed. */
-export function mockCustomCommands(): { label: string; command: string }[] {
+export function mockCustomCommands(): { label: string; command: string; group: string }[] {
   return [
-    { label: "Lint", command: "pnpm lint" },
-    { label: "Unit tests", command: "pnpm test --run" },
-    { label: "Typecheck", command: "pnpm tsc --noEmit" },
-    { label: "Storybook", command: "pnpm storybook" },
+    { label: "Lint", command: "pnpm lint", group: "Checks" },
+    { label: "Unit tests", command: "pnpm test --run", group: "Checks" },
+    { label: "Typecheck", command: "pnpm tsc --noEmit", group: "Checks" },
+    { label: "Storybook", command: "pnpm storybook", group: "" },
   ];
 }
 


### PR DESCRIPTION
Closes #86

## The problem

Settings → Commands had a disabled **Group** field (`title="Command groups aren't stored yet"`). The design shows a group tag and a grouped menu; the backend `CustomCmd` was `{ label, command }`.

## Why this solution

**The render path already existed.** `CommandButtons` was written to read an optional `group` and emit a header per group — with a comment saying the backend never supplies one, so the headers only appear "if a group ever appears in the data". This PR supplies it. That makes an existing, already-reviewed code path reachable rather than adding a second grouping implementation beside it.

**Ungrouped stays the default and looks unchanged.** `group` defaults to empty, so a settings file written before this behaves identically and a repo that never sets a group sees exactly the menu it saw before. `#[serde(default)]` means no migration.

**The field suggests rather than demands.** Grouping is only useful when names match *exactly* — free-typed strings are how you end up with "Build" and "build" rendering as two separate headers next to each other. So the input is backed by a `datalist` of the groups already in use in that repo: still free text, but the existing names are one keystroke away.

**Still read defensively in the menu.** The `Grouped` type keeps `group?: string` rather than becoming required: a settings file written before groups existed genuinely has commands without the key, and the popover shouldn't depend on serde having filled it in.

## Verification

`cargo clippy --all-targets --features devtools -- -D warnings` clean · `tsc --noEmit` clean. The mock command list gains a group so the grouped menu is visible in the no-backend dev build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYXXuRwMVeF6Dv7xebjQJL