### PR TITLE
Settings/Files: explicit provisioning strategy & advanced options

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1093,6 +1093,18 @@ pub struct ProvisionEntry {
     /// ordered (key, value-template) pairs
     #[serde(default)]
     pub keys: Vec<(String, String)>,
+    /// seed | upsert | copy; empty = derive from `format`
+    #[serde(default)]
+    pub mode: String,
+    /// keep | overwrite
+    #[serde(default)]
+    pub on_conflict: String,
+    /// create | always
+    #[serde(default)]
+    pub apply_on: String,
+    /// octal, e.g. "0600"; empty = leave the file's mode alone
+    #[serde(default)]
+    pub file_mode: String,
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -1111,7 +1123,17 @@ pub struct RepoConfig {
 
 impl From<crate::setup::ProvisionFile> for ProvisionEntry {
     fn from(p: crate::setup::ProvisionFile) -> Self {
-        ProvisionEntry { path: p.path, format: p.format, from: p.from, interpolate: p.interpolate, keys: p.keys }
+        ProvisionEntry {
+            path: p.path,
+            format: p.format,
+            from: p.from,
+            interpolate: p.interpolate,
+            keys: p.keys,
+            mode: p.mode,
+            on_conflict: p.on_conflict,
+            apply_on: p.apply_on,
+            file_mode: p.file_mode,
+        }
     }
 }
 
@@ -1123,6 +1145,10 @@ impl From<ProvisionEntry> for crate::setup::ProvisionFile {
             from: e.from,
             interpolate: e.interpolate,
             keys: e.keys,
+            mode: e.mode,
+            on_conflict: e.on_conflict,
+            apply_on: e.apply_on,
+            file_mode: e.file_mode,
         }
     }
 }

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -40,6 +40,51 @@ pub struct ProvisionFile {
     pub interpolate: bool,
     /// ordered (key, value-template) pairs upserted into the file (not for text)
     pub keys: Vec<(String, String)>,
+    /// How the file is applied. Empty = derive from `format`, which is what
+    /// every existing config means: keyed formats upsert, `text` copies.
+    /// Explicit values: "seed" | "upsert" | "copy".
+    pub mode: String,
+    /// What to do when the target already exists, for seed/copy.
+    /// "keep" (default) | "overwrite".
+    pub on_conflict: String,
+    /// When it runs: "create" (only on a new worktree) | "always" (default —
+    /// create and every later setup/reset run).
+    pub apply_on: String,
+    /// Octal permissions applied after writing, e.g. "0600". Empty = leave the
+    /// file's own mode alone. Unix only; ignored on Windows.
+    pub file_mode: String,
+}
+
+/// The strategy a provision entry actually uses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProvisionMode {
+    /// write only when the target is missing; never touch an existing file
+    Seed,
+    /// merge named keys, preserving every other line
+    Upsert,
+    /// replace the whole file from source (optionally interpolating)
+    Copy,
+}
+
+impl ProvisionFile {
+    /// Resolve the strategy: an explicit `mode` wins, otherwise it is derived
+    /// from the format exactly as it always was — so a config written before
+    /// modes existed behaves identically.
+    pub fn resolved_mode(&self) -> ProvisionMode {
+        match self.mode.trim() {
+            "seed" => ProvisionMode::Seed,
+            "upsert" => ProvisionMode::Upsert,
+            "copy" | "replace" => ProvisionMode::Copy,
+            _ if self.format == "text" => ProvisionMode::Copy,
+            _ => ProvisionMode::Upsert,
+        }
+    }
+
+    /// Does this entry run outside worktree creation? Default yes — that is
+    /// what provisioning did before this was configurable.
+    pub fn applies_on_setup(&self) -> bool {
+        self.apply_on.trim() != "create"
+    }
 }
 
 #[derive(Default, Clone)]
@@ -85,7 +130,18 @@ fn parse_provision(v: &serde_json::Value) -> Vec<ProvisionFile> {
                                 .collect::<Vec<_>>()
                         })
                         .unwrap_or_default();
-                    Some(ProvisionFile { path, format, from, interpolate, keys })
+                    let str_field = |k: &str| o.get(k).and_then(|x| x.as_str()).unwrap_or("").to_string();
+                    Some(ProvisionFile {
+                        path,
+                        format,
+                        from,
+                        interpolate,
+                        keys,
+                        mode: str_field("mode"),
+                        on_conflict: str_field("onConflict"),
+                        apply_on: str_field("applyOn"),
+                        file_mode: str_field("fileMode"),
+                    })
                 })
                 .collect()
         })
@@ -128,6 +184,10 @@ pub fn read_config(wt_path: &str, repo_path: &str) -> WtmConfig {
                         from: String::new(),
                         interpolate: false,
                         keys: legacy_env,
+                        mode: String::new(),
+                        on_conflict: String::new(),
+                        apply_on: String::new(),
+                        file_mode: String::new(),
                     },
                 );
             }
@@ -161,10 +221,28 @@ fn provision_to_json(provision: &[ProvisionFile]) -> serde_json::Value {
                 if !p.from.trim().is_empty() {
                     o.insert("from".into(), serde_json::Value::String(p.from.clone()));
                 }
-                if p.format == "text" {
+                // `mode` is written explicitly now; when the user never chose
+                // one it is still written as the derived value, so the file
+                // says what it does instead of relying on the reader deriving
+                // the same thing.
+                let mode = match p.resolved_mode() {
+                    ProvisionMode::Seed => "seed",
+                    ProvisionMode::Upsert => "upsert",
+                    ProvisionMode::Copy => "copy",
+                };
+                o.insert("mode".into(), serde_json::Value::String(mode.into()));
+                if !p.on_conflict.trim().is_empty() {
+                    o.insert("onConflict".into(), serde_json::Value::String(p.on_conflict.trim().into()));
+                }
+                if !p.apply_on.trim().is_empty() {
+                    o.insert("applyOn".into(), serde_json::Value::String(p.apply_on.trim().into()));
+                }
+                if !p.file_mode.trim().is_empty() {
+                    o.insert("fileMode".into(), serde_json::Value::String(p.file_mode.trim().into()));
+                }
+                if p.resolved_mode() == ProvisionMode::Copy {
                     o.insert("interpolate".into(), serde_json::Value::Bool(p.interpolate));
                 } else {
-                    o.insert("mode".into(), serde_json::Value::String("upsert".into()));
                     let mut keys = serde_json::Map::new();
                     for (k, v) in p.keys.iter().filter(|(k, _)| !k.trim().is_empty()) {
                         keys.insert(k.clone(), serde_json::Value::String(v.clone()));
@@ -467,39 +545,94 @@ fn provision_file(wt_path: &str, repo_path: &str, pf: &ProvisionFile, vars: &Has
     }
     let src_rel = if pf.from.trim().is_empty() { pf.path.as_str() } else { pf.from.as_str() };
     let src = Path::new(repo_path).join(src_rel);
+    let exists = target.exists();
+    // "keep" is the default for a reason: overwriting a file the user has
+    // edited by hand is the one provisioning outcome that destroys work.
+    let overwrite = pf.on_conflict.trim() == "overwrite";
 
-    if pf.format == "text" {
-        let content = if target.exists() {
-            std::fs::read_to_string(&target).unwrap_or_default()
-        } else if src.exists() {
-            std::fs::read_to_string(&src).map_err(|e| format!("read {}: {e}", src.display()))?
-        } else {
-            String::new()
-        };
-        let out = if pf.interpolate { interpolate(&content, vars) } else { content };
-        return std::fs::write(&target, out).map_err(|e| format!("write {}: {e}", target.display()));
+    match pf.resolved_mode() {
+        ProvisionMode::Seed => {
+            // Seed is create-only. An existing file is left completely alone
+            // unless the entry explicitly asks to overwrite it.
+            if exists && !overwrite {
+                return Ok(());
+            }
+            if src.exists() {
+                std::fs::copy(&src, &target).map_err(|e| format!("seed {}: {e}", target.display()))?;
+            } else if !exists {
+                std::fs::write(&target, "").map_err(|e| format!("create {}: {e}", target.display()))?;
+            }
+        }
+        ProvisionMode::Copy => {
+            if exists && !overwrite {
+                // Preserve the previous behaviour for `text`: re-interpolate
+                // what is already there rather than re-copying from source, so
+                // a hand-edited file keeps its edits.
+                let content = std::fs::read_to_string(&target).unwrap_or_default();
+                let out = if pf.interpolate { interpolate(&content, vars) } else { content };
+                std::fs::write(&target, out).map_err(|e| format!("write {}: {e}", target.display()))?;
+            } else {
+                let content = if src.exists() {
+                    std::fs::read_to_string(&src).map_err(|e| format!("read {}: {e}", src.display()))?
+                } else {
+                    String::new()
+                };
+                let out = if pf.interpolate { interpolate(&content, vars) } else { content };
+                std::fs::write(&target, out).map_err(|e| format!("write {}: {e}", target.display()))?;
+            }
+        }
+        ProvisionMode::Upsert => {
+            // seed from source if the target doesn't exist yet, then merge keys
+            if !exists && src.exists() {
+                std::fs::copy(&src, &target).map_err(|e| format!("seed {}: {e}", target.display()))?;
+            }
+            let resolved: Vec<(String, String)> = pf
+                .keys
+                .iter()
+                .filter(|(k, _)| !k.trim().is_empty())
+                .map(|(k, tpl)| (k.clone(), interpolate(tpl, vars)))
+                .collect();
+            if !resolved.is_empty() {
+                let existing = std::fs::read_to_string(&target).unwrap_or_default();
+                let body = match pf.format.as_str() {
+                    "json" => upsert_json_str(&existing, &resolved)?,
+                    "yaml" => upsert_yaml_str(&existing, &resolved),
+                    _ => upsert_dotenv_str(&existing, &resolved),
+                };
+                std::fs::write(&target, body).map_err(|e| format!("write {}: {e}", target.display()))?;
+            }
+        }
     }
 
-    // key formats: seed from source if the target doesn't exist yet
-    if !target.exists() && src.exists() {
-        std::fs::copy(&src, &target).map_err(|e| format!("seed {}: {e}", target.display()))?;
-    }
-    let resolved: Vec<(String, String)> = pf
-        .keys
-        .iter()
-        .filter(|(k, _)| !k.trim().is_empty())
-        .map(|(k, tpl)| (k.clone(), interpolate(tpl, vars)))
-        .collect();
-    if resolved.is_empty() {
+    apply_file_mode(&target, &pf.file_mode)
+}
+
+/// Apply an octal permission string to a provisioned file.
+///
+/// This exists for the case that motivates it: a `.env` holding credentials
+/// should be `0600`, not whatever umask produced. A malformed value is an
+/// error rather than being ignored — silently leaving a secrets file
+/// world-readable is exactly the failure this option is meant to prevent.
+fn apply_file_mode(target: &Path, mode: &str) -> Result<(), String> {
+    let mode = mode.trim();
+    if mode.is_empty() {
         return Ok(());
     }
-    let existing = std::fs::read_to_string(&target).unwrap_or_default();
-    let body = match pf.format.as_str() {
-        "json" => upsert_json_str(&existing, &resolved)?,
-        "yaml" => upsert_yaml_str(&existing, &resolved),
-        _ => upsert_dotenv_str(&existing, &resolved),
-    };
-    std::fs::write(&target, body).map_err(|e| format!("write {}: {e}", target.display()))
+    let parsed = u32::from_str_radix(mode.trim_start_matches("0o"), 8)
+        .map_err(|_| format!("file mode '{mode}' is not octal (e.g. 0600)"))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(target, std::fs::Permissions::from_mode(parsed))
+            .map_err(|e| format!("chmod {}: {e}", target.display()))?;
+    }
+    #[cfg(not(unix))]
+    {
+        // Windows has no POSIX mode bits; the value is still validated above so
+        // a config is portable, but there is nothing to apply.
+        let _ = (target, parsed);
+    }
+    Ok(())
 }
 
 /// Re-apply every key-based provisioned file's keys with fresh `vars` (e.g. after
@@ -507,7 +640,11 @@ fn provision_file(wt_path: &str, repo_path: &str, pf: &ProvisionFile, vars: &Has
 /// `text` files so their contents aren't re-copied.
 pub fn reapply_provision(wt_path: &str, repo_path: &str, vars: &HashMap<String, String>) -> Result<(), String> {
     let cfg = read_config(wt_path, repo_path);
-    for pf in cfg.provision.iter().filter(|p| p.format != "text") {
+    for pf in cfg
+        .provision
+        .iter()
+        .filter(|p| p.resolved_mode() == ProvisionMode::Upsert && p.applies_on_setup())
+    {
         provision_file(wt_path, repo_path, pf, vars)?;
     }
     Ok(())
@@ -683,6 +820,69 @@ mod tests {
     use super::*;
 
     #[test]
+    fn provision_modes_and_conflict_policy() {
+        let dir = std::env::temp_dir().join("canopy_provision_mode_test_xyz");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let d = dir.to_str().unwrap();
+        let vars = HashMap::new();
+        let target = dir.join("out.env");
+
+        // An entry with no explicit mode behaves exactly as it always did:
+        // keyed formats upsert, `text` copies.
+        let legacy = ProvisionFile { path: "out.env".into(), format: "dotenv".into(), keys: vec![("A".into(), "1".into())], ..Default::default() };
+        assert_eq!(legacy.resolved_mode(), ProvisionMode::Upsert);
+        let legacy_text = ProvisionFile { path: "t.txt".into(), format: "text".into(), ..Default::default() };
+        assert_eq!(legacy_text.resolved_mode(), ProvisionMode::Copy);
+
+        // seed: creates when missing …
+        let seed = ProvisionFile { path: "out.env".into(), format: "dotenv".into(), mode: "seed".into(), ..Default::default() };
+        provision_file(d, d, &seed, &vars).unwrap();
+        assert!(target.exists(), "seed creates the file");
+        std::fs::write(&target, "HAND=edited\n").unwrap();
+        // … and never touches it again, which is the whole point
+        provision_file(d, d, &seed, &vars).unwrap();
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "HAND=edited\n", "seed leaves an existing file alone");
+
+        // upsert merges without disturbing other lines
+        provision_file(d, d, &legacy, &vars).unwrap();
+        let body = std::fs::read_to_string(&target).unwrap();
+        assert!(body.contains("HAND=edited"), "upsert preserves untouched lines");
+        assert!(body.contains("A=1"), "upsert adds the key");
+
+        // copy with the default keep policy re-interpolates in place rather
+        // than clobbering hand edits
+        let copy = ProvisionFile { path: "out.env".into(), format: "text".into(), mode: "copy".into(), ..Default::default() };
+        provision_file(d, d, &copy, &vars).unwrap();
+        assert!(std::fs::read_to_string(&target).unwrap().contains("HAND=edited"), "copy keeps by default");
+
+        // overwrite is opt-in and does replace
+        std::fs::write(dir.join("src.txt"), "FROM=source\n").unwrap();
+        let clobber = ProvisionFile {
+            path: "out.env".into(),
+            format: "text".into(),
+            from: "src.txt".into(),
+            mode: "copy".into(),
+            on_conflict: "overwrite".into(),
+            ..Default::default()
+        };
+        provision_file(d, d, &clobber, &vars).unwrap();
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "FROM=source\n", "overwrite replaces");
+
+        // applyOn: "create" entries are skipped by later setup runs
+        assert!(legacy.applies_on_setup(), "default applies on every run");
+        let once = ProvisionFile { apply_on: "create".into(), ..legacy.clone() };
+        assert!(!once.applies_on_setup());
+
+        // a malformed file mode is an error, not a silent no-op — the whole
+        // point of the option is not leaving a secrets file world-readable
+        let bad = ProvisionFile { path: "out.env".into(), format: "dotenv".into(), file_mode: "rw-".into(), ..Default::default() };
+        assert!(provision_file(d, d, &bad, &vars).unwrap_err().contains("octal"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
     fn wt_slug_is_db_safe() {
         assert_eq!(wt_slug("/Users/me/wt/Feat-X.2"), "feat_x_2");
         assert_eq!(wt_slug("/w/plain"), "plain");
@@ -767,6 +967,7 @@ mod tests {
             from: String::new(),
             interpolate: false,
             keys: vec![("A".into(), "1".into())],
+            ..Default::default()
         }];
         write_repo_config(dir.to_str().unwrap(), &prov, &["echo hi".into()]).unwrap();
         let v: serde_json::Value = serde_json::from_str(&std::fs::read_to_string(&cfg_path).unwrap()).unwrap();
@@ -815,6 +1016,7 @@ mod tests {
             from: from.into(),
             interpolate: false,
             keys: vec![("K".into(), "v".into())],
+            ..Default::default()
         };
         let d = dir.to_str().unwrap();
         assert!(provision_file(d, d, &mk("../escape.env", ""), &vars).is_err(), "rejects ..");

--- a/src/app/SettingsView.tsx
+++ b/src/app/SettingsView.tsx
@@ -102,19 +102,30 @@ const VARS: { t: string; d: string }[] = [
 let _uid = 0;
 const uid = (p: string) => `${p}-${++_uid}`;
 type KeyRow = { id: string; k: string; v: string };
-type FileCardT = { id: string; path: string; format: ProvisionFormat; from: string; interpolate: boolean; keys: KeyRow[] };
+type FileCardT = {
+  id: string; path: string; format: ProvisionFormat; from: string; interpolate: boolean; keys: KeyRow[];
+  /** "" derives from the format, exactly as the backend does */
+  mode: string; onConflict: string; applyOn: string; fileMode: string;
+};
+
+/** The strategy an entry actually uses — mirrors ProvisionFile::resolved_mode
+    so the radios show what will happen, not what was typed. */
+const resolvedMode = (c: { mode: string; format: ProvisionFormat }): "seed" | "upsert" | "copy" =>
+  c.mode === "seed" || c.mode === "upsert" || c.mode === "copy" ? c.mode : c.format === "text" ? "copy" : "upsert";
 
 function toCards(entries: ProvisionEntry[]): FileCardT[] {
   return entries.map((e) => ({
     id: uid("f"), path: e.path, format: e.format, from: e.from || "", interpolate: !!e.interpolate,
     keys: (e.keys || []).map(([k, v]) => ({ id: uid("k"), k, v })),
+    mode: e.mode || "", onConflict: e.onConflict || "", applyOn: e.applyOn || "", fileMode: e.fileMode || "",
   }));
 }
 function fromCards(cards: FileCardT[]): ProvisionEntry[] {
   return cards.filter((c) => c.path.trim()).map((c) => ({
     path: c.path.trim(), format: c.format, from: c.from.trim(),
-    interpolate: c.format === "text" ? c.interpolate : false,
-    keys: c.format === "text" ? [] : (c.keys.filter((k) => k.k.trim()).map((k) => [k.k, k.v]) as [string, string][]),
+    interpolate: resolvedMode(c) === "copy" ? c.interpolate : false,
+    keys: resolvedMode(c) === "copy" ? [] : (c.keys.filter((k) => k.k.trim()).map((k) => [k.k, k.v]) as [string, string][]),
+    mode: c.mode, onConflict: c.onConflict, applyOn: c.applyOn, fileMode: c.fileMode.trim(),
   }));
 }
 function buildConfig(cards: FileCardT[], setup: string[], teardown: string[], migrate: string[]) {
@@ -123,8 +134,13 @@ function buildConfig(cards: FileCardT[], setup: string[], teardown: string[], mi
     provision: cards.filter((c) => c.path.trim()).map((c) => {
       const o: Record<string, unknown> = { path: c.path.trim(), format: c.format };
       if (c.from.trim()) o.from = c.from.trim();
-      if (c.format === "text") o.interpolate = c.interpolate;
-      else { o.mode = "upsert"; o.keys = Object.fromEntries(c.keys.filter((k) => k.k.trim()).map((k) => [k.k, k.v])); }
+      const m = resolvedMode(c);
+      o.mode = m;
+      if (c.onConflict) o.onConflict = c.onConflict;
+      if (c.applyOn) o.applyOn = c.applyOn;
+      if (c.fileMode.trim()) o.fileMode = c.fileMode.trim();
+      if (m === "copy") o.interpolate = c.interpolate;
+      else o.keys = Object.fromEntries(c.keys.filter((k) => k.k.trim()).map((k) => [k.k, k.v]));
       return o;
     }),
     setup: setup.filter((s) => s.trim()),
@@ -170,8 +186,8 @@ const MOCK: Settings = {
   }],
 };
 const MOCK_CARDS: ProvisionEntry[] = [
-  { path: ".env", format: "dotenv", from: ".env", interpolate: false, keys: [["PG_DB", "${INT_DB_NAME}"], ["PORT", "${WT_SERVICE_PORT}"]] },
-  { path: "ee/.env", format: "dotenv", from: "ee/.env", interpolate: false, keys: [["LICENSE_KEY", ""]] },
+  { path: ".env", format: "dotenv", from: ".env", interpolate: false, keys: [["PG_DB", "${INT_DB_NAME}"], ["PORT", "${WT_SERVICE_PORT}"]], mode: "", onConflict: "", applyOn: "", fileMode: "" },
+  { path: "ee/.env", format: "dotenv", from: "ee/.env", interpolate: false, keys: [["LICENSE_KEY", ""]], mode: "", onConflict: "", applyOn: "", fileMode: "0600" },
 ];
 const MOCK_SETUP = ["pnpm install", "pnpm --filter server db:migrate", "pnpm build:plugins"];
 
@@ -448,7 +464,8 @@ function CommandsPage({ repo, patchRepo, markDirty, flash, selKey }: PageProps) 
 
 /* ══════════════════════════ real: Files ════════════════════════════════ */
 const FMTS: ProvisionFormat[] = ["dotenv", "json", "yaml", "text"];
-function FilesPage({ cards, setCards, markDirty, flash }: PageProps) {
+function FilesPage({ cards, setCards, markDirty, flash, repo }: PageProps) {
+  const repoPath = repo?.path ?? "";
   const [selId, setSelId] = useState<string | null>(cards[0]?.id ?? null);
   const sel = cards.find((c) => c.id === selId) || cards[0] || null;
   const keyRef = useRef<number | null>(null);
@@ -482,7 +499,7 @@ function FilesPage({ cards, setCards, markDirty, flash }: PageProps) {
           ))}
         </div>
         <div className="row" style={{ marginTop: 8 }}>
-          <button className="btn" onClick={() => { const n: FileCardT = { id: uid("f"), path: "", format: "dotenv", from: "", interpolate: false, keys: [] }; setCards(cards.concat([n])); setSelId(n.id); markDirty("files"); }}><Plus size={11} />Add file</button>
+          <button className="btn" onClick={() => { const n: FileCardT = { id: uid("f"), path: "", format: "dotenv", from: "", interpolate: false, keys: [], mode: "", onConflict: "", applyOn: "", fileMode: "" }; setCards(cards.concat([n])); setSelId(n.id); markDirty("files"); }}><Plus size={11} />Add file</button>
           <span className="hint" style={{ marginTop: 0 }}>Any path, any format. Env overrides take precedence.</span>
         </div>
       </div>
@@ -505,27 +522,39 @@ function FilesPage({ cards, setCards, markDirty, flash }: PageProps) {
             <div className="sbody">
               <div className="row">
                 <input className="inp mono gr" value={sel.from} placeholder="same path in the repo root" onChange={(e) => patch({ from: e.target.value })} />
-                <button className="ico" title="Browse for a source file (coming soon)" onClick={() => flash("Choosing a source file isn't wired yet")}><Finder size={12} /></button>
+                <button className="ico" title="Browse for a source file" onClick={async () => {
+                  if (!hasBackend()) return flash("Browsing needs the desktop app");
+                  try {
+                    const picked = await openDialog({ title: "Choose a source file", multiple: false, directory: false });
+                    if (typeof picked !== "string") return;
+                    // `from` is repo-relative — an absolute path outside the
+                    // repo is rejected by the backend's containment check, so
+                    // say so here rather than saving something that will fail.
+                    const root = repoPath ? repoPath.replace(/\/$/, "") + "/" : "";
+                    if (root && picked.startsWith(root)) patch({ from: picked.slice(root.length) });
+                    else flash("Pick a file inside the repository — sources are repo-relative");
+                  } catch (e) { flash(errText(e)); }
+                }}><Finder size={12} /></button>
               </div>
               <div className="hint">Leave empty to read the same path from the repo root.</div>
             </div>
 
             <div className="stp done"><span className="num">3</span><span className="st"><b>Strategy</b><span>how it is applied</span></span></div>
             <div className="sbody">
-              {/* the backend derives strategy from the format (keyed → upsert,
-                  text → copy + interpolate); an independent mode isn't stored yet */}
               <div className="strat">
-                {([["seed", "Seed if missing", "create only when the file does not exist"], ["upsert", "Upsert keys", "add or update named keys, leave the rest alone"], ["replace", "Copy + interpolate", "overwrite the whole file from source"]] as [string, string, string][]).map(([v, t, d]) => {
-                  const cur = sel.format === "text" ? "replace" : "upsert";
+                {([["seed", "Seed if missing", "create only when the file does not exist"], ["upsert", "Upsert keys", "add or update named keys, leave the rest alone"], ["copy", "Copy + interpolate", "replace the whole file from source"]] as [string, string, string][]).map(([v, t, d]) => {
+                  const cur = resolvedMode(sel);
                   return (
                     <label key={v} className={cur === v ? "on" : ""}>
-                      <input type="radio" name={"mode-" + sel.id} checked={cur === v} disabled readOnly />
+                      <input type="radio" name={"mode-" + sel.id} checked={cur === v} onChange={() => patch({ mode: v })} />
                       <b>{t}</b><span>{d}</span>
                     </label>
                   );
                 })}
               </div>
-              <div className="hint">Derived from the format for now — an independent strategy isn't stored yet.</div>
+              <div className="hint">
+                {sel.mode ? "Chosen explicitly." : `Derived from the format (${sel.format}). Pick one to set it explicitly.`}
+              </div>
             </div>
 
             <div className={"stp" + ((sel.format === "text" ? sel.interpolate : sel.keys.length) ? " done" : "")}>
@@ -567,13 +596,26 @@ function FilesPage({ cards, setCards, markDirty, flash }: PageProps) {
               )}
             </div>
           </div>
-          <Adv n="not wired yet">
-            <Soon>The on-conflict policy, when-to-apply trigger and file mode aren't stored yet — keys are upserted on create and reset.</Soon>
-            <div className="soonwrap fgrid">
-              <span className="lb">On conflict</span><select className="inp" disabled><option>Keep existing value</option></select>
-              <span className="lb">Apply on</span><select className="inp" disabled><option>Create and reset</option></select>
-              <span className="lb">File mode</span><input className="inp mono" disabled defaultValue="0644" style={{ width: 90 }} />
+          <Adv>
+            <div className="fgrid">
+              <span className="lb">On conflict</span>
+              <select className="inp" value={sel.onConflict || "keep"} onChange={(e) => patch({ onConflict: e.target.value === "keep" ? "" : e.target.value })}>
+                <option value="keep">Keep the existing file</option>
+                <option value="overwrite">Overwrite it</option>
+              </select>
+              <span className="lb">Apply on</span>
+              <select className="inp" value={sel.applyOn || "always"} onChange={(e) => patch({ applyOn: e.target.value === "always" ? "" : e.target.value })}>
+                <option value="always">Create and every setup run</option>
+                <option value="create">Only when the worktree is created</option>
+              </select>
+              <span className="lb">File mode</span>
+              <input className="inp mono" style={{ width: 90 }} value={sel.fileMode} placeholder="unchanged" onChange={(e) => patch({ fileMode: e.target.value })} />
             </div>
+            <p className="hint">
+              Keeping the existing file is the default: overwriting one someone edited by hand is the only provisioning
+              outcome that destroys work. File mode is octal (<span className="mono">0600</span> for a file holding
+              credentials) and applies on Unix; a malformed value is rejected rather than silently ignored.
+            </p>
           </Adv>
         </div>
       )}

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -72,6 +72,15 @@ export interface ProvisionEntry {
   interpolate: boolean;
   /** ordered [key, value-template] pairs (ignored for `text`) */
   keys: [string, string][];
+  /** seed | upsert | copy. Empty derives from `format`, which is what every
+      config written before modes existed means. */
+  mode: string;
+  /** keep | overwrite — what to do when the target already exists */
+  onConflict: string;
+  /** create | always — whether later setup runs re-apply it */
+  applyOn: string;
+  /** octal permissions, e.g. "0600"; empty leaves the file's mode alone */
+  fileMode: string;
 }
 
 /** The repo's `.worktreemanager.json` as exchanged with Settings. `teardown` /

--- a/src/onboarding/Onboarding.tsx
+++ b/src/onboarding/Onboarding.tsx
@@ -901,7 +901,14 @@ export default function Onboarding({ onClose, onCreateWorktree }: { onClose: () 
         t: "Writing .worktreemanager.json",
         run: async () => {
           if (!ctx.repo) throw new Error("repo not resolved");
-          const provision: ProvisionEntry[] = envPairs.length ? [{ path: ".env", format: "dotenv", from: "", interpolate: false, keys: envPairs }] : [];
+          const provision: ProvisionEntry[] = envPairs.length
+            ? [{
+                path: ".env", format: "dotenv", from: "", interpolate: false, keys: envPairs,
+                // Onboarding writes the defaults explicitly rather than leaving
+                // them blank, so the generated config says what it does.
+                mode: "upsert", onConflict: "", applyOn: "", fileMode: "",
+              }]
+            : [];
           await ipc.saveRepoConfig(ctx.repo.id, provision, setupCmds);
           return `${envPairs.length} env ${envPairs.length === 1 ? "key" : "keys"} · ${setupCmds.length} setup`;
         },


### PR DESCRIPTION
Closes #88

## The problem

Settings → Files showed the **Strategy** radios disabled ("Derived from the format for now"), an Advanced block behind a coming-soon banner (On conflict / Apply on / File mode), and a **Browse…** button that flashed "isn't wired yet".

## Why this solution

**The derivation becomes the fallback, not the rule.** `provision_file` inferred strategy from `format`: keyed formats upsert, `text` copies. That inference stays — as the behaviour of an entry with no explicit `mode` — so every existing `.worktreemanager.json` provisions exactly as it did. An explicit mode simply wins. No migration, no version bump.

**The radios show the resolved mode, not the stored one.** A file with `mode: ""` and `format: "dotenv"` renders "Upsert keys" as selected, because that is what will happen. Showing the empty stored value would leave all three radios blank on every pre-existing entry, which reads as "nothing configured" for something that is very much configured.

**"Keep the existing file" is the default on-conflict policy.** Overwriting a file someone edited by hand is the one provisioning outcome that destroys work — and `.env` files are edited by hand constantly. Overwrite is available and opt-in.

Copy-with-keep **re-interpolates in place** rather than re-copying from source. That's not a compromise, it's the previous behaviour for `text` entries preserved precisely: hand edits survive, `${VAR}` tokens refresh.

**File mode is validated, not best-effort.** It exists for one reason: a `.env` holding credentials should be `0600`, not whatever `umask` produced. So a malformed value is an **error** — silently ignoring "rw-" would leave the secrets file world-readable, which is exactly the failure the option is meant to prevent. It's validated on every platform (so a config stays portable) and applied on Unix.

**Apply-on defaults to "always"**, matching today: `reapply_provision` re-runs keyed entries after a port change so dependent values follow. `"create"` opts an entry out of that, for a file that should be seeded once and then owned by the user.

**Browse rejects files outside the repository.** `from` is repo-relative and the backend's containment check refuses anything else, so the picker converts a path under the repo root to a relative one and tells you plainly when you picked outside it — rather than storing an absolute path that fails later, during a worktree creation.

## Verification

`provision_modes_and_conflict_policy` covers: legacy entries resolving to the old behaviour for both keyed and `text` formats; seed creating then never touching an existing file; upsert preserving untouched lines; copy keeping hand edits by default; overwrite actually replacing; `applyOn` gating; and a malformed file mode erroring.

`cargo test` 42 passed · `cargo clippy --all-targets --features devtools -- -D warnings` clean · `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYXXuRwMVeF6Dv7xebjQJL