### PR TITLE
CI: verify the production CSP actually renders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,30 @@ jobs:
       # warnings are errors in CI — the branch is clippy-clean; keep it that way
       - run: cargo clippy --all-targets --features devtools --locked -- -D warnings
         working-directory: src-tauri
+      # includes the CSP regression guard (src-tauri/src/csp.rs): asserts the
+      # production policy exists and still carries the directives the app needs
       - run: cargo test --locked
         working-directory: src-tauri
+
+      # ── does the app actually RENDER under the shipped CSP? (#93) ──
+      #
+      # Nothing else in this workflow can answer that. `cargo test` never loads
+      # a webview; `tauri dev` runs under devCsp, not the shipped policy; and
+      # `tauri build` proves the bundle compiles and signs, not that it paints.
+      # The failure mode is a blank window on first launch of a release build.
+      #
+      # This serves the already-built `dist/` with the exact Content-Security-
+      # Policy read from tauri.conf.json (never a copy) and loads all three
+      # entry points in headless Chromium, failing on any CSP violation or on a
+      # page that loads but renders empty.
+      #
+      # NOT COVERED: without a Tauri runtime `hasBackend()` is false, so the app
+      # renders in mock mode and the IPC bridge is never exercised —
+      # `connect-src ipc:` is not verified here. Doing so needs tauri-driver +
+      # WebdriverIO (Linux/Windows only, unsupported on macOS); see #93 layer 3.
+      - name: Install Chromium for the CSP check
+        run: npx playwright install --with-deps chromium
+      - run: npm run csp:check
 
   windows:
     runs-on: windows-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^6.0.4",
+        "playwright": "^1.58.0",
         "typescript": "~7.0.2",
         "vite": "^8.1.5"
       }
@@ -1368,6 +1369,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "csp:check": "node scripts/csp-check.mjs"
   },
   "dependencies": {
     "@tauri-apps/api": "^2.11.1",
@@ -26,6 +27,7 @@
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^6.0.4",
+    "playwright": "^1.58.0",
     "typescript": "~7.0.2",
     "vite": "^8.1.5"
   },

--- a/scripts/csp-check.mjs
+++ b/scripts/csp-check.mjs
@@ -1,0 +1,154 @@
+/* Layer 2 of the CSP guard (#93).
+ *
+ * The failure this exists to catch is the worst kind: a blank window on first
+ * launch of a RELEASE build, with the cause visible only in the devtools
+ * console. Nothing in the existing CI can see it — `cargo test` never loads a
+ * webview, `tauri dev` exercises `devCsp` rather than the shipped policy, and
+ * `tauri build` proves the bundle compiles and signs, not that it renders.
+ *
+ * The frontend is static, so it can be verified without Tauri at all:
+ *
+ *   1. serve `dist/` with the EXACT `Content-Security-Policy` header read from
+ *      tauri.conf.json — never a copy, or this rots the first time the policy
+ *      changes and nobody updates the test
+ *   2. load each entry point in headless Chromium
+ *   3. fail on any `securitypolicyviolation` or CSP-related console error
+ *   4. assert the page actually rendered — a root element with children, not a
+ *      blank body that "loaded fine"
+ *
+ * ── What this does NOT cover ──
+ *
+ * Without a Tauri runtime `hasBackend()` is false, so the app renders in mock
+ * mode and the IPC bridge is never exercised. `connect-src ipc:` is therefore
+ * NOT verified here. That gap is deliberate and accepted: this covers the
+ * rendering class of failure, which is what actually produces the blank
+ * window. Verifying the bridge needs tauri-driver + WebdriverIO (Linux and
+ * Windows only — not supported on macOS), which is issue #93's layer 3.
+ */
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { createReadStream, existsSync } from "node:fs";
+import { extname, join, normalize, resolve } from "node:path";
+import { chromium } from "playwright";
+
+const ROOT = resolve(import.meta.dirname, "..");
+const DIST = join(ROOT, "dist");
+const CONF = join(ROOT, "src-tauri", "tauri.conf.json");
+
+/** Entry points Tauri can open. All three must load clean. */
+const ENTRIES = ["index.html", "popover.html", "terminal.html"];
+
+const MIME = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".mjs": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+  ".woff2": "font/woff2",
+  ".json": "application/json",
+  ".map": "application/json",
+};
+
+async function readCsp() {
+  const conf = JSON.parse(await readFile(CONF, "utf8"));
+  const csp = conf?.app?.security?.csp;
+  if (typeof csp !== "string" || !csp.trim()) {
+    throw new Error(`app.security.csp in ${CONF} is ${JSON.stringify(csp)} — expected a policy string`);
+  }
+  return csp;
+}
+
+function serve(csp) {
+  const server = createServer((req, res) => {
+    // strip the query/hash, then normalize — a served path must not escape dist
+    const rel = normalize(decodeURIComponent((req.url ?? "/").split("?")[0])).replace(/^(\.\.[/\\])+/, "");
+    const file = join(DIST, rel === "/" ? "index.html" : rel);
+    if (!file.startsWith(DIST) || !existsSync(file)) {
+      res.writeHead(404).end("not found");
+      return;
+    }
+    res.writeHead(200, {
+      "Content-Type": MIME[extname(file)] ?? "application/octet-stream",
+      // the whole point: the shipped policy, verbatim
+      "Content-Security-Policy": csp,
+    });
+    createReadStream(file).pipe(res);
+  });
+  return new Promise((ok) => server.listen(0, "127.0.0.1", () => ok(server)));
+}
+
+/** A console message that indicates a CSP problem rather than app noise. */
+const isCspError = (text) => /content security policy|refused to (load|execute|apply|connect)/i.test(text);
+
+async function main() {
+  if (!existsSync(DIST)) {
+    throw new Error(`${DIST} does not exist — run \`npm run build\` first`);
+  }
+  const csp = await readCsp();
+  console.log(`policy under test (from tauri.conf.json):\n  ${csp.replace(/;\s*/g, ";\n  ")}\n`);
+
+  const server = await serve(csp);
+  const { port } = server.address();
+  const browser = await chromium.launch();
+  const failures = [];
+
+  for (const entry of ENTRIES) {
+    const page = await browser.newPage();
+    const problems = [];
+
+    // The event the browser fires for every blocked resource — the
+    // authoritative signal, ahead of console text matching.
+    await page.addInitScript(() => {
+      window.__cspViolations = [];
+      document.addEventListener("securitypolicyviolation", (e) => {
+        window.__cspViolations.push(`${e.violatedDirective} blocked ${e.blockedURI || "(inline)"}`);
+      });
+    });
+    page.on("console", (m) => {
+      if (m.type() === "error" && isCspError(m.text())) problems.push(`console: ${m.text()}`);
+    });
+    page.on("pageerror", (e) => problems.push(`pageerror: ${e.message}`));
+
+    const url = `http://127.0.0.1:${port}/${entry}`;
+    await page.goto(url, { waitUntil: "networkidle" });
+    // give React a moment to mount before asking whether anything rendered
+    await page.waitForTimeout(500);
+
+    problems.push(...(await page.evaluate(() => window.__cspViolations ?? [])));
+
+    // "Loaded" is not "rendered": a CSP that blocks the bundle still returns a
+    // 200 for the HTML and a body with a root element in it. Children are the
+    // thing that proves the app ran.
+    const rendered = await page.evaluate(() => {
+      const root = document.getElementById("root");
+      return { hasRoot: !!root, children: root?.childElementCount ?? 0, bodyText: (document.body.innerText ?? "").trim().length };
+    });
+    if (!rendered.hasRoot) problems.push("no #root element");
+    else if (rendered.children === 0 && rendered.bodyText === 0) problems.push("#root is empty — the page rendered blank");
+
+    if (problems.length) {
+      failures.push(`${entry}:\n    ${problems.join("\n    ")}`);
+      console.log(`  ✕ ${entry}`);
+    } else {
+      console.log(`  ✓ ${entry} — rendered ${rendered.children} root child element(s), no CSP violations`);
+    }
+    await page.close();
+  }
+
+  await browser.close();
+  server.close();
+
+  if (failures.length) {
+    console.error(`\nCSP check failed:\n\n  ${failures.join("\n\n  ")}\n`);
+    console.error("The production policy blocks something the app needs. Fix the policy in");
+    console.error("src-tauri/tauri.conf.json, or the code that depends on what it blocks.\n");
+    process.exit(1);
+  }
+  console.log(`\nAll ${ENTRIES.length} entry points render clean under the production CSP.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src-tauri/src/csp.rs
+++ b/src-tauri/src/csp.rs
@@ -1,0 +1,104 @@
+// Layer 1 of the CSP guard (see .github/workflows/ci.yml and #93).
+//
+// `cargo check`, `clippy` and `cargo test` never load a webview, so nothing in
+// the Rust test suite can prove the production Content-Security-Policy lets
+// the app render. What it CAN prove is that the policy still exists and still
+// contains the directives the app is known to depend on — which catches the
+// most likely regression by far: someone loosening, gutting or deleting the
+// policy while debugging and not putting it back.
+//
+// The stronger check (does it actually render?) is layer 2, a headless
+// Chromium load under this exact policy. See `scripts/csp-check.mjs`.
+
+/// The shipped Tauri config, read from source rather than embedded, so this
+/// test fails on the *current* file rather than on whatever was compiled in.
+#[cfg(test)]
+fn tauri_conf() -> serde_json::Value {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tauri.conf.json");
+    let txt = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    serde_json::from_str(&txt).unwrap_or_else(|e| panic!("{} is not valid JSON: {e}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::tauri_conf;
+
+    /// Directives the app depends on, and why. Each entry is
+    /// (directive, required-source, what breaks without it).
+    const REQUIRED: &[(&str, &str, &str)] = &[
+        ("default-src", "'self'", "everything not covered by a more specific directive"),
+        ("script-src", "'self'", "the bundled JS, including Tauri's injected IPC bootstrap"),
+        // xterm.js and the design system both set inline styles at runtime;
+        // without this the terminal and every themed surface render unstyled.
+        ("style-src", "'unsafe-inline'", "xterm.js and runtime theming set inline styles"),
+        // the app icon set and terminal glyph atlas are data: / blob: URLs
+        ("img-src", "data:", "inline SVG icons and the WebGL glyph atlas"),
+        ("font-src", "data:", "the bundled woff2 faces"),
+        // the IPC bridge: without it every command call is blocked and the app
+        // renders but can do nothing
+        ("connect-src", "ipc:", "the Tauri IPC bridge"),
+    ];
+
+    #[test]
+    fn production_csp_exists_and_keeps_the_directives_the_app_needs() {
+        let conf = tauri_conf();
+        let csp = conf
+            .pointer("/app/security/csp")
+            .unwrap_or_else(|| panic!("app.security.csp is missing — the production policy must not be removed"));
+
+        let csp = csp.as_str().unwrap_or_else(|| {
+            panic!("app.security.csp is {csp} — `null` disables the policy entirely, which ships an app with no CSP")
+        });
+        assert!(!csp.trim().is_empty(), "app.security.csp is empty");
+
+        for (directive, source, why) in REQUIRED {
+            let found = csp
+                .split(';')
+                .map(str::trim)
+                .find(|d| d.split_whitespace().next() == Some(directive))
+                .unwrap_or_else(|| panic!("CSP is missing `{directive}` — needed for {why}\npolicy: {csp}"));
+            assert!(
+                found.split_whitespace().any(|t| t == *source),
+                "CSP `{directive}` no longer allows `{source}` — needed for {why}\nfound: {found}"
+            );
+        }
+    }
+
+    /// `worker-src` is unset and therefore inherits `default-src 'self'`. The
+    /// issue flags this as the fragile spot: a bundler chunking strategy or a
+    /// library upgrade that introduces a `blob:` worker would break silently,
+    /// at runtime, in a release build only.
+    ///
+    /// This test does not require `worker-src` — it pins the CURRENT state, so
+    /// that adding one is a deliberate edit here rather than an accident.
+    #[test]
+    fn worker_src_inheritance_is_deliberate() {
+        let conf = tauri_conf();
+        let csp = conf.pointer("/app/security/csp").and_then(|c| c.as_str()).unwrap_or_default();
+        let has_worker_src = csp.split(';').map(str::trim).any(|d| d.split_whitespace().next() == Some("worker-src"));
+        assert!(
+            !has_worker_src,
+            "worker-src was added to the CSP. That may be correct — but update this test and \
+             confirm scripts/csp-check.mjs still passes, since workers are exactly the case \
+             layer 1 cannot verify."
+        );
+    }
+
+    /// The dev policy is a superset for the dev server; it must never be the
+    /// one that ships, and it must not be missing (a dev build with the
+    /// production policy cannot reach the Vite HMR socket).
+    #[test]
+    fn dev_csp_is_separate_from_the_production_one() {
+        let conf = tauri_conf();
+        let prod = conf.pointer("/app/security/csp").and_then(|c| c.as_str()).unwrap_or_default();
+        let dev = conf
+            .pointer("/app/security/devCsp")
+            .and_then(|c| c.as_str())
+            .expect("app.security.devCsp is missing — `npm run tauri dev` would run under the production policy");
+        assert_ne!(prod, dev, "devCsp and csp are identical — one of them is wrong");
+        assert!(
+            !prod.contains("localhost:1420"),
+            "the PRODUCTION policy allows the Vite dev server; devCsp was probably copied over it\npolicy: {prod}"
+        );
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,6 @@
 mod commands;
+#[cfg(test)]
+mod csp;
 mod db;
 mod error;
 mod git;


### PR DESCRIPTION
Closes #93

## The problem

#91 replaced `"csp": null` with a real Content Security Policy — and it was the one change on that branch **no existing check could validate**:

- `cargo check` / `clippy` / `cargo test` never load a webview
- `npm run tauri dev` exercises **`devCsp`**, not the shipped `csp`
- `npm run tauri build` proves the bundle *compiles and signs*, not that it *renders*

The failure mode is the worst kind: a blank window on first launch of a release build, with the cause visible only in the devtools console. The only way to catch it was for a human to build the bundle and open it.

## What this adds — two layers, cheapest first

### Layer 1 — static regression guard (all OSes, ~0ms, inside `cargo test`)

`src-tauri/src/csp.rs` reads `tauri.conf.json` **from source** — not the copy embedded at compile time — so it fails on the current file rather than on whatever was last built. Three tests:

1. the policy exists, is not `null`, is not empty, and still carries every directive the app depends on. Each requirement records *why* it's there, so the failure message explains the consequence: `CSP is missing 'connect-src' — needed for the Tauri IPC bridge`.
2. **`worker-src` is pinned as deliberately absent.** The issue flags it as the fragile spot — it inherits `default-src 'self'`, so a future `blob:` worker from a bundler chunking strategy or a library upgrade would break silently, at runtime, in a release build only. The test doesn't *require* it; it makes adding one a deliberate edit here rather than an accident.
3. `devCsp` exists and hasn't been copied over the production policy (a real mistake: they're edited together, and prod allowing `localhost:1420` would ship a dev policy).

Catches someone deleting or gutting the policy. Does **not** catch a genuinely-too-strict one — that's layer 2.

### Layer 2 — real browser, real policy (Linux job, ~20s)

`scripts/csp-check.mjs` serves the already-built `dist/` with the **exact `Content-Security-Policy` header read from `tauri.conf.json`** — never a hardcoded copy, or the check rots the first time the policy changes and nobody updates it. Then it loads `index.html`, `popover.html` and `terminal.html` in headless Chromium and fails on:

- any `securitypolicyviolation` event (the authoritative signal, ahead of console-text matching)
- any CSP-related console error or page error
- **a page that loads but renders empty.** "Loaded" is not "rendered": a CSP blocking the bundle still returns 200 for the HTML with a `#root` element sitting in the body. Root *children* are what prove the app ran.

## Verified in both directions

Passing on the real policy proves nothing on its own — a check that can't fail is worse than no check. So:

```
$ npm run csp:check                       # real policy
  ✓ index.html — rendered 1 root child element(s), no CSP violations
  ✓ popover.html — …
  ✓ terminal.html — …
  exit 0

$ # with 'unsafe-inline' removed from style-src
  ✓ index.html
  ✓ popover.html
  ✕ terminal.html
    console: Applying inline style violates … 'style-src 'self''
    style-src-attr blocked inline
  exit 1
```

**Note which one caught it.** `index.html` and `popover.html` both passed the broken policy; only `terminal.html` failed, because xterm.js is what sets inline styles at runtime. That is precisely why all three entry points are loaded rather than just the main one — and it's the concrete case the issue predicted ("xterm.js + the WebGL addon are the most likely source of a future violation").

## Acceptance criteria

- [x] CI fails if the production CSP is null, missing, or missing a required directive → layer 1
- [x] CI fails if any of the three entry points logs a CSP violation under the **production** policy → layer 2
- [x] CI fails if a page loads but renders empty → layer 2, root-children assertion
- [x] The policy under test is **read from `tauri.conf.json`**, never duplicated in test code → both layers
- [x] Runs on the existing PR trigger; adds < ~1 min to the Linux job → ~20s plus the Chromium download
- [x] The IPC-bridge gap is documented in the workflow so nobody assumes it's covered

## The gap, stated where it will be read

Without a Tauri runtime `hasBackend()` is false, so the app renders in **mock mode** and the IPC bridge is never exercised — **`connect-src ipc:` is not verified here**. This covers the rendering class of failure, which is what actually produces the blank window. Verifying the bridge needs `tauri-driver` + WebdriverIO (Linux/Windows only, unsupported on macOS) — layer 3, and worth it only if layer 2 proves insufficient. That caveat is written into `ci.yml` next to the step, not just here, so someone reading the workflow can't assume more coverage than exists.

Adds one devDependency (`playwright`) and one CI step to install Chromium.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYXXuRwMVeF6Dv7xebjQJL