### PR TITLE
UX fixes: backgroundable worktree ops, DB loaders, agent picker, complete shortcuts

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "canopy"
-version = "0.4.0"
+version = "0.4.6"
 dependencies = [
  "base64 0.23.0",
  "fix-path-env",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "canopy"
-version = "0.4.0"
+version = "0.4.6"
 description = "Canopy — lightweight git worktree and dev-service manager"
 authors = ["Midhun Kumar"]
 license = "AGPL-3.0-only"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -285,6 +285,22 @@ pub async fn fetch_submodules(app: AppHandle, wt_key: String) -> Result<usize, C
     Ok(git::fetch_submodules(&wt_key).await)
 }
 
+/// Re-pin every submodule to the commit the parent records (⇧⌘S in the UI).
+#[tauri::command]
+pub async fn sync_submodules(app: AppHandle, wt_key: String) -> Result<String, CanopyError> {
+    ensure_known_worktree(&app, &wt_key)?;
+    // shares the worktree lease with pull/setup: a sync rewriting submodule
+    // checkouts under a running `pnpm install` is exactly the collision leases exist for
+    let _lease = crate::state::try_lease(&app, &wt_key, "sync submodules")?;
+    let n = git::sync_submodules(&wt_key).await.map_err(CanopyError::git)?;
+    refresh_git_meta(&app, &wt_key).await;
+    Ok(match n {
+        0 => "No submodules to sync".to_string(),
+        1 => "1 submodule back on its pinned commit".to_string(),
+        n => format!("{n} submodules back on their pinned commits"),
+    })
+}
+
 /// Check out a different branch in this worktree (in place — deps reused).
 #[tauri::command]
 pub async fn switch_worktree_branch(

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -468,6 +468,28 @@ pub async fn switch_branch(wt_path: &str, branch: &str, create: bool, base: Opti
     Ok(())
 }
 
+/// Put every submodule back on the commit the parent pins: `submodule sync`
+/// (re-reads URLs from .gitmodules, which a branch change can rewrite) then
+/// `submodule update --init --recursive`.
+///
+/// This is the counterpart to Pull, not a variant of it: Pull moves submodules
+/// FORWARD onto their own branches, while this moves them back to what the
+/// parent commit says — the repair for "my submodules are on the wrong commit".
+/// Returns how many submodules the worktree has.
+pub async fn sync_submodules(wt_path: &str) -> Result<usize, String> {
+    let subs = submodule_entries(wt_path).await;
+    if subs.is_empty() {
+        return Ok(0);
+    }
+    run_git(wt_path, &["submodule", "sync", "--recursive"]).await?;
+    run_git_net(
+        wt_path,
+        &["-c", "protocol.file.allow=always", "submodule", "update", "--init", "--recursive"],
+    )
+    .await?;
+    Ok(subs.len())
+}
+
 /// `git fetch --prune` inside every submodule so ahead/behind-of-remote and
 /// drift are computed against fresh remote refs. Best-effort per submodule.
 pub async fn fetch_submodules(wt_path: &str) -> usize {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -274,6 +274,7 @@ pub fn run() {
             commands::switch_submodule_branch,
             commands::list_submodule_branches,
             commands::fetch_submodules,
+            commands::sync_submodules,
             commands::switch_worktree_branch,
             commands::list_branches,
             commands::fetch_branches,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Canopy",
-  "version": "0.4.0",
+  "version": "0.4.6",
   "identifier": "com.midhunkumare.canopy",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -214,6 +214,9 @@ export default function App() {
     }
   };
 
+  // declared before the keyboard handler, which stands down for it on ⌘N
+  const onboardingActive = showOnboarding || addRepoOpen || (tree.length === 0 && !obDismissed);
+
   /* ── keyboard: the whole app is reachable without the mouse ─────── */
   useEffect(() => {
     const k = (e: KeyboardEvent) => {
@@ -224,6 +227,13 @@ export default function App() {
       if (meta && e.key.toLowerCase() === "k") {
         e.preventDefault();
         setPalette((p) => !p);
+        return;
+      }
+      // ⌘, — Settings, the platform convention. The tray's gear has always
+      // shown this hint; nothing listened for it in either window.
+      if (meta && e.key === ",") {
+        e.preventDefault();
+        setShowSettings(true);
         return;
       }
       if (e.key === "Escape") {
@@ -251,6 +261,15 @@ export default function App() {
       if (meta && e.shiftKey && e.key.toLowerCase() === "s") {
         e.preventDefault();
         if (sel) syncSubmodules(sel.wt.wtKey);
+        return;
+      }
+      // ⌘N — new worktree. The tray menu and the onboarding CTA have always
+      // advertised it; the main window was the one place it did nothing.
+      // Onboarding binds ⌘N itself (to its add-repository screen), so stand
+      // down while it is up rather than opening a dialog behind it.
+      if (meta && !e.shiftKey && e.key.toLowerCase() === "n") {
+        e.preventDefault();
+        if (!onboardingActive) setShowNewWt(true);
         return;
       }
       if (meta && e.key >= "1" && e.key <= String(LAYOUT_ORDER.length)) {
@@ -299,7 +318,6 @@ export default function App() {
     };
   }, []);
 
-  const onboardingActive = showOnboarding || addRepoOpen || (tree.length === 0 && !obDismissed);
   const worktreeCount = tree.reduce((n, r) => n + r.worktrees.length, 0);
 
   return (

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -19,6 +19,7 @@ import StatusBar from "./canopy/StatusBar";
 import { LAYOUT_ORDER, LAYOUTS, panesOf, type LayoutId, type PaneKind } from "./canopy/WorkSurface";
 import { useLaneLaunch } from "./canopy/laneLaunch";
 import DatabaseModal from "./canopy/DatabaseModal";
+import NoticeModal from "./canopy/NoticeModal";
 import SetupRunnerModal from "./canopy/SetupRunnerModal";
 import ServiceDetailModal from "./canopy/ServiceDetailModal";
 import ContextModal from "./canopy/ContextModal";
@@ -49,6 +50,10 @@ export default function App() {
   const openPort = useStore((s) => s.openPort);
   const openWorktree = useStore((s) => s.openWorktree);
   const setActiveTerm = useStore((s) => s.setActiveTerm);
+  const notices = useStore((s) => s.notices);
+  const dismissNotice = useStore((s) => s.dismissNotice);
+  const syncSubmodules = useStore((s) => s.syncSubmodules);
+  const switchBranchEnabled = useStore((s) => s.showSwitchBranch);
 
   const [view, setView] = useState<"wt" | "overview">("wt");
   // the pane set is the state; a preset is just a named one, so a hand-made
@@ -71,6 +76,7 @@ export default function App() {
   const [pruneFor, setPruneFor] = useState<(PrunableWorktree & { dbName: string | null })[] | null>(null);
   const [showOnboarding, setShowOnboarding] = useState(false);
   const [obDismissed, setObDismissed] = useState(false);
+  const [noticeId, setNoticeId] = useState<string | null>(null);
   const [, setTick] = useState(0);
   const attnRef = useRef<HTMLButtonElement>(null);
 
@@ -92,7 +98,8 @@ export default function App() {
     if (sel) primeLogs(sel.wt.wtKey);
   }, [sel?.wt.wtKey, primeLogs]);
 
-  const attn = useMemo<AttnItem[]>(() => attentionItems(tree, sessions), [tree, sessions]);
+  const attn = useMemo<AttnItem[]>(() => attentionItems(tree, sessions, notices), [tree, sessions, notices]);
+  const notice = useMemo(() => notices.find((n) => n.id === noticeId) ?? null, [notices, noticeId]);
   const na = useMemo<NextAction | null>(
     () => (sel ? nextAction(sel.wt, sessions[sel.wt.wtKey] ?? []) : null),
     [sel, sessions],
@@ -238,6 +245,14 @@ export default function App() {
         addRepo();
         return;
       }
+      // ⇧⌘S — put every submodule back on the commit this worktree pins. Shift
+      // keeps it clear of ⌘S (Save, in Settings), and it pairs with the same
+      // action in the pull popover rather than being a second, separate route.
+      if (meta && e.shiftKey && e.key.toLowerCase() === "s") {
+        e.preventDefault();
+        if (sel) syncSubmodules(sel.wt.wtKey);
+        return;
+      }
       if (meta && e.key >= "1" && e.key <= String(LAYOUT_ORDER.length)) {
         e.preventDefault();
         setLayout(LAYOUT_ORDER[Number(e.key) - 1]);
@@ -248,7 +263,9 @@ export default function App() {
       }
       if (meta && e.key === "\\") {
         e.preventDefault();
-        if (sel) setShowSwitchBranch(true);
+        // Settings can turn the action off; the shortcut has to obey, or the
+        // toggle only hides the button and the feature is still one key away.
+        if (sel && switchBranchEnabled) setShowSwitchBranch(true);
       }
       if (meta && e.key.toLowerCase() === "o") {
         e.preventDefault();
@@ -274,6 +291,7 @@ export default function App() {
     import("@tauri-apps/api/event").then(({ listen }) => {
       track(listen("tray:new-worktree", () => setShowNewWt(true)));
       track(listen("tray:overview", () => setView("overview")));
+      track(listen("tray:settings", () => setShowSettings(true)));
     });
     return () => {
       dead = true;
@@ -355,7 +373,7 @@ export default function App() {
               onSetup={() => setShowSetup(true)}
               onOpenService={(s) => setSvcDetail(s.svcKey)}
               onEditContext={() => setShowCtx(true)}
-              onSwitchBranch={() => setShowSwitchBranch(true)}
+              onSwitchBranch={switchBranchEnabled ? () => setShowSwitchBranch(true) : undefined}
             />
           )
         )}
@@ -371,7 +389,7 @@ export default function App() {
           setLayout(LAYOUT_ORDER[(at + 1) % LAYOUT_ORDER.length]);
         }}
         onAttn={() => setAttnOpen((a) => !a)}
-        onSwitchBranch={() => setShowSwitchBranch(true)}
+        onSwitchBranch={switchBranchEnabled ? () => setShowSwitchBranch(true) : undefined}
         onDirty={() => setShowDirty(true)}
         worktreeCount={worktreeCount}
         repoCount={tree.length}
@@ -382,8 +400,20 @@ export default function App() {
           anchor={attnRef}
           items={attn}
           onClose={() => setAttnOpen(false)}
+          onDismiss={(a) => a.noticeId && dismissNotice(a.noticeId)}
           onPick={(a) => {
             setAttnOpen(false);
+            // A failure notice is the detail, not a destination — the worktree
+            // it names may not even exist. Completions just clear.
+            if (a.noticeId && a.kind === "error") {
+              setNoticeId(a.noticeId);
+              return;
+            }
+            if (a.noticeId) {
+              dismissNotice(a.noticeId);
+              if (tree.some((r) => r.worktrees.some((w) => w.wtKey === a.wtKey))) goto(a.wtKey);
+              return;
+            }
             goto(a.wtKey);
             if (a.kind === "wait") setLayout("agent");
           }}
@@ -445,6 +475,7 @@ export default function App() {
         <SwitchBranchModal repo={sel.repo} wt={sel.wt} onClose={() => setShowSwitchBranch(false)} />
       )}
       {showDirty && sel && <UncommittedChangesModal wt={sel.wt} onClose={() => setShowDirty(false)} />}
+      {notice && <NoticeModal notice={notice} onClose={() => setNoticeId(null)} />}
       {onboardingActive && (
         <Onboarding
           initialView={addRepoOpen ? "add" : "empty"}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -229,19 +229,25 @@ export default function App() {
         setPalette((p) => !p);
         return;
       }
-      // ⌘, — Settings, the platform convention. The tray's gear has always
-      // shown this hint; nothing listened for it in either window.
-      if (meta && e.key === ",") {
-        e.preventDefault();
-        setShowSettings(true);
-        return;
-      }
       if (e.key === "Escape") {
         setPalette(false);
         setAttnOpen(false);
         return;
       }
       if (palette) return;
+      /* A dialog owns the keyboard while it is up. The two bindings below open
+         a NEW surface, and stacking one behind an open dialog leaves two
+         scrims and no way to tell which has focus — so they stand down for it.
+         The scrim is the reliable signal: every dialog renders exactly one,
+         wherever in the tree it was mounted from. */
+      const dialogOpen = !!document.querySelector(".cx-scrim");
+      // ⌘, — Settings, the platform convention. The tray's gear has always
+      // shown this hint; nothing listened for it in either window.
+      if (meta && e.key === ",") {
+        e.preventDefault();
+        if (!dialogOpen) setShowSettings(true);
+        return;
+      }
       // ⇧⌘N — add a repository. The design gives plain ⌘N to "Add a
       // repository" (cxo-onboard.jsx), but only on the empty state; this app
       // already advertises ⌘N as "New worktree" in the tray menu and the
@@ -269,7 +275,7 @@ export default function App() {
       // down while it is up rather than opening a dialog behind it.
       if (meta && !e.shiftKey && e.key.toLowerCase() === "n") {
         e.preventDefault();
-        if (!onboardingActive) setShowNewWt(true);
+        if (!onboardingActive && !dialogOpen) setShowNewWt(true);
         return;
       }
       if (meta && e.key >= "1" && e.key <= String(LAYOUT_ORDER.length)) {

--- a/src/app/NewWorktreeModal.tsx
+++ b/src/app/NewWorktreeModal.tsx
@@ -8,7 +8,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { errText, hasBackend, ipc, type Branches, type OpEvent } from "../ipc";
-import { useStore } from "../store";
+import { backgroundOp, useStore } from "../store";
 import { Alert, ChevRight, Fork, Info, Plus, Refresh, Spinner } from "../icons";
 import Modal, { Hint, Spacer } from "./canopy/Modal";
 import RefPick from "./canopy/RefPick";
@@ -25,6 +25,7 @@ export default function NewWorktreeModal({ repoId, onClose }: { repoId: string; 
   const tree = useStore((s) => s.tree);
   const select = useStore((s) => s.select);
   const showToast = useStore((s) => s.showToast);
+  const createWorktree = useStore((s) => s.createWorktree);
 
   const repos = tree.map((r) => ({ id: r.repoId, name: r.name }));
   const [repo, setRepo] = useState(repoId || repos[0]?.id || "");
@@ -108,13 +109,41 @@ export default function NewWorktreeModal({ repoId, onClose }: { repoId: string; 
     }
   }
 
-  const branch = mode === "new" ? name.trim() : existing;
-  const ok = !!branch;
+  const picked = mode === "new" ? name.trim() : existing;
+  const ok = !!picked;
+
+  /* What create_worktree will actually be asked for. `git worktree add <path>
+     origin/foo` checks out the remote-tracking ref DETACHED, so a remote pick
+     has to become a real local branch tracking it — reuse the local one if it
+     already exists, otherwise create it. Derived once, because the destination
+     panel and the create call must agree on the branch NAME (they didn't for
+     remote picks, which land under the local name, not `origin/…`). */
+  const payload = useMemo(() => {
+    const localOf = (ref: string) => ref.replace(/^[^/]+\//, "");
+    if (mode === "new") return { branch: picked, base: base || undefined, createBranch: true };
+    if (existingKind === "tags")
+      // checking out a tag → create a local branch named after it
+      return { branch: existing, base: `refs/tags/${existing}`, createBranch: true };
+    if (existingKind === "remote")
+      return {
+        branch: localOf(existing),
+        base: existing,
+        createBranch: !branches?.local.includes(localOf(existing)),
+      };
+    return { branch: existing, base: undefined, createBranch: false };
+  }, [mode, picked, base, existing, existingKind, branches]);
+
+  const branch = payload.branch;
   // create_worktree: `${worktree_dir || repo.path + "-worktrees"}/${sanitize_branch(branch)}`
   const destination =
     ok && worktreeDir !== null && activeRepo
       ? `${worktreeDir.trim() || `${activeRepo.path}-worktrees`}/${sanitizeBranch(branch)}`
       : null;
+  /* The key the in-progress row and the failure notice are filed under. It is
+     the destination when we can predict it — that is what worktree:op events
+     are keyed by, so the row can show live steps. When the repo's settings
+     could not be read we still create; the row just has no step detail. */
+  const opKey = destination ?? `${repo}::${branch}`;
 
   async function create() {
     if (!ok) return;
@@ -122,29 +151,16 @@ export default function NewWorktreeModal({ repoId, onClose }: { repoId: string; 
     setProgress([]);
     setError(null);
     try {
-      if (!hasBackend()) {
-        showToast("New worktree needs the desktop app");
-        return;
-      }
-      // `git worktree add <path> origin/foo` checks out the remote-tracking ref
-      // DETACHED. A remote pick has to become a real local branch tracking it —
-      // reuse the local one if it already exists, otherwise create it.
-      const localOf = (ref: string) => ref.replace(/^[^/]+\//, "");
-      const payload =
-        mode === "new"
-          ? { branch, base: base || undefined, createBranch: true }
-          : existingKind === "tags"
-            ? // checking out a tag → create a local branch named after it
-              { branch: existing, base: `refs/tags/${existing}`, createBranch: true }
-            : existingKind === "remote"
-              ? { branch: localOf(existing), base: existing, createBranch: !branches?.local.includes(localOf(existing)) }
-              : { branch: existing, createBranch: false };
-
-      const wtPath = await ipc.createWorktree({ repoId: repo, ...payload });
-      // seed the human handoff now, keyed by the new path — the runtime
-      // details are read back from the authoritative tree afterwards
-      seedWtContext(wtPath, { title: branch, pr, prDescription, issue, issueDescription });
-      showToast(`Worktree ready — ${branch}`);
+      const wtPath = await createWorktree({
+        repoId: repo,
+        repoName: activeRepo?.name ?? "",
+        wtPath: opKey,
+        ...payload,
+        // seed the human handoff keyed by the REAL path — the runtime details
+        // are read back from the authoritative tree afterwards. Runs whether or
+        // not this dialog is still open, so a backgrounded create still gets it.
+        onCreated: (path) => seedWtContext(path, { title: branch, pr, prDescription, issue, issueDescription }),
+      });
       select(wtPath);
       onClose();
     } catch (e) {
@@ -152,6 +168,15 @@ export default function NewWorktreeModal({ repoId, onClose }: { repoId: string; 
     } finally {
       setBusy(false);
     }
+  }
+
+  /* Dismiss the dialog and let the create finish on its own. The job is
+     backend-owned and runs to completion either way; what changes is where it
+     reports — the sidebar shows an in-progress row, and the outcome lands in
+     "Needs you" instead of in a dialog that is no longer on screen. */
+  function runInBackground() {
+    backgroundOp(opKey);
+    onClose();
   }
 
   return (
@@ -163,11 +188,19 @@ export default function NewWorktreeModal({ repoId, onClose }: { repoId: string; 
       onClose={onClose}
       foot={
         <>
-          <Hint icon={Info}>Ports and database are derived automatically</Hint>
+          <Hint icon={Info}>
+            {busy ? "Setup keeps running if you close this" : "Ports and database are derived automatically"}
+          </Hint>
           <Spacer />
-          <button className="cx-btn cx-btn--ghost" onClick={onClose} disabled={busy}>
-            Cancel
-          </button>
+          {busy ? (
+            <button className="cx-btn cx-btn--ghost" onClick={runInBackground}>
+              Run in background
+            </button>
+          ) : (
+            <button className="cx-btn cx-btn--ghost" onClick={onClose}>
+              Cancel
+            </button>
+          )}
           <button className="cx-btn cx-btn--primary" onClick={create} disabled={busy || !ok}>
             {busy ? (
               <>

--- a/src/app/NewWorktreeModal.tsx
+++ b/src/app/NewWorktreeModal.tsx
@@ -10,7 +10,7 @@ import { listen } from "@tauri-apps/api/event";
 import { errText, hasBackend, ipc, type Branches, type OpEvent } from "../ipc";
 import { backgroundOp, useStore } from "../store";
 import { Alert, ChevRight, Fork, Info, Plus, Refresh, Spinner } from "../icons";
-import Modal, { Hint, Spacer } from "./canopy/Modal";
+import Modal, { Hint, Spacer, usePrimaryAction } from "./canopy/Modal";
 import RefPick from "./canopy/RefPick";
 import { seedWtContext } from "./WorktreeContext";
 
@@ -178,6 +178,9 @@ export default function NewWorktreeModal({ repoId, onClose }: { repoId: string; 
     backgroundOp(opKey);
     onClose();
   }
+
+  // the ⌘⏎ the Create button has always advertised
+  usePrimaryAction("mod-enter", ok && !busy, create);
 
   return (
     <Modal

--- a/src/app/RemoveWorktreeModal.tsx
+++ b/src/app/RemoveWorktreeModal.tsx
@@ -6,7 +6,7 @@
    private submodule clones, not just a directory. */
 import { useEffect, useState } from "react";
 import { errText, hasBackend, ipc } from "../ipc";
-import { useStore } from "../store";
+import { backgroundOp, useStore } from "../store";
 import type { WorktreeNode } from "../types";
 import { Alert, Info, Spinner, Trash } from "../icons";
 import Modal, { Hint, Spacer } from "./canopy/Modal";
@@ -16,7 +16,7 @@ import Modal, { Hint, Spacer } from "./canopy/Modal";
 const DIRTY_CAP = 10;
 
 export default function RemoveWorktreeModal({ wt, onClose }: { wt: WorktreeNode; onClose: () => void }) {
-  const showToast = useStore((s) => s.showToast);
+  const removeWorktrees = useStore((s) => s.removeWorktrees);
   const [report, setReport] = useState<{ dirty: boolean; details: string[]; total: number } | null>(null);
   const [probeError, setProbeError] = useState<string | null>(null);
   const [deleteBranch, setDeleteBranch] = useState(false);
@@ -50,18 +50,21 @@ export default function RemoveWorktreeModal({ wt, onClose }: { wt: WorktreeNode;
     setBusy(true);
     setError(null);
     try {
-      if (!hasBackend()) {
-        showToast("Remove needs the desktop app");
-        return;
-      }
-      await ipc.removeWorktree(wt.wtKey, deleteBranch, dropDb);
-      showToast(`Worktree removed — ${wt.branch}`);
+      await removeWorktrees([wt.wtKey], deleteBranch, dropDb);
       onClose();
     } catch (e) {
       setError(errText(e));
     } finally {
       setBusy(false);
     }
+  }
+
+  /* Teardown (dropping the database, deleting a large tree) can take a while.
+     Dismissing hands the job to the background: the sidebar row shows it going,
+     and the outcome — including a failure — reports into "Needs you". */
+  function runInBackground() {
+    backgroundOp(wt.wtKey);
+    onClose();
   }
 
   return (
@@ -74,10 +77,12 @@ export default function RemoveWorktreeModal({ wt, onClose }: { wt: WorktreeNode;
       onClose={onClose}
       foot={
         <>
-          <Hint icon={Info}>The branch itself is kept unless you tick it</Hint>
+          <Hint icon={Info}>
+            {busy ? "Removal keeps running if you close this" : "The branch itself is kept unless you tick it"}
+          </Hint>
           <Spacer />
-          <button className="cx-btn cx-btn--ghost" onClick={onClose} disabled={busy}>
-            Cancel
+          <button className="cx-btn cx-btn--ghost" onClick={busy ? runInBackground : onClose}>
+            {busy ? "Run in background" : "Cancel"}
           </button>
           <button className="cx-btn cx-btn--danger" onClick={remove} disabled={busy || !report || !!probeError}>
             {busy ? (

--- a/src/app/RemoveWorktreesModal.tsx
+++ b/src/app/RemoveWorktreesModal.tsx
@@ -6,14 +6,14 @@
    No type-to-confirm — the list itself is the confirmation. */
 import { useEffect, useMemo, useState } from "react";
 import { errText, hasBackend, ipc } from "../ipc";
-import { useStore } from "../store";
+import { backgroundOp, useStore } from "../store";
 import type { WorktreeNode } from "../types";
 import { Alert, Info, Spinner, Trash } from "../icons";
 import { clear as clearSelection } from "./multiselect";
 import Modal, { Hint, Spacer } from "./canopy/Modal";
 
 export default function RemoveWorktreesModal({ wts, onClose }: { wts: WorktreeNode[]; onClose: () => void }) {
-  const showToast = useStore((s) => s.showToast);
+  const removeWorktrees = useStore((s) => s.removeWorktrees);
   const [dropDb, setDropDb] = useState(true);
   const [deleteBranch, setDeleteBranch] = useState(false);
   const [busy, setBusy] = useState(false);
@@ -46,16 +46,11 @@ export default function RemoveWorktreesModal({ wts, onClose }: { wts: WorktreeNo
     setBusy(true);
     setError(null);
     try {
-      if (!hasBackend()) {
-        showToast("Removing worktrees needs the desktop app");
-        return;
-      }
-      await ipc.removeWorktrees(
+      await removeWorktrees(
         wts.map((w) => w.wtKey),
         deleteBranch,
         dropDb,
       );
-      showToast(`Removed ${wts.length} worktree${wts.length === 1 ? "" : "s"}`);
       clearSelection();
       onClose();
     } catch (e) {
@@ -65,6 +60,15 @@ export default function RemoveWorktreesModal({ wts, onClose }: { wts: WorktreeNo
     } finally {
       setBusy(false);
     }
+  }
+
+  /* Removing several worktrees is the longest of these jobs. Dismissing hands
+     it off: each row goes into its removing state, and the outcome reports into
+     "Needs you" rather than into a dialog that has gone. */
+  function runInBackground() {
+    wts.forEach((w) => backgroundOp(w.wtKey));
+    clearSelection();
+    onClose();
   }
 
   return (
@@ -77,10 +81,12 @@ export default function RemoveWorktreesModal({ wts, onClose }: { wts: WorktreeNo
       onClose={onClose}
       foot={
         <>
-          <Hint icon={Info}>Branches are kept unless you tick it</Hint>
+          <Hint icon={Info}>
+            {busy ? "Removal keeps running if you close this" : "Branches are kept unless you tick it"}
+          </Hint>
           <Spacer />
-          <button className="cx-btn cx-btn--ghost" onClick={onClose} disabled={busy}>
-            Cancel
+          <button className="cx-btn cx-btn--ghost" onClick={busy ? runInBackground : onClose}>
+            {busy ? "Run in background" : "Cancel"}
           </button>
           <button className="cx-btn cx-btn--danger" onClick={remove} disabled={busy}>
             {busy ? (

--- a/src/app/SettingsView.tsx
+++ b/src/app/SettingsView.tsx
@@ -448,7 +448,27 @@ function CommandsPage({ repo, patchRepo, markDirty, flash, selKey }: PageProps) 
 
 /* ══════════════════════════ real: Files ════════════════════════════════ */
 const FMTS: ProvisionFormat[] = ["dotenv", "json", "yaml", "text"];
-function FilesPage({ cards, setCards, markDirty, flash }: PageProps) {
+
+/** A path inside the repo is stored RELATIVE to it — that is what provisioning
+    resolves against, and an absolute path would break the moment the repo moves
+    or the config is shared. Anything outside stays absolute. */
+function repoRelative(picked: string, repoPath: string | undefined): string {
+  const root = (repoPath || "").replace(/\/+$/, "");
+  if (root && picked.startsWith(root + "/")) return picked.slice(root.length + 1);
+  return picked;
+}
+
+/** Guess the format from the file the user picked, so choosing `config.json`
+    does not silently keep the dotenv parser. */
+function formatOf(path: string): ProvisionFormat | null {
+  const f = path.toLowerCase();
+  if (/\.ya?ml$/.test(f)) return "yaml";
+  if (f.endsWith(".json")) return "json";
+  if (/(^|\/)\.env(\.|$)/.test(f)) return "dotenv";
+  return null;
+}
+
+function FilesPage({ repo, cards, setCards, markDirty, flash }: PageProps) {
   const [selId, setSelId] = useState<string | null>(cards[0]?.id ?? null);
   const sel = cards.find((c) => c.id === selId) || cards[0] || null;
   const keyRef = useRef<number | null>(null);
@@ -458,6 +478,28 @@ function FilesPage({ cards, setCards, markDirty, flash }: PageProps) {
     const i = keyRef.current;
     if (i == null || !sel) { flash("Select a value field first, then insert"); return; }
     patch({ keys: sel.keys.map((k, j) => (j === i ? { ...k, v: (k.v || "") + tok } : k)) });
+  };
+  /* Both file fields are pickable. Typing `ee/.env` from memory is how you end
+     up provisioning a path that does not exist — and on macOS a dotfile cannot
+     be reached by the picker at all unless it starts inside the repo, which is
+     why the dialog opens there. */
+  const browse = async (which: "path" | "from") => {
+    if (!sel) return;
+    if (!hasBackend()) { flash("Choosing a file needs the desktop app"); return; }
+    try {
+      const picked = await openDialog({
+        multiple: false,
+        directory: false,
+        defaultPath: repo?.path || undefined,
+        title: which === "path" ? "Choose the file to provision" : "Choose the source file",
+      });
+      if (typeof picked !== "string") return;
+      const rel = repoRelative(picked, repo?.path);
+      const fmt = which === "path" ? formatOf(rel) : null;
+      patch(which === "path" ? { path: rel, ...(fmt ? { format: fmt } : {}) } : { from: rel });
+    } catch (e) {
+      flash(`Could not open the file picker — ${errText(e)}`);
+    }
   };
   return (
     <>
@@ -495,17 +537,19 @@ function FilesPage({ cards, setCards, markDirty, flash }: PageProps) {
             <div className="sbody">
               <div className="row">
                 <input className="inp mono gr" value={sel.path} placeholder=".env or config/app.json" onChange={(e) => patch({ path: e.target.value })} />
+                <button className="ico" title="Browse for the file to provision" onClick={() => browse("path")}><Finder size={12} /></button>
                 <select className="inp" value={sel.format} onChange={(e) => patch({ format: e.target.value as ProvisionFormat })}>
                   {FMTS.map((f) => <option key={f} value={f}>{f}</option>)}
                 </select>
               </div>
+              <div className="hint">Relative to each worktree's root. Browsing inside the repository stores the path relative to it.</div>
             </div>
 
             <div className={"stp" + (sel.from ? " done" : "")}><span className="num">2</span><span className="st"><b>Source</b><span>where to copy from</span></span></div>
             <div className="sbody">
               <div className="row">
                 <input className="inp mono gr" value={sel.from} placeholder="same path in the repo root" onChange={(e) => patch({ from: e.target.value })} />
-                <button className="ico" title="Browse for a source file (coming soon)" onClick={() => flash("Choosing a source file isn't wired yet")}><Finder size={12} /></button>
+                <button className="ico" title="Browse for a source file" onClick={() => browse("from")}><Finder size={12} /></button>
               </div>
               <div className="hint">Leave empty to read the same path from the repo root.</div>
             </div>
@@ -798,6 +842,7 @@ const KEYS: [string, string, string][] = [
   ["Cross-worktree overview", "⌘ O", "Global"], ["Switch branch", "⌘ \\", "Worktree"], ["Runtime layout", "⌘ 1", "Worktree"],
   ["Split layout", "⌘ 2", "Worktree"], ["Agent layout", "⌘ 3", "Worktree"], ["Shell layout", "⌘ 4", "Worktree"],
   ["Run next action", "⏎", "Worktree"], ["Pull everything", "⌘ ⏎", "Worktree"],
+  ["Sync submodules", "⇧ ⌘ S", "Worktree"], ["Add repository", "⇧ ⌘ N", "Global"],
   ["Search settings", "⌘ F", "Settings"], ["Save changes", "⌘ S", "Settings"], ["Toggle preview", "⌘ P", "Settings"],
 ];
 function ShortcutsPage() {
@@ -1028,12 +1073,17 @@ export default function SettingsView({ onClose }: { onClose: () => void }) {
       const meta = e.metaKey || e.ctrlKey;
       if (meta && e.key.toLowerCase() === "f") { e.preventDefault(); setSearch(true); }
       else if (meta && e.key.toLowerCase() === "s") { e.preventDefault(); if (dirty.size) save(); }
-      else if (meta && e.key.toLowerCase() === "p") { e.preventDefault(); setPreview((v) => !v); }
+      // ⌘P previews the repo's config file — it has nothing to show from a
+      // platform page, where the panel would render blank
+      else if (meta && e.key.toLowerCase() === "p") {
+        e.preventDefault();
+        if (REPO_PAGE_IDS.has(page) && repoId) setPreview((v) => !v);
+      }
     };
     document.addEventListener("keydown", k);
     return () => document.removeEventListener("keydown", k);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dirty, settings, repoId, cardsByRepo, setupByRepo]);
+  }, [dirty, settings, repoId, page, cardsByRepo, setupByRepo]);
 
   useEffect(() => {
     if (!repoMenu) return;
@@ -1258,7 +1308,9 @@ export default function SettingsView({ onClose }: { onClose: () => void }) {
         <div className="ttl"><span className="ic"><Cog size={13} /></span>Settings</div>
         <span className="sp" />
         <button className="ib" onClick={() => setSearch(true)} title="Search all settings (⌘F)"><Search size={13} />Search<span className="k">⌘F</span></button>
-        <button className={"ib" + (preview ? " on" : "")} onClick={() => setPreview((v) => !v)} title="Toggle config preview (⌘P)"><Braces size={13} /></button>
+        {/* The JSON preview belongs to a REPOSITORY's config, so it is offered
+            on the repo pages that have one (below) — not from the title bar,
+            where it sat over platform pages it has nothing to do with. */}
         <button className="ib" onClick={onClose} title="Close settings"><X size={14} /></button>
       </div>
 
@@ -1313,18 +1365,23 @@ export default function SettingsView({ onClose }: { onClose: () => void }) {
               {isRepoPage && repo && (
                 <button className={"btn sm" + (preview ? " pri" : "")} onClick={() => setPreview((v) => !v)}><Braces size={11} />{preview ? "Hide" : "Preview"} JSON<span className="k">⌘P</span></button>
               )}
-              <div style={{ position: "relative" }} ref={moreRef}>
-                <button className={"ib" + (moreMenu ? " on" : "")} title="More — the repo's .worktreemanager.json" onClick={() => setMoreMenu((m) => !m)} aria-haspopup="menu" aria-expanded={moreMenu} disabled={!repo}><More size={15} /></button>
-                {moreMenu && repo && (
-                  <div className="varmenu" style={{ top: 30, width: 244 }}>
-                    <div className="vh">.worktreemanager.json</div>
-                    <button className="vitem" onClick={() => { copyJson(); setMoreMenu(false); }}><Copy size={12} /><span style={{ marginLeft: 0, color: "var(--text-primary)" }}>Copy JSON</span></button>
-                    <button className="vitem" onClick={() => { exportJson(); setMoreMenu(false); }}><Download size={12} /><span style={{ marginLeft: 0, color: "var(--text-primary)" }}>Export config…</span></button>
-                    <button className="vitem" onClick={() => { reloadFromRepo(); setMoreMenu(false); }} title="Reads the repo's own .worktreemanager.json by path (it's hidden, so a file picker can't see it)"><Refresh size={12} /><span style={{ marginLeft: 0, color: "var(--text-primary)" }}>Load from repo file</span></button>
-                    <button className="vitem" onClick={() => { triggerImport(); setMoreMenu(false); }}><Pull size={12} /><span style={{ marginLeft: 0, color: "var(--text-primary)" }}>Import from file…</span></button>
-                  </div>
-                )}
-              </div>
+              {/* .worktreemanager.json is a property of one repository. On the
+                  platform pages there is no repo in scope, so the menu had
+                  nothing true to act on — it is not offered there. */}
+              {isRepoPage && repo && (
+                <div style={{ position: "relative" }} ref={moreRef}>
+                  <button className={"ib" + (moreMenu ? " on" : "")} title="More — the repo's .worktreemanager.json" onClick={() => setMoreMenu((m) => !m)} aria-haspopup="menu" aria-expanded={moreMenu}><More size={15} /></button>
+                  {moreMenu && (
+                    <div className="varmenu" style={{ top: 30, width: 244 }}>
+                      <div className="vh">.worktreemanager.json</div>
+                      <button className="vitem" onClick={() => { copyJson(); setMoreMenu(false); }}><Copy size={12} /><span style={{ marginLeft: 0, color: "var(--text-primary)" }}>Copy JSON</span></button>
+                      <button className="vitem" onClick={() => { exportJson(); setMoreMenu(false); }}><Download size={12} /><span style={{ marginLeft: 0, color: "var(--text-primary)" }}>Export config…</span></button>
+                      <button className="vitem" onClick={() => { reloadFromRepo(); setMoreMenu(false); }} title="Reads the repo's own .worktreemanager.json by path (it's hidden, so a file picker can't see it)"><Refresh size={12} /><span style={{ marginLeft: 0, color: "var(--text-primary)" }}>Load from repo file</span></button>
+                      <button className="vitem" onClick={() => { triggerImport(); setMoreMenu(false); }}><Pull size={12} /><span style={{ marginLeft: 0, color: "var(--text-primary)" }}>Import from file…</span></button>
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
           </div>
           <div className="pbody">
@@ -1346,11 +1403,12 @@ export default function SettingsView({ onClose }: { onClose: () => void }) {
         </div>
       ) : (
         <div className="statusline">
-          <span className="mono">.worktreemanager.json</span>
+          {/* name the file only where it IS the file being edited */}
+          <span className="mono">{isRepoPage && repo ? ".worktreemanager.json" : "Canopy settings"}</span>
           <span className="sdiv" />
           <span>All changes saved</span>
           <span style={{ flex: 1 }} />
-          {repo && <span>{wtCount(repo.id)} worktrees · {cards.length} provisioned files · {repo.services.length} services</span>}
+          {isRepoPage && repo && <span>{wtCount(repo.id)} worktrees · {cards.length} provisioned files · {repo.services.length} services</span>}
         </div>
       )}
 

--- a/src/app/SettingsView.tsx
+++ b/src/app/SettingsView.tsx
@@ -74,7 +74,12 @@ const INDEX: { page: PageId; label: string; hint: string }[] = (
     ["notifications", "Service crash alerts", "interrupt when a service dies"],
     ["notifications", "Agent needs a decision", "blocked agent"],
     ["shortcuts", "Command palette", "⌘K"], ["shortcuts", "Save changes", "⌘S"],
-    ["shortcuts", "Toggle worktree list", "⌘B"], ["shortcuts", "Layout presets", "⌘1 ⌘2 ⌘3 ⌘4"],
+    ["shortcuts", "Toggle worktree list", "⌘B"], ["shortcuts", "Layout presets", "⌘1 ⌘2 ⌘3 ⌘4 ⌘5"],
+    ["shortcuts", "New worktree", "⌘N"], ["shortcuts", "Add repository", "⇧⌘N"],
+    ["shortcuts", "Sync submodules", "⇧⌘S"], ["shortcuts", "Switch branch", "⌘\\"],
+    ["shortcuts", "Pull everything", "⌘⏎"], ["shortcuts", "Run next action", "⏎"],
+    ["shortcuts", "Cross-worktree overview", "⌘O"], ["shortcuts", "Open settings", "⌘,"],
+    ["shortcuts", "Select several worktrees", "⌘click ⇧click"],
     ["advanced", "Diagnostics", "version, config path"], ["advanced", "Experiments", "parallel setup"],
     ["repo-general", "Repository path", "where the repo lives"], ["repo-general", "Worktree root", ".worktrees"],
     ["repo-general", "Remove repository", "stop tracking"],
@@ -837,13 +842,51 @@ function NotificationsPage() {
   );
 }
 
+/* Every binding the app actually listens for, grouped by where it applies.
+   This table is a reference, so it is only worth having if it is exhaustive
+   and true — an entry here without a listener behind it is worse than a gap.
+   Sources: App.tsx (global + worktree), SettingsView (settings), Modal's
+   usePrimaryAction (dialogs), Palette / SearchOverlay (lists), SidebarNav
+   (selection chords) and Popover.tsx (the menu-bar window). */
 const KEYS: [string, string, string][] = [
-  ["Command palette", "⌘ K", "Global"], ["New worktree", "⌘ N", "Global"], ["Toggle worktree list", "⌘ B", "Global"],
-  ["Cross-worktree overview", "⌘ O", "Global"], ["Switch branch", "⌘ \\", "Worktree"], ["Runtime layout", "⌘ 1", "Worktree"],
-  ["Split layout", "⌘ 2", "Worktree"], ["Agent layout", "⌘ 3", "Worktree"], ["Shell layout", "⌘ 4", "Worktree"],
-  ["Run next action", "⏎", "Worktree"], ["Pull everything", "⌘ ⏎", "Worktree"],
-  ["Sync submodules", "⇧ ⌘ S", "Worktree"], ["Add repository", "⇧ ⌘ N", "Global"],
-  ["Search settings", "⌘ F", "Settings"], ["Save changes", "⌘ S", "Settings"], ["Toggle preview", "⌘ P", "Settings"],
+  // global
+  ["Command palette", "⌘ K", "Global"],
+  ["New worktree", "⌘ N", "Global"],
+  ["Add repository", "⇧ ⌘ N", "Global"],
+  ["Toggle worktree list", "⌘ B", "Global"],
+  ["Cross-worktree overview", "⌘ O", "Global"],
+  ["Settings", "⌘ ,", "Global"],
+  // worktree
+  ["Run next action", "⏎", "Worktree"],
+  ["Switch branch", "⌘ \\", "Worktree"],
+  ["Sync submodules", "⇧ ⌘ S", "Worktree"],
+  ["Pull everything", "⌘ ⏎", "Pull menu"],
+  // layouts
+  ["Runtime layout", "⌘ 1", "Worktree"],
+  ["Split logs + agent", "⌘ 2", "Worktree"],
+  ["Agent layout", "⌘ 3", "Worktree"],
+  ["Terminal + logs layout", "⌘ 4", "Worktree"],
+  ["Terminal layout", "⌘ 5", "Worktree"],
+  // dialogs
+  ["Confirm the primary action", "⌘ ⏎", "Dialogs"],
+  ["Confirm a simple prompt", "⏎", "Dialogs"],
+  ["Close the dialog", "esc", "Dialogs"],
+  // lists and menus
+  ["Move through a list", "↑ ↓", "Lists"],
+  ["Choose the highlighted row", "⏎", "Lists"],
+  ["Close a menu or popover", "esc", "Lists"],
+  ["Add to the selection", "⌘ click", "Worktree list"],
+  ["Select a range", "⇧ click", "Worktree list"],
+  // settings
+  ["Search all settings", "⌘ F", "Settings"],
+  ["Save changes", "⌘ S", "Settings"],
+  ["Toggle the JSON preview", "⌘ P", "Settings"],
+  // menu-bar window
+  ["Focus the search field", "⌘ K", "Menu bar"],
+  ["New worktree", "⌘ N", "Menu bar"],
+  ["Settings", "⌘ ,", "Menu bar"],
+  ["Start or focus the highlighted worktree", "⏎", "Menu bar"],
+  ["Clear the search field", "esc", "Menu bar"],
 ];
 function ShortcutsPage() {
   const [q, setQ] = useState("");
@@ -857,8 +900,11 @@ function ShortcutsPage() {
       </div>
       <table className="keys">
         <thead><tr><th>Command</th><th>Keys</th><th>Scope</th></tr></thead>
+        {/* keyed by all three columns: the command name alone is not unique —
+            "New worktree" and "Settings" each exist in two scopes (the main
+            window and the menu bar) */}
         <tbody>{rows.map(([a, b, c]) => (
-          <tr key={a}><td>{a}</td>
+          <tr key={a + b + c}><td>{a}</td>
             <td><span className="kbdk">{b.split(" ").map((k, i) => <i key={i}>{k}</i>)}</span></td>
             <td style={{ color: "var(--text-tertiary)" }}>{c}</td></tr>))}</tbody>
       </table>

--- a/src/app/canopy/ContextModal.tsx
+++ b/src/app/canopy/ContextModal.tsx
@@ -7,7 +7,7 @@ import { Copy, Doc, Info, Link, Plus, Sparkle, X } from "../../icons";
 import { useStore } from "../../store";
 import type { RepoNode, WorktreeNode } from "../../types";
 import { composeContextMd, mdRender, runtimeFor, useWtContext } from "../WorktreeContext";
-import Modal, { Hint, Spacer } from "./Modal";
+import Modal, { Hint, Spacer, usePrimaryAction } from "./Modal";
 
 export default function ContextModal({
   repo,
@@ -26,6 +26,13 @@ export default function ContextModal({
   /** the inline add-a-link field; null when the affordance is at rest */
   const [draftLink, setDraftLink] = useState<string | null>(null);
   const runtime = runtimeFor(repo, wt);
+
+  // the ⌘⏎ the Start-agent button advertises. Modifier-based, so it coexists
+  // with the plain ⏎ that commits the inline add-a-link field.
+  usePrimaryAction("mod-enter", true, () => {
+    onStartAgent();
+    onClose();
+  });
 
   return (
     <Modal

--- a/src/app/canopy/DatabaseModal.tsx
+++ b/src/app/canopy/DatabaseModal.tsx
@@ -5,11 +5,16 @@
    actually does, so that is what the dialog offers. Confirmations are past
    tense and unremarkable: "Snapshot … created", "Now using tj_main". */
 import { useEffect, useState } from "react";
-import { Database, Download, Info, Refresh, Restart, Pull } from "../../icons";
+import { Database, Download, Info, Refresh, Restart, Pull, Spinner } from "../../icons";
 import { errText, hasBackend, ipc } from "../../ipc";
 import { useStore } from "../../store";
 import type { WorktreeNode } from "../../types";
 import Modal, { Hint, Spacer } from "./Modal";
+
+/** Which long-running database job is in flight. Only one runs at a time —
+    they all take the worktree's op lease in the backend, so offering a second
+    would only produce a "busy" error. */
+type Job = "migrate" | "reset" | "snapshot" | "export" | "restore" | null;
 
 const snapDefault = (db: string) => {
   const d = new Date();
@@ -20,11 +25,16 @@ const snapDefault = (db: string) => {
 export default function DatabaseModal({ wt, onClose }: { wt: WorktreeNode; onClose: () => void }) {
   const showToast = useStore((s) => s.showToast);
   const resetDb = useStore((s) => s.resetDb);
+  // reset is fire-and-forget over reset:status events, so its progress lives in
+  // the store — the dialog reads it rather than keeping a second copy
+  const resetting = useStore((s) => !!s.resetting[wt.wtKey]);
   const [dbs, setDbs] = useState<string[]>([]);
   const [current, setCurrent] = useState<string | null>(wt.dbName);
   const [q, setQ] = useState("");
   const [snap, setSnap] = useState<string | null>(null);
-  const [busy, setBusy] = useState(false);
+  const [switching, setSwitching] = useState(false);
+  const [job, setJob] = useState<Job>(null);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!hasBackend()) return;
@@ -32,11 +42,30 @@ export default function DatabaseModal({ wt, onClose }: { wt: WorktreeNode; onClo
     ipc.currentDatabase(wt.wtKey).then(setCurrent).catch(() => {});
   }, [wt.wtKey]);
 
+  const busy = switching || job !== null || resetting;
   const list = dbs.filter((d) => d.toLowerCase().includes(q.toLowerCase()));
 
+  /** Run one database job with a spinner on its own row, and keep the dialog
+      open until it finishes — these take seconds to minutes, and closing on
+      "started" made every one of them look instantaneous. */
+  const run = async (which: Exclude<Job, null>, work: () => Promise<void>, ok: string) => {
+    if (busy) return;
+    setJob(which);
+    setError(null);
+    try {
+      await work();
+      showToast(ok);
+      onClose();
+    } catch (e) {
+      setError(errText(e));
+    } finally {
+      setJob((j) => (j === which ? null : j));
+    }
+  };
+
   const switchTo = async (name: string) => {
-    if (name === current || !hasBackend()) return;
-    setBusy(true);
+    if (name === current || !hasBackend() || busy) return;
+    setSwitching(true);
     try {
       await ipc.switchDatabase(wt.wtKey, name);
       setCurrent(name);
@@ -44,7 +73,7 @@ export default function DatabaseModal({ wt, onClose }: { wt: WorktreeNode; onClo
     } catch (e) {
       showToast(errText(e));
     } finally {
-      setBusy(false);
+      setSwitching(false);
     }
   };
 
@@ -69,20 +98,30 @@ export default function DatabaseModal({ wt, onClose }: { wt: WorktreeNode; onClo
               className="cx-btn cx-btn--primary"
               disabled={!snap.trim() || busy}
               onClick={async () => {
-                setBusy(true);
+                const name = snap.trim();
+                setJob("snapshot");
                 try {
-                  if (hasBackend()) await ipc.snapshotDatabase(wt.wtKey, snap.trim());
-                  showToast(`Snapshot ${snap.trim()} created`);
+                  if (hasBackend()) await ipc.snapshotDatabase(wt.wtKey, name);
+                  showToast(`Snapshot ${name} created`);
                   setSnap(null);
                 } catch (e) {
                   showToast(errText(e));
                 } finally {
-                  setBusy(false);
+                  setJob(null);
                 }
               }}
             >
-              Create
-              <span className="cx-k">⏎</span>
+              {job === "snapshot" ? (
+                <>
+                  <Spinner size={12} />
+                  Creating…
+                </>
+              ) : (
+                <>
+                  Create
+                  <span className="cx-k">⏎</span>
+                </>
+              )}
             </button>
           </>
         }
@@ -111,26 +150,34 @@ export default function DatabaseModal({ wt, onClose }: { wt: WorktreeNode; onClo
       onClose={onClose}
       foot={
         <>
-          <Hint icon={Info}>Each worktree gets its own database</Hint>
+          <Hint icon={Info}>
+            {busy ? "This runs in the worktree — it can take a while" : "Each worktree gets its own database"}
+          </Hint>
           <Spacer />
           <button className="cx-btn cx-btn--ghost" onClick={onClose}>
-            Close
+            {busy ? "Run in background" : "Close"}
           </button>
           <button
             className="cx-btn cx-btn--primary"
-            onClick={async () => {
-              try {
+            disabled={busy}
+            onClick={() =>
+              run("migrate", async () => {
                 if (hasBackend()) await ipc.runMigration(wt.wtKey);
-                showToast("Running migration…");
-                onClose();
-              } catch (e) {
-                showToast(errText(e));
-              }
-            }}
+              }, "Migration complete")
+            }
           >
-            <Restart size={12} />
-            Run migration
-            <span className="cx-k">⏎</span>
+            {job === "migrate" ? (
+              <>
+                <Spinner size={12} />
+                Migrating…
+              </>
+            ) : (
+              <>
+                <Restart size={12} />
+                Run migration
+                <span className="cx-k">⏎</span>
+              </>
+            )}
           </button>
         </>
       }
@@ -162,7 +209,7 @@ export default function DatabaseModal({ wt, onClose }: { wt: WorktreeNode; onClo
 
       <div className="cxm-fld">
         <div className="cxm-flab">Actions</div>
-        <button className="cxm-act" onClick={() => setSnap(snapDefault(current ?? "db"))}>
+        <button className="cxm-act" disabled={busy} onClick={() => setSnap(snapDefault(current ?? "db"))}>
           <span className="ic">
             <Pull size={13} />
           </span>
@@ -171,62 +218,72 @@ export default function DatabaseModal({ wt, onClose }: { wt: WorktreeNode; onClo
         </button>
         <button
           className="cxm-act"
+          disabled={busy}
           onClick={async () => {
             if (!hasBackend()) return showToast("Export needs the desktop app");
             const { save } = await import("@tauri-apps/plugin-dialog");
             const path = await save({ defaultPath: `${current}.dump`, title: "Export database" });
             if (!path) return;
-            try {
-              await ipc.exportDatabase(wt.wtKey, path);
-              showToast(`Exported ${current}`);
-              onClose();
-            } catch (e) {
-              showToast(errText(e));
-            }
+            run("export", () => ipc.exportDatabase(wt.wtKey, path), `Exported ${current}`);
           }}
         >
-          <span className="ic">
-            <Download size={12} />
-          </span>
-          Export to file…
+          <span className="ic">{job === "export" ? <Spinner size={12} /> : <Download size={12} />}</span>
+          {job === "export" ? "Exporting…" : "Export to file…"}
           <span className="sub">{current}.dump</span>
         </button>
         <button
           className="cxm-act"
+          disabled={busy}
           onClick={async () => {
             if (!hasBackend()) return showToast("Restore needs the desktop app");
             const { open } = await import("@tauri-apps/plugin-dialog");
             const path = await open({ title: "Restore database", multiple: false });
             if (!path || typeof path !== "string") return;
-            try {
-              await ipc.restoreDatabase(wt.wtKey, path);
-              showToast(`Restoring ${current} from file…`);
-              onClose();
-            } catch (e) {
-              showToast(errText(e));
-            }
+            run("restore", () => ipc.restoreDatabase(wt.wtKey, path), `Restored ${current}`);
           }}
         >
-          <span className="ic">
-            <Refresh size={12} />
-          </span>
-          Restore from file…
+          <span className="ic">{job === "restore" ? <Spinner size={12} /> : <Refresh size={12} />}</span>
+          {job === "restore" ? "Restoring…" : "Restore from file…"}
           <span className="sub">.dump · .backup · .sql</span>
         </button>
         <button
           className="cxm-act cxm-act--danger"
-          onClick={() => {
-            resetDb(wt.wtKey);
-            onClose();
-          }}
+          disabled={busy}
+          onClick={() =>
+            run(
+              "reset",
+              async () => {
+                // reset_db awaits the drop + re-seed, so the invoke IS the
+                // progress signal.
+                if (hasBackend()) return ipc.resetDb(wt.wtKey);
+                // Browser-only: the mock reports through the same `resetting`
+                // flag, so wait for it to clear rather than claiming success
+                // the instant the call returns.
+                resetDb(wt.wtKey);
+                await new Promise<void>((resolve) => {
+                  const un = useStore.subscribe((s) => {
+                    if (!s.resetting[wt.wtKey]) {
+                      un();
+                      resolve();
+                    }
+                  });
+                });
+              },
+              "Database reset",
+            )
+          }
         >
-          <span className="ic">
-            <Restart size={12} />
-          </span>
-          Reset database
+          <span className="ic">{resetting || job === "reset" ? <Spinner size={12} /> : <Restart size={12} />}</span>
+          {resetting || job === "reset" ? "Resetting…" : "Reset database"}
           <span className="sub">drops and re-seeds</span>
         </button>
       </div>
+
+      {error && (
+        <div className="cx-alert cx-alert--error" style={{ marginTop: "var(--sp-modal-head)" }}>
+          <div>{error}</div>
+        </div>
+      )}
     </Modal>
   );
 }

--- a/src/app/canopy/DatabaseModal.tsx
+++ b/src/app/canopy/DatabaseModal.tsx
@@ -7,7 +7,7 @@
 import { useEffect, useState } from "react";
 import { Database, Download, Info, Refresh, Restart, Pull, Spinner } from "../../icons";
 import { errText, hasBackend, ipc } from "../../ipc";
-import { useStore } from "../../store";
+import { opTail, useStore } from "../../store";
 import type { WorktreeNode } from "../../types";
 import Modal, { Hint, Spacer, usePrimaryAction } from "./Modal";
 
@@ -15,6 +15,16 @@ import Modal, { Hint, Spacer, usePrimaryAction } from "./Modal";
     they all take the worktree's op lease in the backend, so offering a second
     would only produce a "busy" error. */
 type Job = "migrate" | "reset" | "snapshot" | "export" | "restore" | null;
+
+/** Names a job in a failure notice, where "reset failed" has to make sense
+    with the dialog long gone. */
+const JOB_LABEL: Record<Exclude<Job, null>, string> = {
+  migrate: "Migration failed",
+  reset: "Database reset failed",
+  snapshot: "Snapshot failed",
+  export: "Database export failed",
+  restore: "Database restore failed",
+};
 
 const snapDefault = (db: string) => {
   const d = new Date();
@@ -28,6 +38,7 @@ export default function DatabaseModal({ wt, onClose }: { wt: WorktreeNode; onClo
   // reset is fire-and-forget over reset:status events, so its progress lives in
   // the store — the dialog reads it rather than keeping a second copy
   const resetting = useStore((s) => !!s.resetting[wt.wtKey]);
+  const notify = useStore((s) => s.notify);
   const [dbs, setDbs] = useState<string[]>([]);
   const [current, setCurrent] = useState<string | null>(wt.dbName);
   const [q, setQ] = useState("");
@@ -58,6 +69,17 @@ export default function DatabaseModal({ wt, onClose }: { wt: WorktreeNode; onClo
       onClose();
     } catch (e) {
       setError(errText(e));
+      // The footer offers "Run in background" while this runs, so the dialog
+      // may well be gone by now — and then setError writes to nothing and the
+      // failure is silent. Same contract as a backgrounded create or remove:
+      // the outcome goes to the attention queue, with the log that explains it.
+      notify({
+        kind: "error",
+        title: JOB_LABEL[which],
+        wt: wt.branch,
+        wtKey: wt.wtKey,
+        detail: [errText(e), opTail(wt.wtKey)].filter(Boolean).join("\n\n"),
+      });
     } finally {
       setJob((j) => (j === which ? null : j));
     }

--- a/src/app/canopy/DatabaseModal.tsx
+++ b/src/app/canopy/DatabaseModal.tsx
@@ -9,7 +9,7 @@ import { Database, Download, Info, Refresh, Restart, Pull, Spinner } from "../..
 import { errText, hasBackend, ipc } from "../../ipc";
 import { useStore } from "../../store";
 import type { WorktreeNode } from "../../types";
-import Modal, { Hint, Spacer } from "./Modal";
+import Modal, { Hint, Spacer, usePrimaryAction } from "./Modal";
 
 /** Which long-running database job is in flight. Only one runs at a time —
     they all take the worktree's op lease in the backend, so offering a second
@@ -77,6 +77,27 @@ export default function DatabaseModal({ wt, onClose }: { wt: WorktreeNode; onClo
     }
   };
 
+  const createSnapshot = async () => {
+    const name = (snap ?? "").trim();
+    if (!name || busy) return;
+    setJob("snapshot");
+    try {
+      if (hasBackend()) await ipc.snapshotDatabase(wt.wtKey, name);
+      showToast(`Snapshot ${name} created`);
+      setSnap(null);
+    } catch (e) {
+      showToast(errText(e));
+    } finally {
+      setJob(null);
+    }
+  };
+
+  /* The snapshot step is a single named field, so ⏎ commits it — the ordinary
+     behaviour of a name prompt. The main view deliberately has no ⏎: its only
+     field is the database search, and running a migration from a search box
+     would be a nasty surprise. */
+  usePrimaryAction("enter", snap !== null && !!snap.trim() && !busy, createSnapshot);
+
   /* ── the snapshot name prompt is its own step, not a separate dialog ── */
   if (snap !== null) {
     return (
@@ -97,19 +118,7 @@ export default function DatabaseModal({ wt, onClose }: { wt: WorktreeNode; onClo
             <button
               className="cx-btn cx-btn--primary"
               disabled={!snap.trim() || busy}
-              onClick={async () => {
-                const name = snap.trim();
-                setJob("snapshot");
-                try {
-                  if (hasBackend()) await ipc.snapshotDatabase(wt.wtKey, name);
-                  showToast(`Snapshot ${name} created`);
-                  setSnap(null);
-                } catch (e) {
-                  showToast(errText(e));
-                } finally {
-                  setJob(null);
-                }
-              }}
+              onClick={createSnapshot}
             >
               {job === "snapshot" ? (
                 <>
@@ -175,7 +184,6 @@ export default function DatabaseModal({ wt, onClose }: { wt: WorktreeNode; onClo
               <>
                 <Restart size={12} />
                 Run migration
-                <span className="cx-k">⏎</span>
               </>
             )}
           </button>

--- a/src/app/canopy/Modal.tsx
+++ b/src/app/canopy/Modal.tsx
@@ -141,7 +141,10 @@ export default function Modal({
             <b>{title}</b>
             {sub && <span>{sub}</span>}
           </span>
-          <button className="cx-ib" onClick={onClose} disabled={busy} title="Close">
+          {/* marked so usePrimaryAction can tell "the user tabbed to a button
+              and means to press it" from "focus fell back here" — this is the
+              first focusable in the card, so an orphaned focus lands on it */}
+          <button className="cx-ib" data-modal-close onClick={onClose} disabled={busy} title="Close">
             <X size={13} />
           </button>
         </div>
@@ -150,6 +153,49 @@ export default function Modal({
       </div>
     </div>
   );
+}
+
+/** Bind a dialog's primary action to the key its button already advertises.
+
+    Every dialog here prints a key on its primary button, and until now only
+    one of them listened for it — the rest were decoration. The guards are what
+    make a bare ⏎ safe to claim:
+
+      · a textarea keeps it (⏎ types a newline there)
+      · a focused button keeps it (⏎ is how you press the one you tabbed to) —
+        except the header's close, which is where focus FALLS BACK to rather
+        than somewhere the user chose, and which Escape already covers
+      · an inner popup that claimed Escape has also claimed ⏎ (a ref picker
+        committing a choice), so stand down for it
+      · a disabled action never fires
+
+    `⌘⏎` needs none of that — a modifier cannot collide with typing — which is
+    why the heavier actions advertise that one. Capture phase + stopPropagation
+    keeps the app-level ⏎ (run next action) out of it while a dialog is up. */
+export function usePrimaryAction(key: "enter" | "mod-enter", enabled: boolean, run: () => void) {
+  const runRef = useRef(run);
+  runRef.current = run;
+  const enabledRef = useRef(enabled);
+  enabledRef.current = enabled;
+
+  useEffect(() => {
+    const h = (e: KeyboardEvent) => {
+      if (e.key !== "Enter" || !enabledRef.current) return;
+      const mod = e.metaKey || e.ctrlKey;
+      if (key === "mod-enter" ? !mod : mod) return;
+      if (document.querySelector("[data-esc-claim]")) return;
+      if (key === "enter") {
+        const el = document.activeElement as HTMLElement | null;
+        if (el?.tagName === "TEXTAREA" || el?.isContentEditable) return;
+        if (el?.tagName === "BUTTON" && !el.hasAttribute("data-modal-close")) return;
+      }
+      e.preventDefault();
+      e.stopPropagation();
+      runRef.current();
+    };
+    document.addEventListener("keydown", h, true);
+    return () => document.removeEventListener("keydown", h, true);
+  }, [key]);
 }
 
 /** The footer's supporting line — always the elastic item, so the actions

--- a/src/app/canopy/NoticeModal.tsx
+++ b/src/app/canopy/NoticeModal.tsx
@@ -1,0 +1,71 @@
+/* What a backgrounded operation has to say for itself.
+
+   A create or delete sent to the background reports its outcome into the
+   attention queue; this is the row's detail view. The whole point is the raw
+   text — the error and the log tail that led to it — so it is selectable,
+   scrollable and one click from the clipboard, not a summarised sentence. */
+import { useState } from "react";
+import { Alert, Check, Copy } from "../../icons";
+import { useStore, type Notice } from "../../store";
+import Modal, { Hint, Spacer } from "./Modal";
+
+export default function NoticeModal({ notice, onClose }: { notice: Notice; onClose: () => void }) {
+  const dismissNotice = useStore((s) => s.dismissNotice);
+  const [copied, setCopied] = useState(false);
+  const failed = notice.kind === "error";
+
+  const copy = () => {
+    navigator.clipboard?.writeText(notice.detail || notice.title).then(
+      () => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1600);
+      },
+      () => setCopied(false),
+    );
+  };
+
+  return (
+    <Modal
+      icon={failed ? Alert : Check}
+      danger={failed}
+      title={notice.title}
+      sub={notice.wt}
+      wide
+      onClose={onClose}
+      foot={
+        <>
+          <Hint>{new Date(notice.ts).toLocaleTimeString()}</Hint>
+          <Spacer />
+          <button className="cx-btn cx-btn--ghost" onClick={copy} disabled={!notice.detail}>
+            {copied ? <Check size={12} /> : <Copy size={12} />}
+            {copied ? "Copied" : "Copy details"}
+          </button>
+          <button
+            className="cx-btn cx-btn--primary"
+            onClick={() => {
+              dismissNotice(notice.id);
+              onClose();
+            }}
+          >
+            Dismiss
+          </button>
+        </>
+      }
+    >
+      <div className="cxm-fld">
+        <div className="cxm-flab cxm-flab--f">{failed ? "What the operation reported" : "Details"}</div>
+        {notice.detail ? (
+          <pre className="cx-logdump">{notice.detail}</pre>
+        ) : (
+          <div className="cxm-fhint">No further detail was reported.</div>
+        )}
+      </div>
+      <div className="cxm-fld">
+        <div className="cxm-flab cxm-flab--f">Worktree</div>
+        <div className="cxm-fhint" style={{ fontFamily: "var(--mono)" }}>
+          {notice.wtKey}
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/app/canopy/Overview.tsx
+++ b/src/app/canopy/Overview.tsx
@@ -38,7 +38,9 @@ export default function Overview({
   const agentCount = Object.values(sessions)
     .flat()
     .filter((s) => s.kind === "agent" && s.running).length;
-  const needs = new Set(attn.map((a) => a.wtKey));
+  // a finished-in-the-background notice is news, not a demand — it stays in
+  // the queue without pulling its worktree into the Needs-you section
+  const needs = new Set(attn.filter((a) => a.kind !== "info").map((a) => a.wtKey));
 
   const head = (
     <tr>

--- a/src/app/canopy/Palette.tsx
+++ b/src/app/canopy/Palette.tsx
@@ -75,19 +75,24 @@ export default function Palette({
         const na = nextAction(sel.wt, sessions[sel.wt.wtKey] ?? []);
         out.push({ g: "Suggested", icon: na.icon, nm: na.label, why: na.why, run: () => onAction(na) });
       }
-      attn.slice(0, 3).forEach((a) =>
-        out.push({
-          g: "Suggested",
-          icon: a.kind === "crash" ? Alert : a.kind === "wait" ? Sparkle : Cube,
-          tone: a.kind === "crash" ? "crash" : "urgent",
-          // The row is labelled with an imperative ("Restart — API crashed"),
-          // so it has to perform it. Selecting and leaving the crash in place
-          // would make ⌘K the one surface that disagrees with the others.
-          nm: `${a.act} — ${a.title}`,
-          why: a.wt,
-          run: () => onRunFor(a.wtKey),
-        }),
-      );
+      // Notices are read, not run — the palette's rows all perform something,
+      // and a row that did nothing when picked would be the odd one out.
+      attn
+        .filter((a) => !a.noticeId)
+        .slice(0, 3)
+        .forEach((a) =>
+          out.push({
+            g: "Suggested",
+            icon: a.kind === "crash" ? Alert : a.kind === "wait" ? Sparkle : Cube,
+            tone: a.kind === "crash" ? "crash" : "urgent",
+            // The row is labelled with an imperative ("Restart — API crashed"),
+            // so it has to perform it. Selecting and leaving the crash in place
+            // would make ⌘K the one surface that disagrees with the others.
+            nm: `${a.act} — ${a.title}`,
+            why: a.wt,
+            run: () => onRunFor(a.wtKey),
+          }),
+        );
     }
 
     flat.forEach(({ wt, repo }) => {

--- a/src/app/canopy/ServiceDetailModal.tsx
+++ b/src/app/canopy/ServiceDetailModal.tsx
@@ -9,7 +9,7 @@ import { Alert, Info, Restart, Server, Stop } from "../../icons";
 import { errText, hasBackend, ipc } from "../../ipc";
 import { useStore } from "../../store";
 import { fmtUptime, type ServiceNode, type WorktreeNode } from "../../types";
-import Modal, { Hint, Spacer } from "./Modal";
+import Modal, { Hint, Spacer, usePrimaryAction } from "./Modal";
 
 export default function ServiceDetailModal({
   wt,
@@ -80,6 +80,10 @@ export default function ServiceDetailModal({
     }
     onClose();
   };
+
+  // the ⏎ the Restart / Save-&-restart button advertises. The only field here
+  // is the port, where committing on ⏎ is what you would expect anyway.
+  usePrimaryAction("enter", valid, save);
 
   return (
     <Modal

--- a/src/app/canopy/SetupRunnerModal.tsx
+++ b/src/app/canopy/SetupRunnerModal.tsx
@@ -9,7 +9,7 @@ import { Check, Cube, Play, Spinner } from "../../icons";
 import { errText, hasBackend, ipc } from "../../ipc";
 import { useStore } from "../../store";
 import type { WorktreeNode } from "../../types";
-import Modal, { Hint, Spacer } from "./Modal";
+import Modal, { Hint, Spacer, usePrimaryAction } from "./Modal";
 
 /** setup.rs emits `{label} [2/5]: pnpm install` — the operation label comes
     first, so the marker is matched anywhere in the line rather than anchored. */
@@ -77,6 +77,13 @@ export default function SetupRunnerModal({
   const done = !running && !failed && steps.length > 0;
   const errored = failed || (op?.lines ?? []).some((l) => l.lv === "err");
   const elapsed = ((Date.now() - startedAt.current) / 1000).toFixed(1);
+
+  // the ⏎ the Start-services button advertises. This dialog has no text
+  // fields, so a bare ⏎ has nothing to take it from.
+  usePrimaryAction("enter", done, () => {
+    onStartServices();
+    onClose();
+  });
 
   return (
     <Modal

--- a/src/app/canopy/SidebarNav.tsx
+++ b/src/app/canopy/SidebarNav.tsx
@@ -4,7 +4,7 @@
    what they want from you, not by which repo they happen to live in.
    "Needs you" outranks everything; pinned worktrees hold the top of the rest. */
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Check, Chevron, Editor, Fork, Logs, Pin, Play, Plus, Search, SidebarIcon, Sparkle, Stop, Terminal, Trash } from "../../icons";
+import { Check, Chevron, Editor, Fork, Logs, Pin, Play, Plus, Search, SidebarIcon, Sparkle, Spinner, Stop, Terminal, Trash } from "../../icons";
 import { useStore, type LaneSession } from "../../store";
 import { isLive, type RepoNode, type WorktreeNode } from "../../types";
 import { agentState, dotClass, wtDot, type AttnItem } from "../nextAction";
@@ -43,6 +43,9 @@ export default function SidebarNav({
   const toggleWorktree = useStore((s) => s.toggleWorktree);
   const openWorktree = useStore((s) => s.openWorktree);
   const addRepo = useStore((s) => s.addRepo);
+  const creating = useStore((s) => s.creating);
+  const removing = useStore((s) => s.removing);
+  const ops = useStore((s) => s.ops);
   const pins = usePins();
   const [closed, setClosed] = useState<Record<string, boolean>>({});
   const [repoFilter, setRepoFilter] = useState<string | null>(null);
@@ -54,7 +57,9 @@ export default function SidebarNav({
 
   const groups = useMemo(() => {
     const vis = flat.filter(({ wt, repo }) => (!activeRepo || repo.repoId === activeRepo) && (!q || `${wt.branch} ${repo.name}`.toLowerCase().includes(q)));
-    const needs = new Set(attn.map((a) => a.wtKey));
+    // "a background job finished" is news, not a demand — it belongs in the
+    // queue but must not drag its worktree into the Needs-you group
+    const needs = new Set(attn.filter((a) => a.kind !== "info").map((a) => a.wtKey));
     const pinned = new Set(pins);
     const rest = vis.filter((f) => !needs.has(f.wt.wtKey));
     return [
@@ -72,6 +77,17 @@ export default function SidebarNav({
       },
     ].filter((g) => g.items.length);
   }, [flat, q, activeRepo, attn, pins]);
+
+  // in-flight creations, oldest first, filtered by the same repo filter the
+  // real rows obey so the list doesn't contradict itself
+  const pending = useMemo(
+    () =>
+      Object.entries(creating)
+        .filter(([, p]) => !activeRepo || p.repoId === activeRepo)
+        .filter(([, p]) => !q || `${p.branch} ${p.repoName}`.toLowerCase().includes(q))
+        .sort((a, b) => a[1].startedAt - b[1].startedAt),
+    [creating, activeRepo, q],
+  );
 
   const multi = useMultiSelect();
   // the visible order across all groups — the axis Shift-click ranges walk
@@ -115,6 +131,22 @@ export default function SidebarNav({
           <span className="n">{flat.length}</span>
         </button>
 
+        {/* A worktree being created has no row in the tree yet — the backend
+            only publishes it once it exists. Without this the sidebar is
+            silent for the minutes `git worktree add` + setup take, which is
+            exactly when "is it working?" gets asked. */}
+        {pending.map(([wtPath, p]) => (
+          <div className="cxs-wtr cxs-wtr--pending" key={wtPath} title={`Creating ${p.branch} in ${p.repoName}`}>
+            <span className="cxs-wtspin">
+              <Spinner size={11} />
+            </span>
+            <span className="b">{p.branch}</span>
+            <span className="meta">
+              <span className="cxs-wtnote">{ops[wtPath]?.step ?? "creating…"}</span>
+            </span>
+          </div>
+        ))}
+
         {groups.map((g) => (
           <div key={g.k}>
             <button
@@ -134,6 +166,7 @@ export default function SidebarNav({
                   wt={wt}
                   repoName={repo.name}
                   selected={wt.wtKey === selKey && view === "wt"}
+                  removing={!!removing[wt.wtKey]}
                   isMulti={multi.includes(wt.wtKey)}
                   sessions={sessions[wt.wtKey] ?? EMPTY}
                   onActivate={(mods) => activate(wt.wtKey, mods)}
@@ -241,6 +274,7 @@ function WorktreeRow({
   wt,
   repoName,
   selected,
+  removing,
   isMulti,
   sessions,
   onActivate,
@@ -251,6 +285,8 @@ function WorktreeRow({
   wt: WorktreeNode;
   repoName: string;
   selected: boolean;
+  /** its removal is in flight — the row is read-only until the tree catches up */
+  removing: boolean;
   isMulti: boolean;
   sessions: LaneSession[];
   onActivate: (mods: { meta: boolean; shift: boolean }) => void;
@@ -265,6 +301,22 @@ function WorktreeRow({
   // the toggle would offer "Start services" — which then races the shutdown.
   const settling = wt.services.some((s) => s.status === "starting" || s.status === "stopping");
   const pinned = isPinned(wt.wtKey);
+
+  // A removal in flight leaves the row in place but inert: the worktree is
+  // still in the tree until the backend republishes it, and clicking into a
+  // directory that is being deleted is not a thing to offer.
+  if (removing)
+    return (
+      <div className="cxs-wtr cxs-wtr--pending" title={`Removing ${wt.branch}`}>
+        <span className="cxs-wtspin">
+          <Spinner size={11} />
+        </span>
+        <span className="b">{wt.branch}</span>
+        <span className="meta">
+          <span className="cxs-wtnote">removing…</span>
+        </span>
+      </div>
+    );
 
   return (
     <div className={"cxs-wtr" + (selected ? " is-on" : "") + (isMulti ? " is-multi" : "")} title={`${repoName}: ${wt.branch}`}

--- a/src/app/canopy/SidebarNav.tsx
+++ b/src/app/canopy/SidebarNav.tsx
@@ -45,7 +45,6 @@ export default function SidebarNav({
   const addRepo = useStore((s) => s.addRepo);
   const creating = useStore((s) => s.creating);
   const removing = useStore((s) => s.removing);
-  const ops = useStore((s) => s.ops);
   const pins = usePins();
   const [closed, setClosed] = useState<Record<string, boolean>>({});
   const [repoFilter, setRepoFilter] = useState<string | null>(null);
@@ -136,15 +135,7 @@ export default function SidebarNav({
             silent for the minutes `git worktree add` + setup take, which is
             exactly when "is it working?" gets asked. */}
         {pending.map(([wtPath, p]) => (
-          <div className="cxs-wtr cxs-wtr--pending" key={wtPath} title={`Creating ${p.branch} in ${p.repoName}`}>
-            <span className="cxs-wtspin">
-              <Spinner size={11} />
-            </span>
-            <span className="b">{p.branch}</span>
-            <span className="meta">
-              <span className="cxs-wtnote">{ops[wtPath]?.step ?? "creating…"}</span>
-            </span>
-          </div>
+          <PendingRow key={wtPath} wtPath={wtPath} branch={p.branch} repoName={p.repoName} />
         ))}
 
         {groups.map((g) => (
@@ -205,6 +196,28 @@ export default function SidebarNav({
 }
 
 const EMPTY: LaneSession[] = [];
+
+/* A worktree being created, before the tree knows about it.
+
+   It subscribes to its own step marker rather than the sidebar subscribing to
+   the whole `ops` map: that map is replaced on EVERY streamed output line, so
+   reading it one level up re-rendered the entire worktree list once per line
+   of `pnpm install`. Selecting a primitive means this row alone re-renders,
+   and only when the step actually advances. */
+function PendingRow({ wtPath, branch, repoName }: { wtPath: string; branch: string; repoName: string }) {
+  const step = useStore((s) => s.ops[wtPath]?.step ?? null);
+  return (
+    <div className="cxs-wtr cxs-wtr--pending" title={`Creating ${branch} in ${repoName}`}>
+      <span className="cxs-wtspin">
+        <Spinner size={11} />
+      </span>
+      <span className="b">{branch}</span>
+      <span className="meta">
+        <span className="cxs-wtnote">{step ?? "creating…"}</span>
+      </span>
+    </div>
+  );
+}
 
 /* Filter the list to one repository. Hidden when there's only one repo — the
    text field already narrows by branch (and repo name), so the dropdown only

--- a/src/app/canopy/StatusBar.tsx
+++ b/src/app/canopy/StatusBar.tsx
@@ -4,7 +4,7 @@
    text plus one welded control: the word "Pull" pulls everything, the ▾ opens
    per-submodule control. Anchored to the control that opened it, not centred. */
 import { useEffect, useRef, useState } from "react";
-import { Bell, Chevron, Fork, Info, Pull, Search, Single, Sparkle, Split, Spinner } from "../../icons";
+import { Bell, Chevron, Fork, Info, Pull, Refresh, Search, Single, Sparkle, Split, Spinner } from "../../icons";
 import { errText, hasBackend, ipc, type Branches } from "../../ipc";
 import { useStore, type LaneSession } from "../../store";
 import type { SubmoduleStatus, WorktreeNode } from "../../types";
@@ -32,7 +32,9 @@ export default function StatusBar({
   panes: PaneKind[];
   onCycleLayout: () => void;
   onAttn: () => void;
-  onSwitchBranch: () => void;
+  /** absent when Settings has turned the Switch-branch action off — the branch
+      still shows, it just stops being a way in */
+  onSwitchBranch?: () => void;
   onDirty: () => void;
   worktreeCount: number;
   repoCount: number;
@@ -66,10 +68,17 @@ export default function StatusBar({
 
   return (
     <div className="cxs-statusbar">
-      <button className="cxs-sb cxs-sb--mono" onClick={onSwitchBranch} title="Switch branch…">
-        <Fork size={11} />
-        {wt.branch}
-      </button>
+      {onSwitchBranch ? (
+        <button className="cxs-sb cxs-sb--mono" onClick={onSwitchBranch} title="Switch branch…">
+          <Fork size={11} />
+          {wt.branch}
+        </button>
+      ) : (
+        <span className="cxs-sb cxs-sb--mono" title={wt.branch}>
+          <Fork size={11} />
+          {wt.branch}
+        </span>
+      )}
 
       {g && (g.ahead > 0 || g.behind > 0) && (
         <span className="cxs-sb cxs-sb--mono" title={`${g.ahead} ahead, ${g.behind} behind origin`}>
@@ -138,6 +147,8 @@ export default function StatusBar({
 
 function PullPop({ wt, onClose, anchor }: { wt: WorktreeNode; onClose: () => void; anchor?: React.RefObject<HTMLElement | null> }) {
   const showToast = useStore((s) => s.showToast);
+  const syncSubmodules = useStore((s) => s.syncSubmodules);
+  const syncing = useStore((s) => !!s.subSyncing[wt.wtKey]);
   const [subs, setSubs] = useState<SubmoduleStatus[]>([]);
   const [loaded, setLoaded] = useState(false);
   const [open, setOpen] = useState<string | null>(null);
@@ -177,6 +188,8 @@ function PullPop({ wt, onClose, anchor }: { wt: WorktreeNode; onClose: () => voi
         pullAll();
       }
     };
+    // ⇧⌘S is handled globally (App.tsx) — it works whether or not this popover
+    // is open, so it is not re-bound here.
     document.addEventListener("mousedown", d);
     document.addEventListener("keydown", k);
     return () => {
@@ -234,6 +247,19 @@ function PullPop({ wt, onClose, anchor }: { wt: WorktreeNode; onClose: () => voi
         </span>
         <span className="cx-kbd">⌘⏎</span>
       </button>
+
+      {/* Pull moves submodules FORWARD onto their branches; this puts them back
+          on the commit the parent pins — the repair after a branch switch. */}
+      {subs.length > 0 && (
+        <button className="cxs-pp-all" onClick={() => syncSubmodules(wt.wtKey)} disabled={!hasBackend() || syncing}>
+          <span className="cxs-pp-ic">{syncing ? <Spinner size={14} /> : <Refresh size={14} />}</span>
+          <span className="cxs-pp-tx">
+            <b>Sync submodules</b>
+            <span>re-pin {subs.length} submodule{subs.length === 1 ? "" : "s"} to this commit</span>
+          </span>
+          <span className="cx-kbd">⇧⌘S</span>
+        </button>
+      )}
 
       {(subs.length > 0 || !loaded) && (
         <>

--- a/src/app/canopy/TopBar.tsx
+++ b/src/app/canopy/TopBar.tsx
@@ -4,7 +4,7 @@
    global entry point (⌘K), right is the cross-worktree signal — how much is
    running, how many agents, and what needs a human. */
 import { useEffect, useRef, type RefObject } from "react";
-import { Bell, Check, ChevRight, Chevron, Cube, Fork, Refresh, Settings, Sparkle, Alert } from "../../icons";
+import { Bell, Check, ChevRight, Chevron, Cube, Fork, Refresh, Settings, Sparkle, Alert, X } from "../../icons";
 import type { AttnItem } from "../nextAction";
 import type { RepoNode, WorktreeNode } from "../../types";
 
@@ -34,7 +34,9 @@ export function TopBar({
   /** shared with AttentionPop so the trigger can close its own popover */
   attnRef?: RefObject<HTMLButtonElement | null>;
 }) {
-  const crashes = attn.filter((a) => a.kind === "crash").length;
+  // a backgrounded op that failed is as red as a crashed service — both mean
+  // something you asked for is not running
+  const crashes = attn.filter((a) => a.kind === "crash" || a.kind === "error").length;
 
   return (
     <div className="cxs-topbar" data-tauri-drag-region>
@@ -106,11 +108,15 @@ export function TopBar({
 export function AttentionPop({
   items,
   onPick,
+  onDismiss,
   onClose,
   anchor,
 }: {
   items: AttnItem[];
   onPick: (a: AttnItem) => void;
+  /** clear a notice row without acting on it (crashes have no dismiss — they
+      leave the queue by being fixed) */
+  onDismiss: (a: AttnItem) => void;
   onClose: () => void;
   /** the trigger, so its own mousedown isn't treated as "outside" — otherwise
       the listener closes the popover and the click immediately reopens it,
@@ -144,19 +150,34 @@ export function AttentionPop({
         </div>
       ) : (
         items.map((a) => (
-          <button className="cxs-attn-i" key={a.id} onClick={() => onPick(a)}>
-            <span className={"ic " + a.kind}>
-              {a.kind === "crash" ? <Alert size={12} /> : a.kind === "wait" ? <Sparkle size={12} /> : <Cube size={12} />}
-            </span>
-            <span className="tx">
-              <span className="tt">{a.title}</span>
-              <span className="wt">{a.wt}</span>
-            </span>
-            <span className="go">
-              {a.act}
-              <ChevRight size={11} />
-            </span>
-          </button>
+          <div className="cxs-attn-r" key={a.id}>
+            <button className="cxs-attn-i" onClick={() => onPick(a)}>
+              <span className={"ic " + a.kind}>
+                {a.kind === "crash" || a.kind === "error" ? (
+                  <Alert size={12} />
+                ) : a.kind === "wait" ? (
+                  <Sparkle size={12} />
+                ) : a.kind === "info" ? (
+                  <Check size={12} />
+                ) : (
+                  <Cube size={12} />
+                )}
+              </span>
+              <span className="tx">
+                <span className="tt">{a.title}</span>
+                <span className="wt">{a.wt}</span>
+              </span>
+              <span className="go">
+                {a.act}
+                <ChevRight size={11} />
+              </span>
+            </button>
+            {a.noticeId && (
+              <button className="cxs-attn-x" title="Dismiss" aria-label={`Dismiss ${a.title}`} onClick={() => onDismiss(a)}>
+                <X size={10} />
+              </button>
+            )}
+          </div>
         ))
       )}
     </div>

--- a/src/app/canopy/WorkSurface.tsx
+++ b/src/app/canopy/WorkSurface.tsx
@@ -6,11 +6,12 @@
    components either way. */
 import { useEffect, useRef, useState } from "react";
 import { Play, PopIn, PopOut, Sparkle, Spinner, Terminal as TerminalIcon, Logs as LogsIcon, Plus, X } from "../../icons";
-import { hasBackend } from "../../ipc";
+import { hasBackend, type AgentCfg } from "../../ipc";
 import { laneLabel, useStore, type LaneSession } from "../../store";
 import type { ServiceNode, WorktreeNode } from "../../types";
 import TerminalPane from "../TerminalPane";
 import LogsPane from "./LogsPane";
+import AnchoredMenu from "./AnchoredMenu";
 import { agentState, nextClass, type NextAction } from "../nextAction";
 import { useWtContext } from "../WorktreeContext";
 import { Chevron } from "../../icons";
@@ -50,6 +51,55 @@ const TAB_META: Record<PaneKind, { label: string; Icon: typeof LogsIcon }> = {
 };
 
 const EMPTY: LaneSession[] = [];
+
+/* Settings lets a repo configure several agent CLIs, but every launch here
+   silently took the first one — so the second and third were configurable and
+   unreachable. With more than one configured, launching asks which; with one,
+   it stays a single click. `render` receives the click handler so the caller
+   keeps its own button styling (a tab chip, or the empty state's primary). */
+function StartAgent({
+  agents,
+  onPick,
+  render,
+}: {
+  agents: AgentCfg[];
+  onPick: (profile?: AgentCfg) => void;
+  render: (open: () => void, ref: React.RefObject<HTMLButtonElement | null>) => React.ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLButtonElement>(null);
+  const many = agents.length > 1;
+  return (
+    <>
+      {render(() => (many ? setOpen((o) => !o) : onPick()), ref)}
+      {open && many && (
+        <AnchoredMenu anchor={ref} onClose={() => setOpen(false)} align="left" width={214}>
+          <div className="cx-pop__head">
+            <Sparkle size={11} />
+            Start an agent
+          </div>
+          {agents.map((a, i) => (
+            <button
+              key={a.id}
+              className="cx-pop__item"
+              role="menuitem"
+              onClick={() => {
+                setOpen(false);
+                onPick(a);
+              }}
+            >
+              <span className="cx-pop__ic">
+                <Sparkle size={13} />
+              </span>
+              {a.name || a.command}
+              {i === 0 && <span className="cx-k">default</span>}
+            </button>
+          ))}
+        </AnchoredMenu>
+      )}
+    </>
+  );
+}
 
 export default function WorkSurface({
   wt,
@@ -280,13 +330,26 @@ function Pane({
                   </span>
                 );
               })}
-              <button
-                className="cxs-sc"
-                title={kind === "agent" ? "New agent" : "New shell"}
-                onClick={() => (kind === "agent" ? launch.startAgent() : launch.startShell())}
-              >
-                <Plus size={10} />
-              </button>
+              {kind === "agent" ? (
+                <StartAgent
+                  agents={launch.agents}
+                  onPick={(profile) => launch.startAgent(profile ? { profile } : undefined)}
+                  render={(open, ref) => (
+                    <button
+                      ref={ref}
+                      className="cxs-sc"
+                      title={launch.agents.length > 1 ? "New agent — choose which" : "New agent"}
+                      onClick={open}
+                    >
+                      <Plus size={10} />
+                    </button>
+                  )}
+                />
+              ) : (
+                <button className="cxs-sc" title="New shell" onClick={() => launch.startShell()}>
+                  <Plus size={10} />
+                </button>
+              )}
             </div>
           )}
         </div>
@@ -313,13 +376,24 @@ function Pane({
               ? "It starts in a real terminal, seeded with this worktree's context — the task, its links, and the branch, database and ports."
               : "A login shell in this worktree's directory, on its pinned toolchain."}
           </span>
-          <button
-            className={nextClass("primary")}
-            onClick={() => (kind === "agent" ? launch.startAgent() : launch.startShell())}
-          >
-            {kind === "agent" ? <Sparkle size={12} /> : <TerminalIcon size={12} />}
-            {kind === "agent" ? "Start agent" : "Open terminal"}
-          </button>
+          {kind === "agent" ? (
+            <StartAgent
+              agents={launch.agents}
+              onPick={(profile) => launch.startAgent(profile ? { profile } : undefined)}
+              render={(open, ref) => (
+                <button ref={ref} className={nextClass("primary")} onClick={open}>
+                  <Sparkle size={12} />
+                  Start agent
+                  {launch.agents.length > 1 && <Chevron size={10} />}
+                </button>
+              )}
+            />
+          ) : (
+            <button className={nextClass("primary")} onClick={() => launch.startShell()}>
+              <TerminalIcon size={12} />
+              Open terminal
+            </button>
+          )}
         </div>
       ) : (
         <div className="cxs-pbody cxs-pbody--term">

--- a/src/app/canopy/WorktreeView.tsx
+++ b/src/app/canopy/WorktreeView.tsx
@@ -4,7 +4,7 @@
    never shrink — a shrinking action group just clips its own button. The
    reason rides in front of the next action and is the first thing to yield. */
 import { useEffect, useRef, useState, type ComponentType } from "react";
-import { Copy, Cube, Database, Doc, Editor, Finder, Fork, More, Pull, SidebarIcon, Swap, Trash } from "../../icons";
+import { Copy, Cube, Database, Doc, Editor, Finder, Fork, More, Pull, Refresh, SidebarIcon, Swap, Trash } from "../../icons";
 import { useStore } from "../../store";
 import type { ServiceNode, WorktreeNode } from "../../types";
 import { nextClass, type NextAction } from "../nextAction";
@@ -66,10 +66,12 @@ export default function WorktreeView({
   onSetup: () => void;
   onOpenService: (s: ServiceNode) => void;
   onEditContext: () => void;
-  onSwitchBranch: () => void;
+  /** absent when Settings has turned the Switch-branch action off */
+  onSwitchBranch?: () => void;
 }) {
   const openWorktree = useStore((s) => s.openWorktree);
   const gitPull = useStore((s) => s.gitPull);
+  const syncSubmodules = useStore((s) => s.syncSubmodules);
   const showToast = useStore((s) => s.showToast);
   const restartService = useStore((s) => s.restartService);
   const [filter, setFilter] = useState("all");
@@ -121,8 +123,11 @@ export default function WorktreeView({
           </button>
           {menu && (
             <AnchoredMenu anchor={moreRef} onClose={() => setMenu(false)} width={246}>
-              <MenuItem icon={Swap} label="Switch branch…" k="⌘\" onPick={() => { setMenu(false); onSwitchBranch(); }} />
+              {onSwitchBranch && (
+                <MenuItem icon={Swap} label="Switch branch…" k="⌘\" onPick={() => { setMenu(false); onSwitchBranch(); }} />
+              )}
               <MenuItem icon={Pull} label="Pull" onPick={() => { setMenu(false); gitPull(wt.wtKey); }} />
+              <MenuItem icon={Refresh} label="Sync submodules" k="⇧⌘S" onPick={() => { setMenu(false); syncSubmodules(wt.wtKey); }} />
               <MenuItem icon={Cube} label="Run setup…" onPick={runSetup} />
               <div className="cx-pop__sep" />
               <MenuItem icon={Database} label="Database…" onPick={() => { setMenu(false); onDatabase(); }} />

--- a/src/app/nextAction.ts
+++ b/src/app/nextAction.ts
@@ -20,7 +20,7 @@
 */
 import type { ComponentType } from "react";
 import { Browser, Bolt, Cube, Doc, Play, Pull, Restart, Spinner, Sparkle } from "../icons";
-import type { LaneSession } from "../store";
+import type { LaneSession, Notice } from "../store";
 import type { RepoNode, ServiceNode, WorktreeNode } from "../types";
 import { isLive } from "../types";
 
@@ -192,7 +192,7 @@ export function nextAction(wt: WorktreeNode, sessions: LaneSession[]): NextActio
    makes "the next action" true globally and not just inside whichever
    worktree happens to be selected. */
 
-export type AttnKind = "crash" | "wait" | "todo";
+export type AttnKind = "crash" | "wait" | "todo" | "error" | "info";
 
 export interface AttnItem {
   id: string;
@@ -207,10 +207,34 @@ export interface AttnItem {
   /** the imperative the row offers */
   act: string;
   svcKey?: string;
+  /** set on rows that came from a Notice — the id to dismiss it by */
+  noticeId?: string;
+  /** the copyable error text / log tail a failed background op carries */
+  detail?: string;
 }
 
-export function attentionItems(tree: RepoNode[], sessions: Record<string, LaneSession[]>): AttnItem[] {
+export function attentionItems(
+  tree: RepoNode[],
+  sessions: Record<string, LaneSession[]>,
+  notices: Notice[] = [],
+): AttnItem[] {
   const out: AttnItem[] = [];
+  /* A backgrounded op that FAILED ranks with a crash — it is the same kind of
+     news (something you asked for is not running) and it has nowhere else to
+     be seen. A completion is the opposite: it ranks last, below every real
+     demand, because it asks nothing of you. */
+  for (const n of notices)
+    out.push({
+      id: n.id,
+      sev: n.kind === "error" ? 0 : 9,
+      kind: n.kind === "error" ? "error" : "info",
+      wtKey: n.wtKey,
+      title: n.title,
+      wt: n.wt,
+      act: n.kind === "error" ? "View" : "Dismiss",
+      noticeId: n.id,
+      detail: n.detail,
+    });
   for (const repo of tree) {
     for (const wt of repo.worktrees) {
       for (const s of wt.services) {

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -146,6 +146,7 @@ export const ipc = {
     invoke<void>("switch_submodule_branch", { wtKey, path, branch }),
   listSubmoduleBranches: (wtKey: string, path: string) => invoke<Branches>("list_submodule_branches", { wtKey, path }),
   fetchSubmodules: (wtKey: string) => invoke<number>("fetch_submodules", { wtKey }),
+  syncSubmodules: (wtKey: string) => invoke<string>("sync_submodules", { wtKey }),
   switchWorktreeBranch: (wtKey: string, branch: string, create: boolean, base?: string) =>
     invoke<void>("switch_worktree_branch", { wtKey, branch, create, base: base ?? null }),
   listBranches: (repoId: string) => invoke<Branches>("list_branches", { repoId }),

--- a/src/popover/Popover.tsx
+++ b/src/popover/Popover.tsx
@@ -314,10 +314,7 @@ export default function Popover() {
   };
   const newWorktree = () => command("tray:new-worktree", "Create a worktree in the manager");
   const openManagerOverview = () => command("tray:overview", "Opening all worktrees");
-  const openSettings = () => {
-    openManager();
-    showToast("Settings — opening the manager");
-  };
+  const openSettings = () => command("tray:settings", "Settings — opening the manager");
 
   return (
     <div className="pop" ref={popRef}>

--- a/src/popover/Popover.tsx
+++ b/src/popover/Popover.tsx
@@ -279,6 +279,10 @@ export default function Popover() {
       } else if (e.metaKey && e.key.toLowerCase() === "n") {
         e.preventDefault();
         newWorktree();
+      } else if (e.metaKey && e.key === ",") {
+        // the hint the gear has always carried, now with a listener behind it
+        e.preventDefault();
+        openSettings();
       } else if (e.key === "Escape") {
         if (q) setQ("");
       } else if (e.key !== "Tab" && !e.metaKey && !e.ctrlKey && !e.altKey) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -9,6 +9,7 @@ import { errText, hasBackend, ipc, on } from "./ipc";
 const LOG_CAP = 160;
 const CPU_SAMPLES = 7; // the service-detail sparkline shows seven slots
 const OP_LOG_CAP = 300;
+const NOTICE_CAP = 24;
 
 /** Buffered progress of a worktree-level operation (setup / create / custom cmd). */
 export interface OpLog {
@@ -17,6 +18,60 @@ export interface OpLog {
   step: string | null;
   running: boolean;
 }
+
+/* ── background operations ────────────────────────────────────────────────
+   Creating and removing a worktree are minutes-long, backend-owned jobs. Both
+   dialogs can be dismissed while the job runs — but a dismissed dialog has
+   nowhere to report back to, and an error that only ever existed inside it is
+   an error the user never sees. So an op whose dialog was sent away records
+   its outcome as a Notice, and the attention queue ("Needs you") renders those
+   next to crashes and blocked agents: the one place the app already promises
+   is where things needing a human turn up. */
+export interface Notice {
+  id: string;
+  /** "error" is something that failed; "done" is a background job reporting in */
+  kind: "error" | "done";
+  /** present-tense statement of what happened */
+  title: string;
+  /** the branch it concerns — the row's context line */
+  wt: string;
+  wtKey: string;
+  /** full error text and log tail, never truncated — this is what gets copied */
+  detail: string;
+  ts: number;
+}
+
+/** A worktree whose `git worktree add` + setup is still running. It has no row
+    in the tree yet (the backend only publishes it once it exists), so the
+    sidebar renders these as its own in-progress rows. */
+export interface PendingCreate {
+  repoId: string;
+  repoName: string;
+  branch: string;
+  startedAt: number;
+}
+
+export interface CreateWorktreeArgs {
+  repoId: string;
+  repoName: string;
+  branch: string;
+  base?: string;
+  createBranch: boolean;
+  /** the path the backend will create. Progress events are keyed by it, so it
+      is also what the in-progress row and the failure notice are filed under. */
+  wtPath: string;
+  /** called with the REAL path once it exists (seeding .canopy/context.md) */
+  onCreated?: (wtPath: string) => void;
+}
+
+/** Keys whose dialog was dismissed while their op ran. Not reactive state —
+    nothing renders from it; it only decides whether the outcome is reported
+    as a Notice (dialog gone) or left to the dialog that is still watching. */
+const backgrounded = new Set<string>();
+export const backgroundOp = (key: string) => backgrounded.add(key);
+const takeBackground = (key: string) => backgrounded.delete(key);
+
+let noticeSeq = 0;
 
 /* ── agent-lane sessions ──────────────────────────────────────────────────────
    A worktree can hold any number of concurrent agent and shell tabs. Each one
@@ -89,8 +144,29 @@ interface State {
       it was previously dropped on the floor. */
   exitCodes: Record<string, number>;
   resetting: Record<string, boolean>;
+  /** worktrees whose submodules are being synced to their pinned commits */
+  subSyncing: Record<string, boolean>;
   toast: string | null;
   flash: "manager" | "quit" | null;
+
+  /** outcomes of backgrounded operations, newest first — the attention queue */
+  notices: Notice[];
+  notify: (n: Omit<Notice, "id" | "ts">) => void;
+  dismissNotice: (id: string) => void;
+
+  /** worktrees being created right now, keyed by their destination path */
+  creating: Record<string, PendingCreate>;
+  /** worktrees being removed right now */
+  removing: Record<string, boolean>;
+  createWorktree: (a: CreateWorktreeArgs) => Promise<string>;
+  removeWorktrees: (wtKeys: string[], deleteBranch: boolean, dropDb: boolean) => Promise<void>;
+
+  /** Settings' "Show the Switch-branch action". Mirrored here so every surface
+      offering it (⌘\, the status bar, the worktree menu) reads ONE answer. */
+  showSwitchBranch: boolean;
+  /** re-read the preferences this store mirrors from Settings */
+  loadPrefs: () => void;
+  syncSubmodules: (wtKey: string) => void;
 
   selKey: string | null;
   query: string;
@@ -175,6 +251,15 @@ function patchStatus(tree: RepoNode[], svcKey: string, status: SvcStatus): RepoN
 export function wtLabel(tree: RepoNode[], wtKey: string): string {
   const f = findWt(tree, wtKey);
   return f ? `${f.wt.branch} · ${f.repo.name}` : wtKey;
+}
+
+/** The tail of a worktree's op buffer — the log a failure notice carries, so
+    "it failed" comes with the lines that say how. */
+function opTail(wtKey: string, n = 24): string {
+  return (useStore.getState().ops[wtKey]?.lines ?? [])
+    .slice(-n)
+    .map((l) => l.text)
+    .join("\n");
 }
 
 const timers: Record<string, ReturnType<typeof setTimeout>> = {};
@@ -277,8 +362,13 @@ export const useStore = create<State>((set, get) => {
     cpuHistory: {},
     exitCodes: {},
     resetting: {},
+    subSyncing: {},
     toast: null,
     flash: null,
+    notices: [],
+    creating: {},
+    removing: {},
+    showSwitchBranch: true,
 
     selKey: mock[0]?.worktrees[0]?.wtKey ?? null,
     query: "",
@@ -360,7 +450,10 @@ export const useStore = create<State>((set, get) => {
         return { detachedTerms: next };
       }),
     settingsRev: 0,
-    bumpSettings: () => set((st) => ({ settingsRev: st.settingsRev + 1 })),
+    bumpSettings: () => {
+      set((st) => ({ settingsRev: st.settingsRev + 1 }));
+      get().loadPrefs();
+    },
     mainRailed: false,
     setMainRailed: (mainRailed) => set({ mainRailed }),
 
@@ -458,6 +551,134 @@ export const useStore = create<State>((set, get) => {
       showToast(`Resetting database — ${label}…`);
       ipc.resetDb(wtKey).catch((e) => showToast(errText(e)));
     },
+    notify: (n) =>
+      set((st) => ({ notices: [{ ...n, id: `n-${Date.now().toString(36)}-${noticeSeq++}`, ts: Date.now() }, ...st.notices].slice(0, NOTICE_CAP) })),
+    dismissNotice: (id) => set((st) => ({ notices: st.notices.filter((n) => n.id !== id) })),
+
+    /* Creating a worktree lives HERE, not in the dialog, because the dialog is
+       dismissable mid-run: the job has to outlive the component that started
+       it, and its outcome has to land somewhere the user will still see. */
+    createWorktree: async (a) => {
+      if (!hasBackend()) {
+        showToast("New worktree needs the desktop app");
+        throw new Error("New worktree needs the desktop app");
+      }
+      set((st) => ({
+        creating: {
+          ...st.creating,
+          [a.wtPath]: { repoId: a.repoId, repoName: a.repoName, branch: a.branch, startedAt: Date.now() },
+        },
+      }));
+      try {
+        const path = await ipc.createWorktree({
+          repoId: a.repoId,
+          branch: a.branch,
+          base: a.base,
+          createBranch: a.createBranch,
+        });
+        a.onCreated?.(path);
+        showToast(`Worktree ready — ${a.branch}`);
+        if (takeBackground(a.wtPath))
+          get().notify({ kind: "done", title: "Worktree ready", wt: a.branch, wtKey: path, detail: opTail(path) });
+        return path;
+      } catch (e) {
+        takeBackground(a.wtPath);
+        // Notify even when the dialog is still open: the dialog shows this
+        // inline, but it can be closed, and a create that failed is exactly the
+        // thing that must not disappear with it.
+        get().notify({
+          kind: "error",
+          title: "Worktree creation failed",
+          wt: a.branch,
+          wtKey: a.wtPath,
+          detail: [errText(e), opTail(a.wtPath)].filter(Boolean).join("\n\n"),
+        });
+        throw e;
+      } finally {
+        set((st) => {
+          const creating = { ...st.creating };
+          delete creating[a.wtPath];
+          return { creating };
+        });
+      }
+    },
+
+    removeWorktrees: async (wtKeys, deleteBranch, dropDb) => {
+      if (!hasBackend()) {
+        showToast("Removing worktrees needs the desktop app");
+        throw new Error("Removing worktrees needs the desktop app");
+      }
+      // resolve the labels BEFORE the removal — afterwards the tree no longer
+      // has these worktrees, so there is nothing left to name them by
+      const labels = wtKeys.map((k) => findWt(get().tree, k)?.wt.branch ?? k);
+      set((st) => ({ removing: { ...st.removing, ...Object.fromEntries(wtKeys.map((k) => [k, true])) } }));
+      const many = wtKeys.length !== 1;
+      const label = many ? `${wtKeys.length} worktrees` : labels[0];
+      try {
+        if (many) await ipc.removeWorktrees(wtKeys, deleteBranch, dropDb);
+        else await ipc.removeWorktree(wtKeys[0], deleteBranch, dropDb);
+        showToast(many ? `Removed ${wtKeys.length} worktrees` : `Worktree removed — ${labels[0]}`);
+        if (wtKeys.map((k) => takeBackground(k)).some(Boolean))
+          get().notify({
+            kind: "done",
+            title: many ? `${wtKeys.length} worktrees removed` : "Worktree removed",
+            wt: label,
+            wtKey: wtKeys[0],
+            detail: labels.join("\n"),
+          });
+      } catch (e) {
+        wtKeys.forEach((k) => takeBackground(k));
+        get().notify({
+          kind: "error",
+          title: many ? "Worktree removal failed" : "Could not remove worktree",
+          wt: label,
+          wtKey: wtKeys[0],
+          detail: [errText(e), opTail(wtKeys[0])].filter(Boolean).join("\n\n"),
+        });
+        throw e;
+      } finally {
+        set((st) => {
+          const removing = { ...st.removing };
+          wtKeys.forEach((k) => delete removing[k]);
+          return { removing };
+        });
+      }
+    },
+
+    loadPrefs: () => {
+      if (!hasBackend()) return;
+      ipc
+        .getSettings()
+        .then((s) => set({ showSwitchBranch: s.showSwitchBranch !== false }))
+        .catch(() => {});
+    },
+
+    /* `git submodule sync` + `update --init --recursive` — puts every submodule
+       back on the commit the parent pins. Distinct from Pull, which moves them
+       FORWARD onto their own branches; this is the "my submodules are on the
+       wrong commit after a branch change" repair. */
+    syncSubmodules: (wtKey) => {
+      const label = wtLabel(get().tree, wtKey);
+      if (!hasBackend()) {
+        showToast("Syncing submodules needs the desktop app");
+        return;
+      }
+      if (get().subSyncing[wtKey]) return;
+      set((st) => ({ subSyncing: { ...st.subSyncing, [wtKey]: true } }));
+      showToast(`Syncing submodules — ${label}…`);
+      ipc
+        .syncSubmodules(wtKey)
+        .then((summary) => showToast(`✓ ${summary} — ${label}`))
+        .catch((e) => showToast(`Submodule sync failed — ${errText(e)}`))
+        .finally(() =>
+          set((st) => {
+            const subSyncing = { ...st.subSyncing };
+            delete subSyncing[wtKey];
+            return { subSyncing };
+          }),
+        );
+    },
+
     addRepoOpen: false,
     addRepo: () => set({ addRepoOpen: true }),
     closeAddRepo: () => set({ addRepoOpen: false }),
@@ -556,6 +777,7 @@ export function initSync(): () => void {
     .getTree()
     .then((tree) => !disposed && reconcile(tree))
     .catch((e) => console.error("get_tree failed", e));
+  useStore.getState().loadPrefs();
 
   track(on.treeChanged((tree) => reconcile(tree)));
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -255,7 +255,7 @@ export function wtLabel(tree: RepoNode[], wtKey: string): string {
 
 /** The tail of a worktree's op buffer — the log a failure notice carries, so
     "it failed" comes with the lines that say how. */
-function opTail(wtKey: string, n = 24): string {
+export function opTail(wtKey: string, n = 24): string {
   return (useStore.getState().ops[wtKey]?.lines ?? [])
     .slice(-n)
     .map((l) => l.text)

--- a/src/styles/canopy-modals.css
+++ b/src/styles/canopy-modals.css
@@ -647,3 +647,22 @@ button.cxm-frow--open:focus-visible {
   color: var(--text-tertiary);
   cursor: default;
 }
+
+/* ── raw operation output (a background job's error + log tail) ──────
+   Selectable and scrollable rather than summarised: the reason this dialog
+   exists is the text itself. Capped so a long tail can't push the footer off
+   the screen. */
+.cx-logdump {
+  margin: 0;
+  padding: var(--sp-pop);
+  max-height: 260px;
+  overflow: auto;
+  border-radius: var(--r-sm);
+  background: var(--btn);
+  border: var(--border-w) solid var(--divider);
+  font: var(--fs-micro) / 1.6 var(--mono);
+  color: var(--text-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  user-select: text;
+}

--- a/src/styles/canopy-shell.css
+++ b/src/styles/canopy-shell.css
@@ -250,25 +250,49 @@
   color: var(--text-secondary);
   filter: none;
 }
+/* A queue row is the item plus — for a notice, which is the only thing here
+   that can be cleared without being fixed — a dismiss. The rule lives on the
+   row rather than the button so the last row still loses it. */
+.cxs-attn-r {
+  display: flex;
+  align-items: stretch;
+  border-bottom: var(--border-w) solid var(--divider);
+}
+.cxs-attn-r:last-child {
+  border-bottom: 0;
+}
+.cxs-attn-r:hover {
+  background: var(--raised);
+}
 .cxs-attn-i {
   display: flex;
   align-items: center;
   gap: var(--sp-4);
   width: 100%;
+  min-width: 0;
   text-align: left;
   padding: var(--sp-3) var(--sp-pop-lg);
   border: 0;
-  border-bottom: var(--border-w) solid var(--divider);
   background: none;
   cursor: pointer;
   color: var(--text-primary);
   font-family: var(--sans);
 }
-.cxs-attn-i:last-child {
-  border-bottom: 0;
+.cxs-attn-x {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  background: none;
+  cursor: pointer;
+  color: var(--text-tertiary);
 }
-.cxs-attn-i:hover {
-  background: var(--raised);
+.cxs-attn-x:hover {
+  color: var(--text-primary);
 }
 .cxs-attn-i .ic {
   flex: none;
@@ -290,6 +314,15 @@
 .cxs-attn-i .ic.todo {
   background: var(--teal-dim);
   color: var(--action-primary);
+}
+/* a backgrounded op that failed reads as a crash; one that finished is calm */
+.cxs-attn-i .ic.error {
+  background: var(--red-dim);
+  color: var(--red-text);
+}
+.cxs-attn-i .ic.info {
+  background: var(--btn);
+  color: var(--text-secondary);
 }
 .cxs-attn-i .tx {
   min-width: 0;
@@ -559,6 +592,32 @@
 }
 .cxs-wtr:hover {
   background: var(--row-hover);
+}
+/* a worktree being created or removed: present, but not yet (or no longer)
+   something to click into */
+.cxs-wtr--pending {
+  cursor: default;
+  opacity: 0.72;
+}
+.cxs-wtr--pending:hover {
+  background: none;
+}
+.cxs-wtspin {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--dot-sm);
+  color: var(--action-primary);
+}
+.cxs-wtnote {
+  font-size: var(--fs-micro);
+  color: var(--text-tertiary);
+  font-family: var(--mono);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 118px;
 }
 .cxs-wtr.is-on {
   background: var(--surface);
@@ -1144,8 +1203,19 @@
 .cxs-sc .d.wait {
   background: var(--state-attention);
 }
+/* The close affordance is a <button>, so it needs the reset spelled out —
+   without it the UA's default border/background painted a raised box around
+   the ✕ that read as a second control sitting inside the tab. */
 .cxs-sc .x {
   display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  padding: 0;
+  border: 0;
+  background: none;
+  cursor: pointer;
   color: var(--text-tertiary);
   border-radius: var(--r-tiny);
   margin-right: calc(var(--sp-micro) * -1);


### PR DESCRIPTION
Fourteen fixes. The organizing idea behind most of them: **a long operation had nowhere to report back to.**

Creating and removing a worktree are minutes-long, backend-owned jobs, but both lived entirely inside their dialog — dismissing one threw away the outcome, including failures. Both now live in the store, can be sent to the background, and report into the attention queue as a Notice carrying the error and log tail, copyable in full.

## The twelve requested fixes

| # | Fix |
|---|---|
| 1 | Tray gear emits `tray:settings`; App opens Settings instead of just raising the window |
| 2 | New worktree: **Run in background** + a spinner row in the sidebar showing the live setup step |
| 3 | A failed create lands in **Needs you** with a copyable error + log tail |
| 4 | Database jobs (reset, migrate, export, restore, snapshot) hold the dialog with a per-row spinner instead of closing on "started" |
| 5 | Settings › Files: browse for the file to provision **and** its source; repo-relative paths, format from the extension |
| 6 | **Sync submodules** — `submodule sync` + `update --init --recursive`, the repair Pull cannot do — in the pull popover, the worktree menu, and ⇧⌘S |
| 7 | Repos can configure several agent CLIs but every launch silently took the first. Starting an agent now asks which |
| 8 | "Show the Switch-branch action" was stored and ignored. It now gates the status-bar button, the menu item and ⌘\ |
| 9 | `.worktreemanager.json` controls only appear on repository pages, where a repo is in scope |
| 10 | Removed the title bar's `{}` toggle; repo pages keep "Preview JSON ⌘P" |
| 11 | Removal can be backgrounded too, reporting the same way |
| 12 | The terminal/agent tab's close ✕ was an unreset `<button>` — that was the box around it |

## Shortcuts

The Shortcuts page was a partial, partly-wrong reference (16 entries, missing ⌘5 and ⇧⌘S, filing ⌘N as "Global" when only the tray listened). Auditing every handler turned up the larger problem: **several keys the UI prints were bound nowhere.** Now real, each on the control that already advertised it:

- `⌘,` Settings (both windows) · `⌘N` New worktree in the main window
- `⌘⏎` Create worktree, Context's Start agent
- `⏎` Setup's Start services, Service detail's Restart, the snapshot prompt

The ⏎ bindings go through one `usePrimaryAction` hook so the guards are written once: a textarea keeps ⏎, a button the user tabbed to keeps it, an inner popup that claimed Escape keeps it, a disabled action never fires. The header's close is the exception — that's where focus *falls back* to, not somewhere chosen.

Database's "Run migration ⏎" is the one hint **removed** rather than honoured: its only field is the database search, and running a migration out of a search box is a nasty surprise.

Table is now 31 entries across Global / Worktree / Pull menu / Dialogs / Lists / Worktree list / Settings / Menu bar, indexed by ⌘F.

## Defects found while testing this branch

- **Performance:** `SidebarNav` subscribed to the whole `ops` map to show a pending worktree's step. That map is *replaced on every streamed output line*, so the entire worktree list re-rendered once per line of `pnpm install`. The row now selects its own step string — measured 400 lines → **400 sidebar renders before, 10 after**.
- Two shortcut rows share a command name ("New worktree" and "Settings" exist in two scopes), colliding React's key. Keyed on all three columns.

## Verification

Every fix re-tested against the mock backend: backgrounded create and remove (dialog dismissed, row stays busy, live step shown, clears on completion), the notice queue and its copyable detail, database loaders holding the dialog, the agent picker launching the *non-default* profile, switch-branch gating across all three surfaces, settings scoping, and the new bindings **including the guards** (⏎ in the database search does not migrate; ⏎ while setup is still running does nothing).

`tsc`, `vite build`, `cargo check` and the production CSP check all clean; console clean. Bundle 208,117 → 217,347 bytes for the whole branch.

A security review of the diff found no newly-introduced vulnerabilities. One item worth a separate look, *pre-existing and unchanged by this PR*: `protocol.file.allow=always` on submodule updates (already in `create_worktree` and `switch_branch`) re-enables `file://` submodules, which git restricted in CVE-2022-39253. The new `sync_submodules` follows the established pattern rather than adding a new class of exposure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKHAXXoKaWpXU5DJasBpiL



Closes #7
Closes #8
