### PR TITLE
UX: text zoom (⌘±), simpler notices + top bar, Sync reloads repo config, .worktrees default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "canopy",
-  "version": "0.3.0",
+  "version": "0.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "canopy",
-      "version": "0.3.0",
+      "version": "0.4.7",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@tauri-apps/api": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canopy",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "canopy"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "base64 0.23.0",
  "fix-path-env",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "canopy"
-version = "0.4.6"
+version = "0.4.7"
 description = "Canopy — lightweight git worktree and dev-service manager"
 authors = ["Midhun Kumar"]
 license = "AGPL-3.0-only"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -77,7 +77,10 @@ pub async fn add_repo(app: AppHandle, path: String) -> Result<RepoCfg, CanopyErr
     let repo = RepoCfg {
         id: name.to_lowercase().replace(' ', "-"),
         name: name.clone(),
-        worktree_dir: format!("{top}-worktrees"),
+        // Default new worktrees to a hidden dir INSIDE the repo. Keeping them
+        // under the repo root (rather than a `<repo>-worktrees` sibling) means
+        // one self-contained tree to back up, move, or delete.
+        worktree_dir: format!("{top}/.worktrees"),
         path: top,
         reset_db: String::new(),
         migrate_db: String::new(),
@@ -734,10 +737,19 @@ pub async fn create_worktree(
             .cloned()
             .ok_or_else(|| CanopyError::not_found("unknown repo"))?
     };
-    let wt_dir = if repo.worktree_dir.trim().is_empty() {
-        format!("{}-worktrees", repo.path)
-    } else {
-        repo.worktree_dir.clone()
+    // Resolve the worktree root: empty falls back to `<repo>/.worktrees`, a
+    // relative dir (e.g. ".worktrees") is taken relative to the repo — so it
+    // lands inside the repo instead of wherever the process CWD happens to be —
+    // and an absolute dir is used verbatim.
+    let wt_dir = {
+        let d = repo.worktree_dir.trim();
+        if d.is_empty() {
+            format!("{}/.worktrees", repo.path)
+        } else if std::path::Path::new(d).is_absolute() {
+            d.to_string()
+        } else {
+            format!("{}/{}", repo.path, d)
+        }
     };
     let wt_path = format!("{wt_dir}/{}", sanitize_branch(&branch));
     if std::path::Path::new(&wt_path).exists() {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -720,6 +720,22 @@ pub(crate) fn sanitize_branch(branch: &str) -> String {
         .collect()
 }
 
+/// Write a self-ignoring `.gitignore` (`*`) into `dir`, creating it if needed.
+/// A worktree root that lives INSIDE the repo (the `.worktrees` default) would
+/// otherwise show up as untracked in the parent checkout — polluting `git
+/// status`, risking a stray `git add .`, and tripping Canopy's own dirty
+/// detection. This is the same self-ignore `.canopy/` uses. Never truncates an
+/// existing `.gitignore`.
+fn ensure_dir_self_ignored(dir: &str) -> Result<(), String> {
+    let p = std::path::Path::new(dir);
+    std::fs::create_dir_all(p).map_err(|e| format!("mkdir {dir}: {e}"))?;
+    let ignore = p.join(".gitignore");
+    if !ignore.exists() {
+        std::fs::write(&ignore, "*\n").map_err(|e| format!("write {}: {e}", ignore.display()))?;
+    }
+    Ok(())
+}
+
 #[tauri::command]
 pub async fn create_worktree(
     app: AppHandle,
@@ -754,6 +770,15 @@ pub async fn create_worktree(
     let wt_path = format!("{wt_dir}/{}", sanitize_branch(&branch));
     if std::path::Path::new(&wt_path).exists() {
         return Err(CanopyError::conflict(format!("Path already exists: {wt_path}")));
+    }
+
+    // Keep a worktree root that sits inside the repo from polluting the parent
+    // checkout. Best-effort: an unwritable root is the git command's problem to
+    // report, not a reason to abort before we've even tried to create.
+    if std::path::Path::new(&wt_dir).starts_with(&repo.path) {
+        if let Err(e) = ensure_dir_self_ignored(&wt_dir) {
+            emit_op(&app, &wt_path, "create", "progress", format!("gitignore skipped — {e}"));
+        }
     }
 
     let _lease = crate::state::try_lease(&app, &wt_path, "create")?;

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -45,7 +45,8 @@ pub struct RepoCfg {
     pub id: String,
     pub name: String,
     pub path: String,
-    /// Directory where new worktrees are created (e.g. <repo>-worktrees)
+    /// Directory where new worktrees are created. Absolute, or relative to the
+    /// repo root (e.g. ".worktrees"). Empty falls back to `<repo>/.worktrees`.
     pub worktree_dir: String,
     /// Command run in the worktree root for "Reset DB" (empty = action hidden)
     pub reset_db: String,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Canopy",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "identifier": "com.midhunkumare.canopy",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -31,6 +31,7 @@ import PruneWorktreesModal from "./PruneWorktreesModal";
 import SwitchBranchModal from "./SwitchBranchModal";
 import UncommittedChangesModal from "./UncommittedChangesModal";
 import Onboarding from "../onboarding/Onboarding";
+import { nudgeFontScale, resetFontScale } from "../appearance";
 
 export default function App() {
   const tree = useStore((s) => s.tree);
@@ -53,6 +54,7 @@ export default function App() {
   const notices = useStore((s) => s.notices);
   const dismissNotice = useStore((s) => s.dismissNotice);
   const syncSubmodules = useStore((s) => s.syncSubmodules);
+  const bumpSettings = useStore((s) => s.bumpSettings);
   const switchBranchEnabled = useStore((s) => s.showSwitchBranch);
 
   const [view, setView] = useState<"wt" | "overview">("wt");
@@ -205,6 +207,10 @@ export default function App() {
     const known = new Map(tree.flatMap((r) => r.worktrees.map((w) => [w.wtKey, w.dbName] as const)));
     try {
       await ipc.refresh();
+      // Sync also reconciles Settings with what's on disk: a repo's
+      // `.worktreemanager.json` (setup tasks, provisioned files, migrate) may
+      // have changed outside the app, so signal open views to re-read it.
+      bumpSettings();
       const prunable = await ipc.listPrunableWorktrees();
       if (prunable.length > 0) {
         setPruneFor(prunable.map((p) => ({ ...p, dbName: known.get(p.path) ?? null })));
@@ -232,6 +238,24 @@ export default function App() {
       if (e.key === "Escape") {
         setPalette(false);
         setAttnOpen(false);
+        return;
+      }
+      // ⌘+ / ⌘- / ⌘0 — app-wide text zoom. Works from anywhere (even a field or
+      // with the palette open) since it never collides with text entry, and
+      // applies live across every Canopy window via appearance.ts.
+      if (meta && (e.key === "=" || e.key === "+")) {
+        e.preventDefault();
+        nudgeFontScale(1);
+        return;
+      }
+      if (meta && (e.key === "-" || e.key === "_")) {
+        e.preventDefault();
+        nudgeFontScale(-1);
+        return;
+      }
+      if (meta && e.key === "0") {
+        e.preventDefault();
+        resetFontScale();
         return;
       }
       if (palette) return;

--- a/src/app/NewWorktreeModal.tsx
+++ b/src/app/NewWorktreeModal.tsx
@@ -134,11 +134,16 @@ export default function NewWorktreeModal({ repoId, onClose }: { repoId: string; 
   }, [mode, picked, base, existing, existingKind, branches]);
 
   const branch = payload.branch;
-  // create_worktree: `${worktree_dir || repo.path + "-worktrees"}/${sanitize_branch(branch)}`
+  // Mirror create_worktree's resolution: empty → `<repo>/.worktrees`, a relative
+  // dir is taken relative to the repo, an absolute dir is used verbatim.
+  const worktreeRoot = (() => {
+    if (!activeRepo) return "";
+    const d = (worktreeDir ?? "").trim();
+    if (!d) return `${activeRepo.path}/.worktrees`;
+    return d.startsWith("/") ? d : `${activeRepo.path}/${d}`;
+  })();
   const destination =
-    ok && worktreeDir !== null && activeRepo
-      ? `${worktreeDir.trim() || `${activeRepo.path}-worktrees`}/${sanitizeBranch(branch)}`
-      : null;
+    ok && worktreeDir !== null && activeRepo ? `${worktreeRoot}/${sanitizeBranch(branch)}` : null;
   /* The key the in-progress row and the failure notice are filed under. It is
      the destination when we can predict it — that is what worktree:op events
      are keyed by, so the row can show live steps. When the repo's settings

--- a/src/app/SettingsView.tsx
+++ b/src/app/SettingsView.tsx
@@ -856,6 +856,9 @@ const KEYS: [string, string, string][] = [
   ["Toggle worktree list", "⌘ B", "Global"],
   ["Cross-worktree overview", "⌘ O", "Global"],
   ["Settings", "⌘ ,", "Global"],
+  ["Increase text size", "⌘ +", "Global"],
+  ["Decrease text size", "⌘ -", "Global"],
+  ["Reset text size", "⌘ 0", "Global"],
   // worktree
   ["Run next action", "⏎", "Worktree"],
   ["Switch branch", "⌘ \\", "Worktree"],
@@ -1060,6 +1063,7 @@ export default function SettingsView({ onClose }: { onClose: () => void }) {
   const showToast = useStore((s) => s.showToast);
   const tree = useStore((s) => s.tree);
   const bumpSettings = useStore((s) => s.bumpSettings);
+  const settingsRev = useStore((s) => s.settingsRev);
   const selKey = useStore((s) => s.selKey);
 
   const [settings, setSettings] = useState<Settings | null>(null);
@@ -1113,6 +1117,25 @@ export default function SettingsView({ onClose }: { onClose: () => void }) {
     }).catch((e) => showToast(`Failed to load settings: ${e}`));
   }
   useEffect(load, []);
+
+  // Sync (and Save) bump settingsRev. When it changes while Settings is open,
+  // re-read each repo's `.worktreemanager.json` from disk so Setup, Files and
+  // Migrate reflect edits made outside the app — but never clobber a repo the
+  // user is mid-edit on (still in dirtyRepos with unsaved changes).
+  const didMount = useRef(false);
+  useEffect(() => {
+    if (!didMount.current) { didMount.current = true; return; }
+    if (!hasBackend() || !settings) return;
+    settings.repos.forEach((r) => {
+      if (dirtyRepos.current.has(r.id)) return;
+      ipc.getRepoConfig(r.id).then((c) => {
+        setCardsByRepo((m) => ({ ...m, [r.id]: toCards(c.provision) }));
+        setSetupByRepo((m) => ({ ...m, [r.id]: c.setup }));
+        setExtrasByRepo((m) => ({ ...m, [r.id]: { teardown: c.teardown || [], migrate: c.migrate || [] } }));
+      }).catch(() => {});
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [settingsRev]);
 
   useEffect(() => {
     const k = (e: KeyboardEvent) => {

--- a/src/app/canopy/TopBar.tsx
+++ b/src/app/canopy/TopBar.tsx
@@ -4,7 +4,7 @@
    global entry point (⌘K), right is the cross-worktree signal — how much is
    running, how many agents, and what needs a human. */
 import { useEffect, useRef, type RefObject } from "react";
-import { Bell, Check, ChevRight, Chevron, Cube, Fork, Refresh, Settings, Sparkle, Alert, X } from "../../icons";
+import { Bell, Check, ChevRight, Cube, Fork, Refresh, Settings, Sparkle, Alert, X } from "../../icons";
 import type { AttnItem } from "../nextAction";
 import type { RepoNode, WorktreeNode } from "../../types";
 
@@ -49,14 +49,13 @@ export function TopBar({
         </div>
         <span className="cxs-tdiv" />
         {repo && wt && (
-          <button className="cxs-crumb" onClick={onPalette} title="Switch worktree  (⌘K)">
+          <div className="cxs-crumb">
             <span className="rp">{repo.name}</span>
             <span className="rpchev">
               <ChevRight size={11} />
             </span>
             <span className="br">{wt.branch}</span>
-            <Chevron size={11} />
-          </button>
+          </div>
         )}
       </div>
 
@@ -167,10 +166,14 @@ export function AttentionPop({
                 <span className="tt">{a.title}</span>
                 <span className="wt">{a.wt}</span>
               </span>
-              <span className="go">
-                {a.act}
-                <ChevRight size={11} />
-              </span>
+              {/* a completion notice is dismissed by the X alone — showing a
+                  second "Dismiss ›" affordance beside it is redundant */}
+              {a.kind !== "info" && (
+                <span className="go">
+                  {a.act}
+                  <ChevRight size={11} />
+                </span>
+              )}
             </button>
             {a.noticeId && (
               <button className="cxs-attn-x" title="Dismiss" aria-label={`Dismiss ${a.title}`} onClick={() => onDismiss(a)}>

--- a/src/appearance.ts
+++ b/src/appearance.ts
@@ -17,11 +17,27 @@ export interface Appearance {
   theme: Theme;
   density: Density;
   accent: Accent;
+  /** app-wide text zoom (⌘+ / ⌘- / ⌘0) — multiplies every `--fs-*` token */
+  fontScale: number;
 }
 
 const KEY = "canopy.appearance";
 const THEMES: Theme[] = ["dark", "light", "system"];
 const ACCENTS: Accent[] = ["teal", "green", "amber", "violet"];
+
+// Font zoom is a multiplier on the size ramp, clamped so text stays legible and
+// the layout never collapses. 10% steps land on clean values off the 1.0 base.
+export const FONT_SCALE_MIN = 0.8;
+export const FONT_SCALE_MAX = 1.6;
+export const FONT_SCALE_STEP = 0.1;
+const FONT_SCALE_DEFAULT = 1;
+
+/** Round to one decimal and clamp — keeps repeated nudges off floating dust. */
+function normScale(n: number): number {
+  if (!Number.isFinite(n)) return FONT_SCALE_DEFAULT;
+  const r = Math.round(n * 10) / 10;
+  return Math.min(FONT_SCALE_MAX, Math.max(FONT_SCALE_MIN, r));
+}
 
 export function getAppearance(): Appearance {
   try {
@@ -32,12 +48,13 @@ export function getAppearance(): Appearance {
         theme: THEMES.includes(p.theme as Theme) ? (p.theme as Theme) : "dark",
         density: p.density === "compact" ? "compact" : "comfortable",
         accent: ACCENTS.includes(p.accent as Accent) ? (p.accent as Accent) : "teal",
+        fontScale: normScale(typeof p.fontScale === "number" ? p.fontScale : FONT_SCALE_DEFAULT),
       };
     }
   } catch {
     /* corrupt or unavailable storage — fall through to defaults */
   }
-  return { theme: "dark", density: "comfortable", accent: "teal" };
+  return { theme: "dark", density: "comfortable", accent: "teal", fontScale: FONT_SCALE_DEFAULT };
 }
 
 /** "system" resolves to the OS scheme; everything else is literal. */
@@ -53,6 +70,19 @@ export function applyAppearance(a: Appearance = getAppearance()): void {
   root.dataset.theme = resolveTheme(a.theme);
   root.dataset.density = a.density;
   root.dataset.accent = a.accent;
+  root.style.setProperty("--font-scale", String(a.fontScale));
+}
+
+/** Bump the app-wide text zoom by whole steps (⌘+ / ⌘-). Persists + applies
+    live across every Canopy window. Returns the resolved scale. */
+export function nudgeFontScale(steps: number): number {
+  const next = normScale(getAppearance().fontScale + steps * FONT_SCALE_STEP);
+  return setAppearance({ fontScale: next }).fontScale;
+}
+
+/** Reset text zoom to 100% (⌘0). */
+export function resetFontScale(): number {
+  return setAppearance({ fontScale: FONT_SCALE_DEFAULT }).fontScale;
 }
 
 /** Persist + apply live, and notify this window's UI and the app's others. */

--- a/src/styles/canopy-shell.css
+++ b/src/styles/canopy-shell.css
@@ -144,19 +144,12 @@
   border-radius: var(--r-md);
   border: 0;
   background: none;
-  cursor: pointer;
+  /* identity, not a control — no cursor/hover, it isn't clickable */
   color: var(--text-secondary);
   font-family: var(--sans);
   font-size: var(--fs-body);
   min-width: 0;
   flex: 0 1 auto;
-  transition:
-    background var(--dur-fast),
-    color var(--dur-fast);
-}
-.cxs-crumb:hover {
-  background: var(--btn);
-  color: var(--text-primary);
 }
 .cxs-crumb .rp {
   color: var(--text-tertiary);

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -107,14 +107,18 @@
   --mono: "JetBrains Mono Variable", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
   --ui: var(--sans);
 
+  /* app-wide text zoom (⌘+ / ⌘- / ⌘0) — appearance.ts sets this on <html>;
+     every size below multiplies by it so one knob scales the whole ramp */
+  --font-scale: 1;
+
   /* size ramp — dense by design; 9.5px is legible only in caps + tracking */
-  --fs-label: 9.5px;
-  --fs-micro: 10.5px;
-  --fs-small: 11.5px;
-  --fs-body: 12.5px;
-  --fs-md: 13.5px;
-  --fs-lg: 15px;
-  --fs-xl: 19px;
+  --fs-label: calc(9.5px * var(--font-scale));
+  --fs-micro: calc(10.5px * var(--font-scale));
+  --fs-small: calc(11.5px * var(--font-scale));
+  --fs-body: calc(12.5px * var(--font-scale));
+  --fs-md: calc(13.5px * var(--font-scale));
+  --fs-lg: calc(15px * var(--font-scale));
+  --fs-xl: calc(19px * var(--font-scale));
 
   --lh-tight: 1.35;
   --lh-body: 1.55;
@@ -199,8 +203,11 @@
   --dot: 6px;
   --dot-sm: 5px;
 
-  --w-sidebar: 238px;
-  --w-sidebar-narrow: 210px; /* below the 1180px breakpoint */
+  /* Sidebar tracks the text zoom (⌘+/⌘-) so labels keep breathing room, but
+     only a little: it grows to a hard cap (~1.2×) and won't shrink past a floor,
+     so the panel never dominates the window or squeezes to nothing. */
+  --w-sidebar: clamp(214px, calc(238px * var(--font-scale)), 288px);
+  --w-sidebar-narrow: clamp(198px, calc(210px * var(--font-scale)), 254px); /* below the 1180px breakpoint */
   /* Declared by the handoff's layout.css but referenced by none of its
      screens. Carried for token parity; nothing consumes it yet. */
   --w-rail-collapsed: 52px;


### PR DESCRIPTION
Five UX fixes, each independent.

## 1. App-wide text zoom — ⌘+ / ⌘- / ⌘0
The size ramp (`--fs-*`) now multiplies by a new `--font-scale` variable, so one knob scales all UI text. `appearance.ts` persists `fontScale` (clamped 0.8–1.6, 10% steps) and it syncs live across every window (main, popover, terminals). Shortcuts work from anywhere, even with a field focused or the palette open, and are listed in Settings → Shortcuts.

The **sidebar width** tracks the zoom too, but gently: it grows only to a ~1.2× cap (288px) and won't shrink past a 214px floor, so the panel keeps labels comfortable without ever taking over the window.

## 2. Notifications — only the close icon
Completion (info) notices in the attention popover dropped the redundant "Dismiss ›" action; the ✕ close button is the sole dismiss. Error notices keep their meaningful "View ›".

## 3. Top bar crumb — no icon, not clickable
The `repo › branch` label is now plain identity: a `<div>` instead of a palette-opening button, with the trailing chevron and hover/cursor removed. ⌘K / the center search still open the palette.

## 4. Sync reconciles Settings with the repo config file
`Sync` now re-reads each repo's `.worktreemanager.json` into Settings — Setup tasks, provisioned Files, and Migrate commands — so on-disk edits show up without reopening Settings. Repos with unsaved edits are skipped so nothing is clobbered.

## 5. New repos default their worktree root to `<repo>/.worktrees`
`add_repo` now defaults to a hidden dir inside the repo instead of a `<repo>-worktrees` sibling. `create_worktree` resolution is now robust: empty → `<repo>/.worktrees`, a relative dir resolves against the repo root, absolute is used verbatim (this also fixes a latent case where a relative dir would have been created relative to the process CWD). Only affects newly added repos.

## Verification
- `tsc --noEmit` clean, `cargo check` clean.
- Built and installed the local release app; smoke-tested zoom, the crumb, and the sidebar cap.

Note: the pre-existing 0.4.6→0.4.7 version bump in the working tree is intentionally left out of this PR.